### PR TITLE
fix(www): stabilize feed infinite query hydration

### DIFF
--- a/apps/www/src/app/[locale]/(blog)/[type]/page.tsx
+++ b/apps/www/src/app/[locale]/(blog)/[type]/page.tsx
@@ -31,8 +31,6 @@ export async function generateMetadata({
   };
 }
 
-const queryClient = getQueryClient();
-
 const CacheFeeds = async ({
   type,
   limit = 10,
@@ -42,6 +40,7 @@ const CacheFeeds = async ({
   limit?: number;
   locale: Locale;
 }) => {
+  const queryClient = getQueryClient();
   const formattedType = type === "posts" ? "post" : "note";
 
   await queryClient.prefetchInfiniteQuery(

--- a/apps/www/src/components/blog/feed-list.tsx
+++ b/apps/www/src/components/blog/feed-list.tsx
@@ -26,7 +26,7 @@ interface Props {
 const FeedList: FC<Props> = ({ nextCursor, query = {}, type }) => {
   const locale = useLocale();
   const t = useTranslations(`blog.posts`);
-  const { data, isSuccess, isFetching, isError, fetchNextPage, hasNextPage } =
+  const { data, isSuccess, isLoading, isError, fetchNextPage, hasNextPage } =
     useInfiniteQuery(
       orpc.feeds["admin-list"].infiniteOptions({
         input: (pageParam) => ({
@@ -112,7 +112,7 @@ const FeedList: FC<Props> = ({ nextCursor, query = {}, type }) => {
       enableSort={false}
       asyncDataStatus={{
         hasMore: hasNextPage,
-        isLoading: isFetching,
+        isLoading,
         isError,
       }}
       onEndReached={fetchNextPage}


### PR DESCRIPTION
This pull request makes minor improvements to data fetching and loading state handling in the blog feed components. The main changes involve moving the initialization of the `queryClient` to the appropriate scope and updating loading state variables for better clarity.

**Data fetching improvements:**

* Moved the initialization of `queryClient` inside the `CacheFeeds` function to ensure it is created in the correct context. ([apps/www/src/app/[locale]/(blog)/[type]/page.tsxL34-L35](diffhunk://#diff-e6df34ef20d451ccd11601c497a689b0111ff0afb6fa5f91f5fe081d0b40ac32L34-L35), [apps/www/src/app/[locale]/(blog)/[type]/page.tsxR43](diffhunk://#diff-e6df34ef20d451ccd11601c497a689b0111ff0afb6fa5f91f5fe081d0b40ac32R43))

**Loading state handling:**

* Replaced the use of `isFetching` with `isLoading` in the `FeedList` component for more accurate loading state representation. [[1]](diffhunk://#diff-f3ec51dc3ec647cf31b60a343ea87319ecd7219ae822bdcc5afcda04dc26e8d4L29-R29) [[2]](diffhunk://#diff-f3ec51dc3ec647cf31b60a343ea87319ecd7219ae822bdcc5afcda04dc26e8d4L115-R115)