### PR TITLE
fix(www): fix vercel build command

### DIFF
--- a/apps/dash/vercel.json
+++ b/apps/dash/vercel.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "cd ../.. && pnpm build:dash",
-  "installCommand": "cd ../.. && rm -r apps/trigger && rm -r apps/service && rm -r apps/www && rm -r tests && npm install -g corepack@latest && pnpm install --store=node_modules/.pnpm-store",
+  "installCommand": "cd ../.. && rm -r apps/www && rm -r tests && npm install -g corepack@latest && pnpm install --store=node_modules/.pnpm-store",
   "git": {
     "deploymentEnabled": {
       "develop": false

--- a/apps/www/vercel.json
+++ b/apps/www/vercel.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "cd ../.. && pnpm build:www",
-  "installCommand": "cd ../.. && rm -r apps/trigger && rm -r apps/service && rm -r apps/dash && rm -r tests && npm install -g corepack@latest && pnpm install --store=node_modules/.pnpm-store",
+  "installCommand": "cd ../.. && rm -r apps/dash && rm -r tests && npm install -g corepack@latest && pnpm install --store=node_modules/.pnpm-store",
   "git": {
     "deploymentEnabled": {
       "develop": false


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Narrows Vercel install-time cleanup to avoid deleting unrelated apps.
> 
> - In `apps/dash/vercel.json`, `installCommand` now only removes `apps/www` and `tests` (no longer removes `apps/trigger` or `apps/service`).
> - In `apps/www/vercel.json`, `installCommand` now only removes `apps/dash` and `tests` (no longer removes `apps/trigger` or `apps/service`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ae5bdeead217a93d17dadf9f102f775d8923152. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->