### PR TITLE
Fix code scanning alert no. 2: Overly permissive regular expression range

### DIFF
--- a/packages/ui/utils/get-base64-image.ts
+++ b/packages/ui/utils/get-base64-image.ts
@@ -10,5 +10,5 @@ export const getBase64Image = (
     ctx?.drawImage(img, 0, 0);
   }
   const dataURL = _canvas.toDataURL("image/png");
-  return dataURL.replace(/^data:image\/?[A-z]*;base64,/, "");
+  return dataURL.replace(/^data:image\/?[A-Za-z]*;base64,/, "");
 };


### PR DESCRIPTION
Fixes [https://github.com/Chia1104/chia1104.dev/security/code-scanning/2](https://github.com/Chia1104/chia1104.dev/security/code-scanning/2)

To fix the problem, we need to correct the regular expression range to match only the intended characters. In this case, we want to match alphabetic characters in the data URL prefix. The correct range should be `A-Za-z` instead of `A-z`.

- Update the regular expression on line 13 to use the correct range `A-Za-z`.
- This change ensures that only valid alphabetic characters are matched, avoiding any unintended matches.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
