### PR TITLE
feat(agent): add multi model provider support

### DIFF
--- a/apps/dash/src/components/agent/agent-model-picker.tsx
+++ b/apps/dash/src/components/agent/agent-model-picker.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { useCallback, useMemo } from "react";
+
+import { ListBox, Select } from "@heroui/react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import { orpc } from "@/libs/orpc/client";
+import type { RouterOutputs } from "@/libs/orpc/types";
+
+type AgentModel = RouterOutputs["agent"]["models"]["list"][number];
+
+interface AgentModelPickerProps {
+  sessionId: string;
+  kind: string;
+  providerId?: string;
+  modelId?: string;
+  onChanged: () => void;
+}
+
+/**
+ * Providers, in the order they are offered.
+ *
+ * The gateway leads because it is the house account and needs no setup; the bring-your-own-key
+ * providers follow. Anything the server adds later still renders — it just sorts last under its
+ * raw id rather than a friendly label.
+ */
+const PROVIDER_ORDER = ["vercel-ai-gateway", "openai", "anthropic"] as const;
+
+const PROVIDER_LABELS: Record<string, string> = {
+  "vercel-ai-gateway": "Gateway",
+  openai: "OpenAI",
+  anthropic: "Anthropic",
+};
+
+const providerLabel = (providerId: string) =>
+  PROVIDER_LABELS[providerId] ?? providerId;
+
+/**
+ * The picker's key.
+ *
+ * A model is identified by its `(providerId, modelId)` pair, never the id alone — the same model
+ * carries different ids under different providers (`anthropic/claude-haiku-4.5` on the gateway is
+ * `claude-haiku-4-5` natively), and two entries would otherwise collide on one key.
+ */
+const keyOf = (model: { providerId: string; modelId: string }) =>
+  `${model.providerId}:${model.modelId}`;
+
+const parseKey = (key: string) => {
+  const [providerId, modelId] = key.split(":");
+  return providerId && modelId ? { providerId, modelId } : null;
+};
+
+const rank = (providerId: string) => {
+  const index = PROVIDER_ORDER.indexOf(
+    providerId as (typeof PROVIDER_ORDER)[number]
+  );
+  return index === -1 ? PROVIDER_ORDER.length : index;
+};
+
+const sortModels = (models: AgentModel[]) =>
+  [...models].sort(
+    (a, b) =>
+      rank(a.providerId) - rank(b.providerId) ||
+      a.providerId.localeCompare(b.providerId) ||
+      a.name.localeCompare(b.name)
+  );
+
+export const AgentModelPicker = ({
+  kind,
+  modelId,
+  onChanged,
+  providerId,
+  sessionId,
+}: AgentModelPickerProps) => {
+  const queryClient = useQueryClient();
+  const { data } = useQuery(
+    orpc.agent.models.list.queryOptions({ input: { kind } })
+  );
+  const update = useMutation(
+    orpc.agent.sessions["settings:update"].mutationOptions()
+  );
+
+  const models = useMemo(() => sortModels(data ?? []), [data]);
+
+  const select = useCallback(
+    async (key: string | null) => {
+      const next = key ? parseKey(key) : null;
+      if (!next) return;
+      if (next.providerId === providerId && next.modelId === modelId) return;
+
+      try {
+        await update.mutateAsync({ sessionId, ...next });
+        await queryClient.invalidateQueries({
+          queryKey: orpc.agent.sessions.get.queryKey({ input: { sessionId } }),
+        });
+        onChanged();
+      } catch (error) {
+        toast.error(
+          error instanceof Error ? error.message : "Could not switch model."
+        );
+      }
+    },
+    [modelId, onChanged, providerId, queryClient, sessionId, update]
+  );
+
+  const selectedKey =
+    providerId && modelId ? keyOf({ providerId, modelId }) : undefined;
+
+  return (
+    <Select
+      aria-label="Agent model"
+      isDisabled={update.isPending || models.length === 0}
+      onChange={(key) => void select(key as string | null)}
+      placeholder="Select a model"
+      value={selectedKey}>
+      <Select.Trigger className="min-w-56">
+        <Select.Value />
+        <Select.Indicator />
+      </Select.Trigger>
+      <Select.Popover>
+        <ListBox>
+          {models.map((model) => (
+            <ListBox.Item
+              /**
+               * A model on an unconfigured bring-your-own-key provider is shown but not
+               * selectable — hiding it would leave the operator with no way to discover that
+               * registering a key unlocks it.
+               */
+              isDisabled={model.requiresApiKey}
+              id={keyOf(model)}
+              key={keyOf(model)}
+              textValue={`${providerLabel(model.providerId)} · ${model.name}`}>
+              {providerLabel(model.providerId)} · {model.name}
+              {model.requiresApiKey ? " · needs API key" : ""}
+            </ListBox.Item>
+          ))}
+        </ListBox>
+      </Select.Popover>
+    </Select>
+  );
+};

--- a/apps/dash/src/components/agent/agent-model-picker.tsx
+++ b/apps/dash/src/components/agent/agent-model-picker.tsx
@@ -91,7 +91,7 @@ export const AgentModelPicker = ({
       if (next.providerId === providerId && next.modelId === modelId) return;
 
       try {
-        await update.mutateAsync({ sessionId, ...next });
+        await update.mutateAsync({ sessionId, model: next });
         await queryClient.invalidateQueries({
           queryKey: orpc.agent.sessions.get.queryKey({ input: { sessionId } }),
         });

--- a/apps/dash/src/components/agent/agent-session.tsx
+++ b/apps/dash/src/components/agent/agent-session.tsx
@@ -29,6 +29,7 @@ import {
 } from "./agent-chat";
 import type { PendingApproval } from "./agent-chat";
 import { AgentDraftPreview } from "./agent-draft-preview";
+import { AgentModelPicker } from "./agent-model-picker";
 import { AgentTranscript } from "./agent-transcript";
 
 type AgentSessionDetail = RouterOutputs["agent"]["sessions"]["get"];
@@ -236,11 +237,13 @@ const AgentSessionContent = ({
           <Card.Title className="truncate">
             {detail.session.title || "Untitled session"}
           </Card.Title>
-          <Card.Description className="truncate">
-            {detail.settings?.modelId ||
-              detail.session.modelId ||
-              "Writing agent"}
-          </Card.Description>
+          <AgentModelPicker
+            kind={detail.session.kind}
+            modelId={detail.settings?.modelId ?? undefined}
+            onChanged={onSessionChanged}
+            providerId={detail.settings?.providerId ?? undefined}
+            sessionId={sessionId}
+          />
         </div>
         <Chip className="ml-auto" color={meta.color} size="sm" variant="soft">
           <Chip.Label>{meta.label}</Chip.Label>

--- a/apps/service/__tests__/agent-credentials.test.ts
+++ b/apps/service/__tests__/agent-credentials.test.ts
@@ -1,0 +1,109 @@
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+import { encodeApiKey, generateKeys } from "@chia/ai/utils";
+
+/**
+ * The bring-your-own-key round trip.
+ *
+ * Worth pinning on its own because both halves fail quietly. A cookie that is read but never
+ * decrypted leaves the turn on the house account; a decrypt failure that is swallowed surfaces
+ * downstream as "unknown model", which sends the operator looking in entirely the wrong place.
+ */
+
+const { keys } = vi.hoisted(() => ({ keys: { public: "", private: "" } }));
+
+vi.mock("../src/env", () => ({
+  env: {
+    get AI_AUTH_PRIVATE_KEY() {
+      return keys.private;
+    },
+  },
+}));
+
+let readEncryptedAgentCredentials: (typeof import("../src/services/agent-credentials"))["readEncryptedAgentCredentials"];
+let decryptAgentCredentials: (typeof import("../src/services/agent-credentials"))["decryptAgentCredentials"];
+let AgentCredentialError: (typeof import("../src/services/agent-credentials"))["AgentCredentialError"];
+
+beforeAll(async () => {
+  const generated = generateKeys();
+  // `encodeApiKey`/`decodeApiKey` take base64-wrapped PEM, which is how the env vars hold them.
+  keys.public = Buffer.from(generated.publicKey, "utf-8").toString("base64");
+  keys.private = Buffer.from(generated.privateKey, "utf-8").toString("base64");
+
+  const module = await import("../src/services/agent-credentials");
+  readEncryptedAgentCredentials = module.readEncryptedAgentCredentials;
+  decryptAgentCredentials = module.decryptAgentCredentials;
+  AgentCredentialError = module.AgentCredentialError;
+});
+
+const headersWith = (cookie: string) => new Headers({ Cookie: cookie });
+
+describe("readEncryptedAgentCredentials", () => {
+  it("lifts each provider's ciphertext out of its cookie", () => {
+    const openai = encodeApiKey("sk-openai", keys.public);
+    const anthropic = encodeApiKey("sk-anthropic", keys.public);
+
+    const credentials = readEncryptedAgentCredentials(
+      headersWith(`OPENAI_API_KEY=${openai}; ANTHROPIC_API_KEY=${anthropic}`)
+    );
+
+    expect(credentials).toEqual({ openai, anthropic });
+  });
+
+  /**
+   * Bring-your-own-key is optional here — a session on the house gateway account needs none — so a
+   * request with no cookies is a normal state rather than a rejection.
+   */
+  it("returns undefined when the caller registered nothing", () => {
+    expect(readEncryptedAgentCredentials(new Headers())).toBeUndefined();
+  });
+
+  it("carries only the providers that are actually present", () => {
+    const openai = encodeApiKey("sk-openai", keys.public);
+
+    expect(
+      readEncryptedAgentCredentials(headersWith(`OPENAI_API_KEY=${openai}`))
+    ).toEqual({ openai });
+  });
+
+  it("never returns plaintext", () => {
+    const openai = encodeApiKey("sk-secret-value", keys.public);
+
+    const credentials = readEncryptedAgentCredentials(
+      headersWith(`OPENAI_API_KEY=${openai}`)
+    );
+
+    expect(credentials?.openai).not.toContain("sk-secret-value");
+  });
+});
+
+describe("decryptAgentCredentials", () => {
+  it("round-trips a key encrypted under the configured public key", () => {
+    const encrypted = {
+      openai: encodeApiKey("sk-openai", keys.public),
+      anthropic: encodeApiKey("sk-anthropic", keys.public),
+    };
+
+    expect(decryptAgentCredentials(encrypted)).toEqual({
+      openai: "sk-openai",
+      anthropic: "sk-anthropic",
+    });
+  });
+
+  it("treats an absent payload as no bring-your-own key", () => {
+    expect(decryptAgentCredentials(undefined)).toEqual({});
+  });
+
+  /**
+   * Almost always a key encrypted under a rotated keypair. Reported as something the operator can
+   * fix, rather than dropped — dropping it would surface as the model not existing.
+   */
+  it("reports an undecryptable key against its provider", () => {
+    expect(() =>
+      decryptAgentCredentials({ openai: "not-actually-ciphertext" })
+    ).toThrow(AgentCredentialError);
+    expect(() =>
+      decryptAgentCredentials({ openai: "not-actually-ciphertext" })
+    ).toThrow(/openai/);
+  });
+});

--- a/apps/service/src/services/agent-credentials.ts
+++ b/apps/service/src/services/agent-credentials.ts
@@ -1,0 +1,93 @@
+import { parse } from "hono/utils/cookie";
+
+import type { AgentCredentials } from "@chia/agent-core";
+import { ANTHROPIC_API_KEY, OPENAI_API_KEY } from "@chia/ai/constants";
+import { verifyApiKey } from "@chia/ai/utils";
+
+import { env } from "../env";
+import type { EncryptedAgentCredentials } from "../workflows/hooks/agent.hooks";
+
+/**
+ * Bring-your-own-key plumbing for agent turns.
+ *
+ * Two halves, deliberately kept apart:
+ *
+ * - {@link readEncryptedAgentCredentials} runs at the HTTP boundary and only *moves* ciphertext out
+ *   of the cookie. It never decrypts, because what it produces is handed to the workflow, and
+ *   everything crossing that boundary is journaled durably.
+ * - {@link decryptAgentCredentials} runs inside the turn step, at the last possible moment.
+ *
+ * The cookies are the same ones `/ai/key:signed` writes for the Vercel AI SDK routes
+ * (`apps/service/src/routes/ai.route.ts`), so an operator who has already registered a key for
+ * those gets it here for free.
+ */
+
+const COOKIE_BY_PROVIDER = {
+  openai: OPENAI_API_KEY,
+  anthropic: ANTHROPIC_API_KEY,
+} as const;
+
+/**
+ * Lifts whatever provider keys the caller has registered out of their cookies.
+ *
+ * Deliberately **not** `aiKeyPolicy`: that policy denies the request when a key is missing, which is
+ * right for the AI SDK routes where the key *is* the auth. Here bring-your-own-key is optional —
+ * a session on the house gateway account needs none — so a missing cookie is a normal state, not a
+ * rejection. Returns undefined when there is nothing at all to carry.
+ */
+export const readEncryptedAgentCredentials = (
+  headers: Headers
+): EncryptedAgentCredentials | undefined => {
+  const cookies = parse(headers.get("Cookie") ?? "");
+  const credentials: EncryptedAgentCredentials = {};
+  for (const [providerId, cookieName] of Object.entries(COOKIE_BY_PROVIDER)) {
+    const encoded = cookies[cookieName];
+    if (encoded) {
+      credentials[providerId as keyof EncryptedAgentCredentials] = encoded;
+    }
+  }
+  return Object.keys(credentials).length > 0 ? credentials : undefined;
+};
+
+export class AgentCredentialError extends Error {
+  constructor(
+    readonly providerId: string,
+    options?: { cause?: unknown }
+  ) {
+    super(
+      `Your ${providerId} API key could not be read. Register it again, then retry.`,
+      options
+    );
+    this.name = "AgentCredentialError";
+  }
+}
+
+/**
+ * Decrypts the ciphertext carried across the workflow boundary.
+ *
+ * A key that fails to decrypt is almost always one encrypted under a rotated `AI_AUTH_PUBLIC_KEY`,
+ * so it is reported as something the operator can fix rather than as an internal error. Silently
+ * dropping it would be worse: the turn would fall through to "provider not registered" and the
+ * operator would be told their model does not exist.
+ */
+export const decryptAgentCredentials = (
+  encrypted: EncryptedAgentCredentials | undefined
+): AgentCredentials => {
+  if (!encrypted) return {};
+  const privateKey = env.AI_AUTH_PRIVATE_KEY;
+  if (!privateKey) return {};
+
+  const credentials: AgentCredentials = {};
+  for (const [providerId, encoded] of Object.entries(encrypted)) {
+    if (!encoded) continue;
+    try {
+      credentials[providerId as keyof AgentCredentials] = verifyApiKey(
+        encoded,
+        privateKey
+      ).apiKey;
+    } catch (error) {
+      throw new AgentCredentialError(providerId, { cause: error });
+    }
+  }
+  return credentials;
+};

--- a/apps/service/src/services/agent-runtime.service.ts
+++ b/apps/service/src/services/agent-runtime.service.ts
@@ -18,7 +18,7 @@ import type {
 import {
   createWritingMaintenanceEngine,
   createWritingTools,
-  isWritingModel,
+  assertWritingModel,
   listWritingModels,
   PgDraftStore,
   WRITING_AGENT_KIND,
@@ -371,14 +371,12 @@ export const writingAgentRuntime: AgentRuntime = {
   async createSession(caller, input) {
     const { repo, draft, content } = dependenciesFor(caller);
 
-    assertKnownModel(input);
-
     const session = await repo.create({
       userId: caller.userId,
       title: input.title,
       settings: {
-        providerId: input.providerId,
-        modelId: input.modelId,
+        providerId: input.model?.providerId,
+        modelId: input.model?.modelId,
         thinkingLevel: input.thinkingLevel as ThinkingLevel | undefined,
         autoApprove: input.autoApprove as ToolTier[] | undefined,
       },
@@ -439,12 +437,10 @@ export const writingAgentRuntime: AgentRuntime = {
   async updateSettings(caller, input) {
     const row = await loadOwnedSession(caller, input.sessionId);
     if (!row) return null;
-    assertKnownModel(input);
-
     await writeSessionSettings(caller.context.db as DB, input.sessionId, {
       title: input.title,
-      providerId: input.providerId,
-      modelId: input.modelId,
+      providerId: input.model?.providerId,
+      modelId: input.model?.modelId,
       thinkingLevel: input.thinkingLevel as ThinkingLevel | undefined,
       activeToolNames: input.activeToolNames,
       autoApprove: input.autoApprove as ToolTier[] | undefined,
@@ -742,6 +738,27 @@ export const writingAgentRuntime: AgentRuntime = {
     return (await draft.get(input.sessionId)) as never;
   },
 
+  /**
+   * The pre-persistence check the transport calls.
+   *
+   * Returns a reason instead of throwing because the caller is a middleware turning this into a
+   * `BAD_REQUEST`. `assertWritingModel` checks policy *and* catalogue membership — the latter is
+   * what stops a typo on a native provider from being stored and then failing on every subsequent
+   * turn, deep in the workflow step where the operator cannot see why.
+   */
+  validateModel(ref) {
+    try {
+      assertWritingModel(ref);
+      return Promise.resolve(null);
+    } catch (error) {
+      return Promise.resolve(
+        error instanceof UnknownAgentModelError
+          ? error.message
+          : `Could not validate model "${ref.modelId}".`
+      );
+    }
+  },
+
   listModels(caller) {
     /**
      * Which BYOK providers this caller has a key for. Read from the cookie rather than decrypted:
@@ -800,30 +817,6 @@ const assertNoTurnRunning = async (
     // Re-throw our own refusal; swallow lookup failures for runs that no longer resolve.
     if (error instanceof Error && error.message.startsWith("Cannot "))
       throw error;
-  }
-};
-
-/**
- * Validates a client-supplied model selection.
- *
- * The pair is checked as a unit, and a `modelId` without a `providerId` is refused rather than
- * defaulted: the same model exists under several providers with different ids and different payers,
- * so there is no safe guess. `isWritingModel` is the same predicate the turn resolves through, so a
- * selection accepted here cannot fail policy later.
- */
-const assertKnownModel = (input: {
-  providerId?: string;
-  modelId?: string;
-}): void => {
-  if (!input.modelId && !input.providerId) return;
-  if (!input.modelId || !input.providerId) {
-    throw new Error(
-      "Both providerId and modelId are required to select a model."
-    );
-  }
-  const ref = { providerId: input.providerId, modelId: input.modelId };
-  if (!isWritingModel(ref)) {
-    throw new UnknownAgentModelError(ref);
   }
 };
 

--- a/apps/service/src/services/agent-runtime.service.ts
+++ b/apps/service/src/services/agent-runtime.service.ts
@@ -1,6 +1,8 @@
 import { getHookByToken, getRun, start } from "workflow/api";
 
 import {
+  BYOK_PROVIDER_IDS,
+  createAgentModels,
   entriesToWireEvents,
   PgPendingMessageStore,
   PgSessionRepo,
@@ -16,10 +18,9 @@ import type {
 import {
   createWritingMaintenanceEngine,
   createWritingTools,
-  isWritingModelId,
+  isWritingModel,
   listWritingModels,
   PgDraftStore,
-  WRITING_MODEL_IDS,
   WRITING_AGENT_KIND,
   WRITING_SESSION_DEFAULTS,
   writingPolicy,
@@ -56,6 +57,10 @@ import {
 } from "../workflows/hooks/agent.hooks";
 
 import { createAgentContentPort } from "./agent-content.port";
+import {
+  decryptAgentCredentials,
+  readEncryptedAgentCredentials,
+} from "./agent-credentials";
 import { getAgentPendingNotifier } from "./agent-pending-notifier";
 
 /**
@@ -200,9 +205,23 @@ const openMaintenanceEngine = async (
     agentSessionId: sessionId,
     session,
     settings: settingsOf(row),
+    /**
+     * Compaction calls the model too, so a BYOK session needs its key here just as much as in a
+     * turn. This path runs inside the request, so the cookie is read and decrypted directly rather
+     * than travelling through the workflow.
+     */
+    models: modelsFor(caller),
   });
   return { session, engine };
 };
+
+/** Per-request `Models`, carrying whatever provider keys the caller has registered. */
+const modelsFor = (caller: AgentRuntimeCaller) =>
+  createAgentModels(
+    decryptAgentCredentials(
+      readEncryptedAgentCredentials(caller.context.headers)
+    )
+  );
 
 const replayOptions = {
   tierOf: writingPolicy.tierOf,
@@ -352,12 +371,13 @@ export const writingAgentRuntime: AgentRuntime = {
   async createSession(caller, input) {
     const { repo, draft, content } = dependenciesFor(caller);
 
-    if (input.modelId) assertKnownModel(input.modelId);
+    assertKnownModel(input);
 
     const session = await repo.create({
       userId: caller.userId,
       title: input.title,
       settings: {
+        providerId: input.providerId,
         modelId: input.modelId,
         thinkingLevel: input.thinkingLevel as ThinkingLevel | undefined,
         autoApprove: input.autoApprove as ToolTier[] | undefined,
@@ -419,10 +439,11 @@ export const writingAgentRuntime: AgentRuntime = {
   async updateSettings(caller, input) {
     const row = await loadOwnedSession(caller, input.sessionId);
     if (!row) return null;
-    if (input.modelId) assertKnownModel(input.modelId);
+    assertKnownModel(input);
 
     await writeSessionSettings(caller.context.db as DB, input.sessionId, {
       title: input.title,
+      providerId: input.providerId,
       modelId: input.modelId,
       thinkingLevel: input.thinkingLevel as ThinkingLevel | undefined,
       activeToolNames: input.activeToolNames,
@@ -455,6 +476,9 @@ export const writingAgentRuntime: AgentRuntime = {
       text: input.text,
       template: input.template,
       preAuthorizeToolNames: input.preAuthorizeToolNames,
+      // Refreshed on every prompt: the run outlives any one request, and the operator may have
+      // registered or rotated a key since the last turn.
+      credentials: readEncryptedAgentCredentials(caller.context.headers),
     };
 
     /**
@@ -654,7 +678,12 @@ export const writingAgentRuntime: AgentRuntime = {
     // Then wake the run, which has been parked on this hook with no compute consumed.
     await agentApprovalHook.resume(
       agentApprovalToken(input.sessionId, input.toolCallId),
-      { approved: input.approved, comment: input.comment }
+      {
+        approved: input.approved,
+        comment: input.comment,
+        // The turns the workflow synthesises after this decision have no request of their own.
+        credentials: readEncryptedAgentCredentials(caller.context.headers),
+      }
     );
 
     return { runId: row.workflowRunId, startIndex };
@@ -713,8 +742,17 @@ export const writingAgentRuntime: AgentRuntime = {
     return (await draft.get(input.sessionId)) as never;
   },
 
-  listModels() {
-    return Promise.resolve(listWritingModels());
+  listModels(caller) {
+    /**
+     * Which BYOK providers this caller has a key for. Read from the cookie rather than decrypted:
+     * the picker only needs to know whether a key is *present*, and decrypting to answer a listing
+     * request would put plaintext keys on a path that has no use for them.
+     */
+    const registered = readEncryptedAgentCredentials(caller.context.headers);
+    const configured = BYOK_PROVIDER_IDS.filter(
+      (providerId) => registered?.[providerId]
+    );
+    return Promise.resolve(listWritingModels({ configured }));
   },
 
   listCapabilities() {
@@ -765,9 +803,27 @@ const assertNoTurnRunning = async (
   }
 };
 
-const assertKnownModel = (modelId: string) => {
-  if (!isWritingModelId(modelId)) {
-    throw new UnknownAgentModelError(modelId, WRITING_MODEL_IDS);
+/**
+ * Validates a client-supplied model selection.
+ *
+ * The pair is checked as a unit, and a `modelId` without a `providerId` is refused rather than
+ * defaulted: the same model exists under several providers with different ids and different payers,
+ * so there is no safe guess. `isWritingModel` is the same predicate the turn resolves through, so a
+ * selection accepted here cannot fail policy later.
+ */
+const assertKnownModel = (input: {
+  providerId?: string;
+  modelId?: string;
+}): void => {
+  if (!input.modelId && !input.providerId) return;
+  if (!input.modelId || !input.providerId) {
+    throw new Error(
+      "Both providerId and modelId are required to select a model."
+    );
+  }
+  const ref = { providerId: input.providerId, modelId: input.modelId };
+  if (!isWritingModel(ref)) {
+    throw new UnknownAgentModelError(ref);
   }
 };
 

--- a/apps/service/src/steps/agent-turn.step.ts
+++ b/apps/service/src/steps/agent-turn.step.ts
@@ -1,6 +1,10 @@
 import { FatalError, getWritable } from "workflow";
 
-import { PgPendingMessageStore, PgSessionRepo } from "@chia/agent-core";
+import {
+  createAgentModels,
+  PgPendingMessageStore,
+  PgSessionRepo,
+} from "@chia/agent-core";
 import type { AgentWireEvent, ThinkingLevel, ToolTier } from "@chia/agent-core";
 import {
   PgDraftStore,
@@ -19,7 +23,9 @@ import {
 } from "@chia/db/repos/agent";
 
 import { createAgentContentPort } from "../services/agent-content.port";
+import { decryptAgentCredentials } from "../services/agent-credentials";
 import { getAgentPendingNotifier } from "../services/agent-pending-notifier";
+import type { EncryptedAgentCredentials } from "../workflows/hooks/agent.hooks";
 
 /**
  * One agent turn, as a durable step.
@@ -58,6 +64,11 @@ export interface AgentTurnRequest {
   text: string;
   template?: { name: string; args?: string[] };
   preAuthorizeToolNames?: string[];
+  /**
+   * The operator's own provider keys, still encrypted — see `services/agent-credentials.ts`.
+   * Absent means the turn runs on the house gateway account.
+   */
+  credentials?: EncryptedAgentCredentials;
 }
 
 export interface AgentApprovalRequestSnapshot {
@@ -154,9 +165,22 @@ async function runWritingAgentTurn(
 
   const writer = createEventWriter();
 
+  /**
+   * Built here, per turn, because it closes over the operator's own keys.
+   *
+   * A `Models` carrying BYOK credentials cannot be a process-wide singleton — it belongs to whoever
+   * sent this message. Providers with no credential are simply not registered, so choosing an
+   * OpenAI model without an OpenAI key fails as "unknown model" rather than quietly billing the
+   * house gateway account.
+   */
+  const models = createAgentModels(
+    decryptAgentCredentials(request.credentials)
+  );
+
   return await writingAgentRuntime.runTurn({
     createOptions: {
       session,
+      models,
       settings: {
         providerId: row.providerId,
         modelId: row.modelId,

--- a/apps/service/src/workflows/agent-session.workflow.ts
+++ b/apps/service/src/workflows/agent-session.workflow.ts
@@ -68,13 +68,16 @@ export const agentSessionWorkflow = async (request: Request) => {
   let turns = 0;
 
   /**
-   * The most recent credentials any request handed us.
+   * The credentials the *most recent* request carried.
    *
    * The run outlives the request that started it, and the turns that follow an approval are
    * synthesised below rather than sent by anyone — so there is no cookie to read at the moment they
-   * execute. Holding the last known ciphertext here is what lets those turns reach the operator's
-   * own provider account. Each new prompt or approval overwrites it, so a rotated key takes effect
-   * on the next interaction rather than being pinned for the life of the run.
+   * execute. Holding the last received ciphertext here is what lets those turns reach the
+   * operator's own provider account.
+   *
+   * Overwritten wholesale, never merged: an absent payload means the operator no longer has that
+   * key registered, and treating it as "keep whatever we had" would let a revoked key keep working
+   * for the life of the run. Each prompt and each approval restates the full set.
    */
   let credentials: EncryptedAgentCredentials | undefined =
     firstMessage.credentials;
@@ -85,7 +88,7 @@ export const agentSessionWorkflow = async (request: Request) => {
       const next = await messages;
       if (next.text === AGENT_END_SENTINEL) break;
       pending = next;
-      credentials = next.credentials ?? credentials;
+      credentials = next.credentials;
     }
 
     turns += 1;
@@ -118,7 +121,7 @@ export const agentSessionWorkflow = async (request: Request) => {
       const decision = await agentApprovalHook.create({
         token: agentApprovalToken(sessionId, gated.toolCallId),
       });
-      credentials = decision.credentials ?? credentials;
+      credentials = decision.credentials;
 
       if (!decision.approved) {
         // Rejected: tell the agent why and let it respond, rather than silently stopping.

--- a/apps/service/src/workflows/agent-session.workflow.ts
+++ b/apps/service/src/workflows/agent-session.workflow.ts
@@ -13,7 +13,9 @@ import {
   agentApprovalToken,
   agentMessageHook,
   agentMessageToken,
+  encryptedAgentCredentialsSchema,
 } from "./hooks/agent.hooks";
+import type { EncryptedAgentCredentials } from "./hooks/agent.hooks";
 
 /**
  * One durable run per agent session.
@@ -43,6 +45,7 @@ export const requestSchema = z.object({
       .object({ name: z.string(), args: z.array(z.string()).optional() })
       .optional(),
     preAuthorizeToolNames: z.array(z.string()).optional(),
+    credentials: encryptedAgentCredentialsSchema.optional(),
   }),
 });
 
@@ -64,12 +67,25 @@ export const agentSessionWorkflow = async (request: Request) => {
   let pending: typeof firstMessage | null = firstMessage;
   let turns = 0;
 
+  /**
+   * The most recent credentials any request handed us.
+   *
+   * The run outlives the request that started it, and the turns that follow an approval are
+   * synthesised below rather than sent by anyone — so there is no cookie to read at the moment they
+   * execute. Holding the last known ciphertext here is what lets those turns reach the operator's
+   * own provider account. Each new prompt or approval overwrites it, so a rotated key takes effect
+   * on the next interaction rather than being pinned for the life of the run.
+   */
+  let credentials: EncryptedAgentCredentials | undefined =
+    firstMessage.credentials;
+
   while (turns < MAX_TURNS_PER_RUN) {
     if (pending === null) {
       // Durable pause: no compute is consumed while waiting for the operator.
       const next = await messages;
       if (next.text === AGENT_END_SENTINEL) break;
       pending = next;
+      credentials = next.credentials ?? credentials;
     }
 
     turns += 1;
@@ -81,6 +97,7 @@ export const agentSessionWorkflow = async (request: Request) => {
       text: pending.text,
       template: pending.template,
       preAuthorizeToolNames: pending.preAuthorizeToolNames,
+      credentials,
     });
     pending = null;
 
@@ -101,6 +118,7 @@ export const agentSessionWorkflow = async (request: Request) => {
       const decision = await agentApprovalHook.create({
         token: agentApprovalToken(sessionId, gated.toolCallId),
       });
+      credentials = decision.credentials ?? credentials;
 
       if (!decision.approved) {
         // Rejected: tell the agent why and let it respond, rather than silently stopping.
@@ -112,6 +130,7 @@ export const agentSessionWorkflow = async (request: Request) => {
             `The operator declined \`${gated.toolName}\`.` +
             (decision.comment ? ` They said: ${decision.comment}` : "") +
             " Do not retry it. Acknowledge and wait for further instructions.",
+          credentials,
         });
         break;
       }
@@ -127,6 +146,7 @@ export const agentSessionWorkflow = async (request: Request) => {
           " Run it now.",
         // The approval is already persisted, so the gate lets this call through.
         preAuthorizeToolNames: [gated.toolName],
+        credentials,
       });
     }
   }

--- a/apps/service/src/workflows/hooks/agent.hooks.ts
+++ b/apps/service/src/workflows/hooks/agent.hooks.ts
@@ -17,6 +17,25 @@ import * as z from "zod";
  * — `defineHook` and zod are both pure.
  */
 
+/**
+ * Caller-supplied provider keys, **still encrypted**.
+ *
+ * Every value here is the RSA ciphertext produced by `encodeApiKey` and stored in the operator's
+ * cookie; it is decrypted only inside the turn step, with `AI_AUTH_PRIVATE_KEY`. Keeping the
+ * ciphertext as the transport form matters because everything crossing this boundary is journaled
+ * durably by the workflow backend — plaintext here would be a plaintext secret at rest.
+ *
+ * Absent means "no bring-your-own key": the turn runs on the house gateway account.
+ */
+export const encryptedAgentCredentialsSchema = z.object({
+  openai: z.string().optional(),
+  anthropic: z.string().optional(),
+});
+
+export type EncryptedAgentCredentials = z.infer<
+  typeof encryptedAgentCredentialsSchema
+>;
+
 export const agentMessageHook = defineHook({
   schema: z.object({
     /** `"/end"` closes the session's run. */
@@ -26,6 +45,7 @@ export const agentMessageHook = defineHook({
       .optional(),
     /** Tool names pre-authorised for this turn only. */
     preAuthorizeToolNames: z.array(z.string()).optional(),
+    credentials: encryptedAgentCredentialsSchema.optional(),
   }),
 });
 
@@ -33,6 +53,13 @@ export const agentApprovalHook = defineHook({
   schema: z.object({
     approved: z.boolean(),
     comment: z.string().optional(),
+    /**
+     * Refreshed on the approval too, because the turns that follow an approval are synthesised by
+     * the workflow itself and have no request of their own to read a cookie from. An approval can
+     * land days after the prompt that triggered it, by which point the operator may well have
+     * rotated their key.
+     */
+    credentials: encryptedAgentCredentialsSchema.optional(),
   }),
 });
 

--- a/packages/agent-core/__tests__/models.test.ts
+++ b/packages/agent-core/__tests__/models.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  AGENT_PROVIDERS,
+  UnknownAgentModelError,
+  createAgentCatalog,
+  createAgentModels,
+  listModels,
+  resolveModel,
+} from "../src/models.ts";
+import type { AgentModelRef } from "../src/models.ts";
+
+/**
+ * The model layer's job is to keep two things straight: whose key pays, and which provider a model
+ * id belongs to. Both fail *silently* when they go wrong — a turn that quietly bills the house
+ * gateway account looks exactly like a working turn — so they are pinned here rather than left to
+ * an end-to-end run to reveal.
+ *
+ * These use pi-ai's real providers. That is deliberate and offline-safe: all three ship static
+ * catalogues and perform no I/O when registered.
+ */
+
+const allowAll = () => true;
+
+const GATEWAY_SONNET: AgentModelRef = {
+  providerId: AGENT_PROVIDERS.gateway,
+  modelId: "anthropic/claude-sonnet-5",
+};
+
+describe("createAgentModels", () => {
+  it("registers the gateway with no credentials, because it runs on an ambient env key", () => {
+    const models = createAgentModels();
+
+    expect(models.getProvider(AGENT_PROVIDERS.gateway)).toBeDefined();
+    expect(
+      models.getModel(GATEWAY_SONNET.providerId, GATEWAY_SONNET.modelId)
+    ).toBeDefined();
+  });
+
+  /**
+   * The load-bearing one. `OPENAI_API_KEY` exists in the service environment for unrelated
+   * features, and pi-ai falls back to ambient env vars when no credential is stored — so a provider
+   * registered unconditionally would resolve against the house key and bill it for what is meant to
+   * be the operator's own account.
+   */
+  it("omits a BYOK provider entirely when its key was not supplied", () => {
+    const models = createAgentModels();
+
+    expect(models.getProvider(AGENT_PROVIDERS.openai)).toBeUndefined();
+    expect(models.getProvider(AGENT_PROVIDERS.anthropic)).toBeUndefined();
+  });
+
+  it("registers only the BYOK provider whose key was supplied", () => {
+    const models = createAgentModels({ openai: "sk-test" });
+
+    expect(models.getProvider(AGENT_PROVIDERS.openai)).toBeDefined();
+    expect(models.getProvider(AGENT_PROVIDERS.anthropic)).toBeUndefined();
+  });
+
+  it("resolves a supplied key ahead of the ambient environment", async () => {
+    const models = createAgentModels({ anthropic: "sk-supplied" });
+
+    const auth = await models.getAuth(AGENT_PROVIDERS.anthropic);
+
+    expect(auth?.auth.apiKey).toBe("sk-supplied");
+  });
+});
+
+describe("resolveModel", () => {
+  it("resolves a pair the predicate admits", () => {
+    const model = resolveModel(GATEWAY_SONNET, allowAll, createAgentModels());
+
+    expect(model.id).toBe(GATEWAY_SONNET.modelId);
+    expect(model.contextWindow).toBeGreaterThan(0);
+  });
+
+  it("rejects a pair the predicate refuses", () => {
+    expect(() =>
+      resolveModel(GATEWAY_SONNET, () => false, createAgentModels())
+    ).toThrow(UnknownAgentModelError);
+  });
+
+  /**
+   * The same model carries different ids under different providers — `anthropic/claude-sonnet-5` on
+   * the gateway is `claude-sonnet-5` natively. Matching on the id alone would resolve a session to
+   * the wrong provider, so a mismatched pair must fail rather than fall back.
+   */
+  it("rejects a native model id under the gateway", () => {
+    expect(() =>
+      resolveModel(
+        { providerId: AGENT_PROVIDERS.gateway, modelId: "claude-sonnet-5" },
+        allowAll,
+        createAgentModels()
+      )
+    ).toThrow(UnknownAgentModelError);
+  });
+
+  it("rejects a model on a BYOK provider with no key, naming the provider", () => {
+    expect(() =>
+      resolveModel(
+        { providerId: AGENT_PROVIDERS.openai, modelId: "gpt-5.2" },
+        allowAll,
+        createAgentModels()
+      )
+    ).toThrow(/openai/);
+  });
+});
+
+describe("listModels", () => {
+  it("enumerates the catalogue rather than a hand-written list", () => {
+    const gateway = listModels(
+      (ref) => ref.providerId === AGENT_PROVIDERS.gateway
+    );
+
+    // The exact count tracks pi-ai's bundled catalogue; only the order of magnitude is the point.
+    expect(gateway.length).toBeGreaterThan(100);
+    expect(gateway.every((model) => model.name.length > 0)).toBe(true);
+    expect(gateway.every((model) => model.contextWindow > 0)).toBe(true);
+  });
+
+  it("applies the predicate per pair", () => {
+    const listed = listModels(
+      (ref) => ref.modelId === "anthropic/claude-sonnet-5"
+    );
+
+    expect(listed).toHaveLength(1);
+    expect(listed[0]?.providerId).toBe(AGENT_PROVIDERS.gateway);
+  });
+
+  /**
+   * The picker lists BYOK models the caller cannot yet use, flagged rather than hidden: hiding them
+   * would leave no way to discover that registering a key unlocks them.
+   */
+  it("flags BYOK models the caller has no key for", () => {
+    const listed = listModels(
+      (ref) => ref.providerId === AGENT_PROVIDERS.openai,
+      { models: createAgentCatalog() }
+    );
+
+    expect(listed.length).toBeGreaterThan(0);
+    expect(listed.every((model) => model.requiresApiKey)).toBe(true);
+  });
+
+  it("clears the flag for a provider the caller has registered", () => {
+    const listed = listModels(
+      (ref) => ref.providerId === AGENT_PROVIDERS.openai,
+      { configured: [AGENT_PROVIDERS.openai] }
+    );
+
+    expect(listed.every((model) => model.requiresApiKey)).toBe(false);
+  });
+
+  it("never flags the gateway, which needs no caller-supplied key", () => {
+    const listed = listModels(
+      (ref) => ref.providerId === AGENT_PROVIDERS.gateway
+    );
+
+    expect(listed.every((model) => !model.requiresApiKey)).toBe(true);
+  });
+});

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -18,12 +18,20 @@
 export * from "./types.ts";
 export * from "./ports.ts";
 export {
-  AGENT_PROVIDER_ID,
+  AGENT_PROVIDERS,
+  BYOK_PROVIDER_IDS,
   UnknownAgentModelError,
-  getAgentModels,
+  createAgentCatalog,
+  createAgentModels,
+  isByokProviderId,
   listModels,
   resolveModel,
+  type AgentCredentials,
   type AgentModelInfo,
+  type AgentModelPredicate,
+  type AgentModelRef,
+  type ByokProviderId,
+  type ListModelsOptions,
 } from "./models.ts";
 export {
   agentWireEventSchema,

--- a/packages/agent-core/src/models.ts
+++ b/packages/agent-core/src/models.ts
@@ -1,65 +1,177 @@
-import { createModels } from "@earendil-works/pi-ai";
-import type { Api, Model, Models } from "@earendil-works/pi-ai";
+import { createModels, InMemoryModelsStore } from "@earendil-works/pi-ai";
+import type {
+  Api,
+  Credential,
+  CredentialInfo,
+  CredentialStore,
+  Model,
+  Models,
+} from "@earendil-works/pi-ai";
+import { anthropicProvider } from "@earendil-works/pi-ai/providers/anthropic";
+import { openaiProvider } from "@earendil-works/pi-ai/providers/openai";
 import { vercelAIGatewayProvider } from "@earendil-works/pi-ai/providers/vercel-ai-gateway";
 
 /**
  * Model layer.
  *
- * pi-ai ships a first-class `vercelAIGatewayProvider()` that talks Anthropic's native
- * messages API against `https://ai-gateway.vercel.sh` and resolves its key from
- * `AI_GATEWAY_API_KEY` — the same gateway and the same env var the rest of the repo
- * already uses. So there is no custom provider to write, and native thinking / prompt
- * caching fidelity is preserved (an OpenAI-compatible shim would have lost both).
+ * Three providers, two credential stories:
+ *
+ * - `vercel-ai-gateway` — the house account. pi-ai's own provider talks Anthropic's native messages
+ *   API against `https://ai-gateway.vercel.sh` and resolves `AI_GATEWAY_API_KEY` from the ambient
+ *   environment, which is the same gateway and env var the rest of the repo already uses. Its
+ *   catalogue is not Anthropic-only: the gateway translates protocols server-side, so `openai/*`
+ *   models are served over the very same `anthropic-messages` API.
+ * - `openai` / `anthropic` — bring-your-own-key. The caller's key arrives per request, so these are
+ *   registered *only* when a credential is supplied. A registration-time decision rather than a
+ *   resolve-time check, because pi-ai's auth resolution falls back to ambient env vars when nothing
+ *   is stored — and `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` do exist in the service environment for
+ *   unrelated features. Registering them unconditionally would silently bill the house account for
+ *   what is meant to be the operator's own key.
+ *
+ * Consequently `Models` is **per-credential-set**, not process-wide. See {@link createAgentModels}.
  */
 
-export const AGENT_PROVIDER_ID = "vercel-ai-gateway";
+export const AGENT_PROVIDERS = {
+  gateway: "vercel-ai-gateway",
+  openai: "openai",
+  anthropic: "anthropic",
+} as const;
+
+/** Providers whose key the caller supplies. The gateway is deliberately absent. */
+export const BYOK_PROVIDER_IDS = [
+  AGENT_PROVIDERS.openai,
+  AGENT_PROVIDERS.anthropic,
+] as const;
+
+export type ByokProviderId = (typeof BYOK_PROVIDER_IDS)[number];
+
+export const isByokProviderId = (
+  providerId: string
+): providerId is ByokProviderId =>
+  (BYOK_PROVIDER_IDS as readonly string[]).includes(providerId);
 
 /**
- * Provider registration is process-wide and immutable, so it is built once and cached.
- * `Models` holds no per-request state — auth resolves per call.
+ * Decrypted, request-scoped provider keys.
+ *
+ * Plaintext: the ciphertext form is a transport concern and is decrypted at the last possible
+ * moment — see `apps/service/src/steps/agent-turn.step.ts`.
  */
-let cached: Models | undefined;
+export type AgentCredentials = Partial<Record<ByokProviderId, string>>;
 
-export const getAgentModels = (): Models => {
-  if (!cached) {
-    const models = createModels();
-    models.setProvider(vercelAIGatewayProvider());
-    cached = models;
-  }
-  return cached;
+/** Identifies a model. Both halves are required — see {@link resolveModel}. */
+export interface AgentModelRef {
+  providerId: string;
+  modelId: string;
+}
+
+/** Whether a kind's policy admits a model. See `@chia/agent-writing`'s `isWritingModel`. */
+export type AgentModelPredicate = (ref: AgentModelRef) => boolean;
+
+/**
+ * Read-only {@link CredentialStore} over a fixed set of keys.
+ *
+ * pi-ai's own `InMemoryCredentialStore` would work, but seeding it means awaiting `modify()` per
+ * provider, which would make model construction async for no gain. Nothing here is ever written:
+ * login and logout are meaningless for credentials that arrived with the request and die with it.
+ */
+const fixedCredentialStore = (
+  credentials: AgentCredentials
+): CredentialStore => {
+  const entries = new Map<string, Credential>(
+    Object.entries(credentials).flatMap(([providerId, key]) =>
+      key ? [[providerId, { type: "api_key", key } as Credential]] : []
+    )
+  );
+  return {
+    read: (providerId) => Promise.resolve(entries.get(providerId)),
+    list: () =>
+      Promise.resolve(
+        [...entries.entries()].map(
+          ([providerId, credential]): CredentialInfo => ({
+            providerId,
+            type: credential.type,
+          })
+        )
+      ),
+    modify: (providerId) => Promise.resolve(entries.get(providerId)),
+    delete: () => Promise.resolve(),
+  };
+};
+
+/**
+ * Model catalogues are static per pi-ai release and identical across callers, so the store that
+ * backs them is shared process-wide even though `Models` instances are not.
+ */
+const modelsStore = new InMemoryModelsStore();
+
+/**
+ * Builds the `Models` an agent turn executes against.
+ *
+ * Called **per turn**, because the BYOK credentials it closes over are per request. Provider
+ * construction is cheap — these three ship static catalogues and perform no I/O at registration.
+ */
+export const createAgentModels = (
+  credentials: AgentCredentials = {}
+): Models => {
+  const models = createModels({
+    modelsStore,
+    credentials: fixedCredentialStore(credentials),
+  });
+  models.setProvider(vercelAIGatewayProvider());
+  if (credentials.openai) models.setProvider(openaiProvider());
+  if (credentials.anthropic) models.setProvider(anthropicProvider());
+  return models;
+};
+
+/**
+ * Every provider registered, no credentials.
+ *
+ * For the model picker only: catalogue metadata (name, context window, cost) is a property of the
+ * model, not of who is paying for it, so the picker can describe a provider the caller has not
+ * authenticated yet — that is exactly what lets the UI say "needs an API key" instead of hiding it.
+ * Never use this to execute a turn; it would resolve BYOK providers against ambient env keys.
+ */
+export const createAgentCatalog = (): Models => {
+  const models = createModels({ modelsStore });
+  models.setProvider(vercelAIGatewayProvider());
+  models.setProvider(openaiProvider());
+  models.setProvider(anthropicProvider());
+  return models;
 };
 
 export class UnknownAgentModelError extends Error {
-  constructor(
-    readonly modelId: string,
-    allowlist: readonly string[]
-  ) {
+  constructor(readonly ref: AgentModelRef) {
     super(
-      `Model "${modelId}" is not available to this agent. Allowed: ${allowlist.join(", ")}`
+      `Model "${ref.modelId}" on provider "${ref.providerId}" is not available to this agent.`
     );
     this.name = "UnknownAgentModelError";
   }
 }
 
 /**
- * Resolves a model against an **allowlist owned by the agent kind**.
+ * Resolves a `(providerId, modelId)` pair against a predicate **owned by the agent kind**.
  *
- * The allowlist is a parameter rather than a constant here: which models an agent may use is
- * policy, and a long-horizon authoring agent with write access wants a different (narrower) set
- * than, say, a public Q&A agent. Ids outside it are rejected even when the gateway would serve
- * them, because the id arrives from a client-supplied setting.
+ * The pair is the identity, never the model id alone: the same model carries different ids under
+ * different providers — `anthropic/claude-haiku-4.5` through the gateway is `claude-haiku-4-5`
+ * natively. Matching on the id alone would resolve a session to the wrong provider, or to nothing.
+ *
+ * The predicate is a parameter rather than a constant because which models an agent may use is
+ * policy: a long-horizon authoring agent with write access wants a different set than a public Q&A
+ * agent. Pairs outside it are rejected even when the provider would serve them, because the pair
+ * arrives from a client-supplied setting.
  */
 export const resolveModel = (
-  modelId: string,
-  allowlist: readonly string[],
-  models: Models = getAgentModels()
+  ref: AgentModelRef,
+  isAllowed: AgentModelPredicate,
+  models: Models
 ): Model<Api> => {
-  if (!allowlist.includes(modelId)) {
-    throw new UnknownAgentModelError(modelId, allowlist);
+  if (!isAllowed(ref)) {
+    throw new UnknownAgentModelError(ref);
   }
-  const model = models.getModel(AGENT_PROVIDER_ID, modelId);
+  const model = models.getModel(ref.providerId, ref.modelId);
   if (!model) {
-    throw new UnknownAgentModelError(modelId, allowlist);
+    // Also the "BYOK provider with no key" path: it was never registered, so it has no models.
+    throw new UnknownAgentModelError(ref);
   }
   return model;
 };
@@ -71,24 +183,45 @@ export interface AgentModelInfo {
   contextWindow: number;
   supportsReasoning: boolean;
   supportsImageInput: boolean;
+  /** True when this provider needs a caller-supplied key that is not configured yet. */
+  requiresApiKey: boolean;
 }
 
-/** Model picker payload. Silently skips ids the installed pi-ai catalogue lacks. */
+export interface ListModelsOptions {
+  /** Defaults to a full catalogue; pass a turn's `Models` only if you want its narrower view. */
+  models?: Models;
+  /** BYOK providers the caller has already authenticated. */
+  configured?: readonly string[];
+}
+
+/**
+ * Model picker payload.
+ *
+ * Enumerates each provider's catalogue and filters it through the kind's policy, rather than
+ * looking up a hand-written list of ids. The metadata is pi-ai's own, so a model's context window
+ * and modality stay correct across pi-ai upgrades without anyone editing a constant.
+ */
 export const listModels = (
-  allowlist: readonly string[],
-  models: Models = getAgentModels()
-): AgentModelInfo[] =>
-  allowlist.flatMap((modelId) => {
-    const model = models.getModel(AGENT_PROVIDER_ID, modelId);
-    if (!model) return [];
-    return [
-      {
-        providerId: AGENT_PROVIDER_ID,
-        modelId,
-        name: model.name,
-        contextWindow: model.contextWindow,
-        supportsReasoning: Boolean(model.reasoning),
-        supportsImageInput: model.input.includes("image"),
-      },
-    ];
-  });
+  isAllowed: AgentModelPredicate,
+  options: ListModelsOptions = {}
+): AgentModelInfo[] => {
+  const models = options.models ?? createAgentCatalog();
+  const configured = new Set(options.configured ?? []);
+  return models.getProviders().flatMap((provider) =>
+    provider.getModels().flatMap((model) => {
+      const ref = { providerId: provider.id, modelId: model.id };
+      if (!isAllowed(ref)) return [];
+      return [
+        {
+          ...ref,
+          name: model.name,
+          contextWindow: model.contextWindow,
+          supportsReasoning: Boolean(model.reasoning),
+          supportsImageInput: model.input.includes("image"),
+          requiresApiKey:
+            isByokProviderId(provider.id) && !configured.has(provider.id),
+        },
+      ];
+    })
+  );
+};

--- a/packages/agent-runtime/src/adapters/pi.ts
+++ b/packages/agent-runtime/src/adapters/pi.ts
@@ -9,14 +9,12 @@ import type {
   Session,
   SessionTreeEntry,
   Skill,
+  ThinkingLevel,
 } from "@earendil-works/pi-agent-core";
+import { clampThinkingLevel } from "@earendil-works/pi-ai";
 import type { Api, Model, Models } from "@earendil-works/pi-ai";
 
-import {
-  createEventMapper,
-  createToolCallGate,
-  getAgentModels,
-} from "@chia/agent-core";
+import { createEventMapper, createToolCallGate } from "@chia/agent-core";
 import type {
   AgentPolicy,
   AgentSessionSettings,
@@ -40,6 +38,14 @@ export interface CreatePiAgentEngineOptions<
   settings: AgentSessionSettings;
   /** Resolved model. Kinds own their own allowlist — see `resolveModel`. */
   model: Model<Api>;
+  /**
+   * The collection `model` was resolved from.
+   *
+   * Required, and required to be the *same* instance: `Models` owns credential resolution, so a
+   * model resolved from a caller's BYOK collection but streamed through a different one would be
+   * billed to whatever key that other collection happens to carry.
+   */
+  models: Models;
   tools: AgentTool<TContext>[];
   /** Static context or a per-turn provider. pi snapshots it at turn start. */
   toolContext: TContext | (() => TContext | Promise<TContext>);
@@ -54,7 +60,6 @@ export interface CreatePiAgentEngineOptions<
   approvedToolCallIds?: ReadonlySet<string>;
   preAuthorizedToolNames?: ReadonlySet<string>;
   pending?: PendingMessageStore;
-  models?: Models;
 }
 
 export interface PiAgentEngineHandle extends AgentMaintenanceEngineHandle {
@@ -90,6 +95,19 @@ export const shouldCompactBranch = (
   return shouldCompact(tokens, contextWindow, DEFAULT_COMPACTION_SETTINGS);
 };
 
+/**
+ * Clamps a session's thinking level to what the resolved model actually supports.
+ *
+ * Sessions persist a thinking level as a bare string, and the model is chosen independently of it,
+ * so switching a session from Claude to GPT (or to a model with no reasoning at all) can leave a
+ * level the new model cannot honour. pi-ai knows each model's supported levels, so the arithmetic
+ * belongs to it rather than to a table here that would drift from the catalogue.
+ */
+const clampSettingsThinkingLevel = (
+  model: Model<Api>,
+  settings: AgentSessionSettings
+): ThinkingLevel => clampThinkingLevel(model, settings.thinkingLevel);
+
 /** Shared by both handles so a single threshold governs turn and maintenance paths alike. */
 const compactIfNeededWith =
   (
@@ -112,8 +130,7 @@ const compactIfNeededWith =
 export const createPiAgentEngine = async <TContext extends object>(
   options: CreatePiAgentEngineOptions<TContext>
 ): Promise<PiAgentEngineHandle> => {
-  const models = options.models ?? getAgentModels();
-  const { policy } = options;
+  const { models, policy } = options;
   const prompt = options.systemPrompt;
   const systemPrompt =
     typeof prompt === "string" ? prompt : async () => await prompt();
@@ -129,7 +146,7 @@ export const createPiAgentEngine = async <TContext extends object>(
     model: options.model,
     tools: options.tools,
     toolContext: options.toolContext,
-    thinkingLevel: options.settings.thinkingLevel,
+    thinkingLevel: clampSettingsThinkingLevel(options.model, options.settings),
     activeToolNames: options.settings.activeToolNames ?? undefined,
     resources: {
       skills: options.skills,
@@ -251,7 +268,8 @@ export const createPiAgentEngine = async <TContext extends object>(
 export interface CreatePiMaintenanceEngineOptions extends AgentMaintenanceCreateOptions {
   /** Resolved model. Only the summarisation calls and the context-window threshold use it. */
   model: Model<Api>;
-  models?: Models;
+  /** The collection `model` was resolved from; see the note on the turn engine's options. */
+  models: Models;
 }
 
 const maintenanceOnly = (method: string): never => {
@@ -279,10 +297,10 @@ export const createPiMaintenanceEngine = async (
 ): Promise<AgentMaintenanceEngineHandle> => {
   const harness = new AgentHarness({
     session: options.session,
-    models: options.models ?? getAgentModels(),
+    models: options.models,
     model: options.model,
     tools: [],
-    thinkingLevel: options.settings.thinkingLevel,
+    thinkingLevel: clampSettingsThinkingLevel(options.model, options.settings),
     systemPrompt: "",
   } as never) as AgentHarness;
 

--- a/packages/agent-writing/__tests__/models.test.ts
+++ b/packages/agent-writing/__tests__/models.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  AGENT_PROVIDERS,
+  UnknownAgentModelError,
+  createAgentModels,
+} from "@chia/agent-core";
+
+import {
+  DEFAULT_WRITING_MODEL,
+  isWritingModel,
+  listWritingModels,
+  resolveWritingModel,
+  WRITING_SESSION_DEFAULTS,
+} from "../src/models.ts";
+
+/**
+ * The policy half of model selection. It replaced a hand-written list of four ids, so what needs
+ * pinning is the *shape* of the filter — a predicate that is too generous quietly exposes 26
+ * vendors' models to an agent with publish rights to the blog.
+ */
+
+describe("isWritingModel", () => {
+  it("admits the two vendors the agent is built against, through the gateway", () => {
+    expect(
+      isWritingModel({
+        providerId: AGENT_PROVIDERS.gateway,
+        modelId: "anthropic/claude-sonnet-5",
+      })
+    ).toBe(true);
+    expect(
+      isWritingModel({
+        providerId: AGENT_PROVIDERS.gateway,
+        modelId: "openai/gpt-5.4",
+      })
+    ).toBe(true);
+  });
+
+  it("refuses the gateway's other vendors", () => {
+    for (const modelId of [
+      "google/gemini-3.1-pro",
+      "xai/grok-4",
+      "meta/llama-4",
+    ]) {
+      expect(
+        isWritingModel({ providerId: AGENT_PROVIDERS.gateway, modelId })
+      ).toBe(false);
+    }
+  });
+
+  /** A caller who supplied their own OpenAI key is asking for OpenAI models; no second filter. */
+  it("admits any model on a native provider", () => {
+    expect(
+      isWritingModel({ providerId: AGENT_PROVIDERS.openai, modelId: "gpt-5.2" })
+    ).toBe(true);
+    expect(
+      isWritingModel({
+        providerId: AGENT_PROVIDERS.anthropic,
+        modelId: "claude-opus-5",
+      })
+    ).toBe(true);
+  });
+
+  it("refuses a provider the agent does not know", () => {
+    expect(
+      isWritingModel({ providerId: "openrouter", modelId: "gpt-5.2" })
+    ).toBe(false);
+  });
+});
+
+describe("resolveWritingModel", () => {
+  it("resolves the session default without any caller-supplied key", () => {
+    const model = resolveWritingModel(DEFAULT_WRITING_MODEL);
+
+    expect(model.id).toBe(DEFAULT_WRITING_MODEL.modelId);
+  });
+
+  /**
+   * The pair — not the id — selects the provider. Same vendor, same model family, two different
+   * ids and two different payers.
+   */
+  it("resolves the same vendor through either provider", () => {
+    const viaGateway = resolveWritingModel({
+      providerId: AGENT_PROVIDERS.gateway,
+      modelId: "anthropic/claude-sonnet-5",
+    });
+    const native = resolveWritingModel(
+      { providerId: AGENT_PROVIDERS.anthropic, modelId: "claude-sonnet-5" },
+      createAgentModels({ anthropic: "sk-test" })
+    );
+
+    expect(viaGateway.provider).toBe(AGENT_PROVIDERS.gateway);
+    expect(native.provider).toBe(AGENT_PROVIDERS.anthropic);
+  });
+
+  it("refuses a gateway model outside the two admitted vendors", () => {
+    expect(() =>
+      resolveWritingModel({
+        providerId: AGENT_PROVIDERS.gateway,
+        modelId: "google/gemini-3.1-pro",
+      })
+    ).toThrow(UnknownAgentModelError);
+  });
+
+  it("refuses a native model when the caller supplied no key for it", () => {
+    expect(() =>
+      resolveWritingModel({
+        providerId: AGENT_PROVIDERS.openai,
+        modelId: "gpt-5.2",
+      })
+    ).toThrow(UnknownAgentModelError);
+  });
+});
+
+describe("listWritingModels", () => {
+  it("offers both vendors through the gateway and nothing else from it", () => {
+    const gateway = listWritingModels().filter(
+      (model) => model.providerId === AGENT_PROVIDERS.gateway
+    );
+
+    expect(gateway.length).toBeGreaterThan(0);
+    expect(
+      gateway.every(
+        (model) =>
+          model.modelId.startsWith("anthropic/") ||
+          model.modelId.startsWith("openai/")
+      )
+    ).toBe(true);
+  });
+
+  it("includes both native providers, flagged as needing a key", () => {
+    const native = listWritingModels().filter(
+      (model) => model.providerId !== AGENT_PROVIDERS.gateway
+    );
+
+    expect(new Set(native.map((model) => model.providerId))).toEqual(
+      new Set([AGENT_PROVIDERS.openai, AGENT_PROVIDERS.anthropic])
+    );
+    expect(native.every((model) => model.requiresApiKey)).toBe(true);
+  });
+});
+
+describe("WRITING_SESSION_DEFAULTS", () => {
+  /** A new session must keep landing on the house gateway account, key or no key. */
+  it("defaults a new session to the gateway", () => {
+    expect(WRITING_SESSION_DEFAULTS.providerId).toBe(AGENT_PROVIDERS.gateway);
+    expect(isWritingModel(DEFAULT_WRITING_MODEL)).toBe(true);
+  });
+});

--- a/packages/agent-writing/__tests__/models.test.ts
+++ b/packages/agent-writing/__tests__/models.test.ts
@@ -7,6 +7,7 @@ import {
 } from "@chia/agent-core";
 
 import {
+  assertWritingModel,
   DEFAULT_WRITING_MODEL,
   isWritingModel,
   listWritingModels,
@@ -109,6 +110,54 @@ describe("resolveWritingModel", () => {
         modelId: "gpt-5.2",
       })
     ).toThrow(UnknownAgentModelError);
+  });
+});
+
+/**
+ * The pre-persistence gate. Its whole reason to exist is that `isWritingModel` returns `true` for
+ * *any* id on a native provider, so policy alone would let a typo be stored and then fail on every
+ * later turn — inside the workflow step, where the operator never sees the cause.
+ */
+describe("assertWritingModel", () => {
+  it("accepts a pair that exists in the catalogue", () => {
+    expect(() => assertWritingModel(DEFAULT_WRITING_MODEL)).not.toThrow();
+    expect(() =>
+      assertWritingModel({
+        providerId: AGENT_PROVIDERS.openai,
+        modelId: "gpt-5.2",
+      })
+    ).not.toThrow();
+  });
+
+  it("rejects an id policy admits but the catalogue has never heard of", () => {
+    expect(() =>
+      assertWritingModel({
+        providerId: AGENT_PROVIDERS.openai,
+        modelId: "gpt-does-not-exist",
+      })
+    ).toThrow(UnknownAgentModelError);
+  });
+
+  it("rejects a vendor outside the gateway's admitted set", () => {
+    expect(() =>
+      assertWritingModel({
+        providerId: AGENT_PROVIDERS.gateway,
+        modelId: "google/gemini-3.1-pro",
+      })
+    ).toThrow(UnknownAgentModelError);
+  });
+
+  /**
+   * Validation runs against the catalogue, not a credential-bearing collection — otherwise whether
+   * a model "exists" would depend on which browser the operator happened to be using.
+   */
+  it("accepts a native model even with no key registered", () => {
+    expect(() =>
+      assertWritingModel({
+        providerId: AGENT_PROVIDERS.anthropic,
+        modelId: "claude-opus-5",
+      })
+    ).not.toThrow();
   });
 });
 

--- a/packages/agent-writing/__tests__/runtime.test.ts
+++ b/packages/agent-writing/__tests__/runtime.test.ts
@@ -48,9 +48,15 @@ interface Fixture {
 const build = async (
   settings: Partial<AgentSessionSettings> = {}
 ): Promise<Fixture> => {
+  /**
+   * The faux provider stands in for whichever provider the settings name, so a turn can be driven
+   * through a non-gateway provider without a second scripting harness.
+   */
+  const providerId = settings.providerId ?? "vercel-ai-gateway";
+  const modelId = settings.modelId ?? "anthropic/claude-sonnet-5";
   const faux = fauxProvider({
-    provider: "vercel-ai-gateway",
-    models: [{ id: "anthropic/claude-sonnet-5" }],
+    provider: providerId,
+    models: [{ id: modelId }],
   });
   const models = createModels();
   models.setProvider(faux.provider);
@@ -74,8 +80,8 @@ const build = async (
   const built = await createWritingEngine({
     session,
     settings: {
-      providerId: "vercel-ai-gateway",
-      modelId: "anthropic/claude-sonnet-5",
+      providerId,
+      modelId,
       thinkingLevel: "off",
       activeToolNames: null,
       autoApprove: [],
@@ -139,6 +145,29 @@ describe("createWritingEngine", () => {
       text: "There is already a post about TypeScript.",
       streaming: false,
     });
+  });
+
+  /**
+   * `settings.providerId` was persisted but never read: model resolution hard-coded the gateway, so
+   * a session pointing at any other provider silently ran on the gateway anyway. This pins that it
+   * is now load-bearing — the turn only completes if the engine resolved against the *named*
+   * provider, since that is the only one the faux collection registers.
+   */
+  it("runs a turn against the provider the settings name", async () => {
+    const native = await build({
+      providerId: "openai",
+      modelId: "gpt-5.2",
+    });
+
+    native.setResponses([fauxAssistantMessage("Answered over OpenAI.")]);
+    await native.engine.prompt("Who is answering?");
+
+    const view = foldEvents(native.events);
+    expect(
+      view.items.filter((item) => item.kind === "assistant").at(-1)
+    ).toMatchObject({ text: "Answered over OpenAI.", streaming: false });
+
+    native.dispose();
   });
 
   it("writes the draft buffer and never touches published content", async () => {

--- a/packages/agent-writing/src/index.ts
+++ b/packages/agent-writing/src/index.ts
@@ -11,14 +11,12 @@
 export * from "./types.ts";
 export * from "./ports.ts";
 export {
-  DEFAULT_WRITING_MODEL_ID,
+  DEFAULT_WRITING_MODEL,
   WRITING_AGENT_KIND,
-  WRITING_MODEL_IDS,
   WRITING_SESSION_DEFAULTS,
-  isWritingModelId,
+  isWritingModel,
   listWritingModels,
   resolveWritingModel,
-  type WritingModelId,
 } from "./models.ts";
 export { writingPolicy } from "./policy.ts";
 export {

--- a/packages/agent-writing/src/index.ts
+++ b/packages/agent-writing/src/index.ts
@@ -14,6 +14,7 @@ export {
   DEFAULT_WRITING_MODEL,
   WRITING_AGENT_KIND,
   WRITING_SESSION_DEFAULTS,
+  assertWritingModel,
   isWritingModel,
   listWritingModels,
   resolveWritingModel,

--- a/packages/agent-writing/src/models.ts
+++ b/packages/agent-writing/src/models.ts
@@ -2,6 +2,7 @@ import type { Api, Model, Models } from "@earendil-works/pi-ai";
 
 import {
   AGENT_PROVIDERS,
+  createAgentCatalog,
   createAgentModels,
   listModels,
   resolveModel,
@@ -62,6 +63,22 @@ export const resolveWritingModel = (
   ref: AgentModelRef,
   models: Models = createAgentModels()
 ): Model<Api> => resolveModel(ref, isWritingModel, models);
+
+/**
+ * Validates a selection without executing it. Throws `UnknownAgentModelError` if it fails.
+ *
+ * `isWritingModel` alone is not enough: it admits *any* id on a native provider, so a typo would
+ * persist happily and then fail on every subsequent turn, deep inside the workflow step where the
+ * operator cannot see why. Resolving against the full catalogue checks that the model exists at
+ * all — the one thing policy cannot know.
+ *
+ * Deliberately the catalogue rather than a credential-bearing collection: whether a model *exists*
+ * must not depend on which keys the caller happens to have registered, or the answer would change
+ * between browsers.
+ */
+export const assertWritingModel = (ref: AgentModelRef): void => {
+  resolveModel(ref, isWritingModel, createAgentCatalog());
+};
 
 export const listWritingModels = (
   options?: ListModelsOptions

--- a/packages/agent-writing/src/models.ts
+++ b/packages/agent-writing/src/models.ts
@@ -1,44 +1,76 @@
 import type { Api, Model, Models } from "@earendil-works/pi-ai";
 
-import { AGENT_PROVIDER_ID, listModels, resolveModel } from "@chia/agent-core";
-import type { AgentModelInfo, AgentSessionDefaults } from "@chia/agent-core";
+import {
+  AGENT_PROVIDERS,
+  createAgentModels,
+  listModels,
+  resolveModel,
+} from "@chia/agent-core";
+import type {
+  AgentModelInfo,
+  AgentModelRef,
+  AgentSessionDefaults,
+  ListModelsOptions,
+} from "@chia/agent-core";
 
 /**
  * Which models the *writing* agent may use.
  *
- * Narrow on purpose: a long-horizon authoring agent with write access to the blog is a bad place to
- * discover that a cheap model ignores tool schemas. Ordered best-first — the head is the default.
+ * A predicate over `(providerId, modelId)` rather than a hand-written list of ids. Names, context
+ * windows and costs all come from pi-ai's bundled catalogue, so they stay correct across pi-ai
+ * upgrades without anyone editing a constant here — what this file owns is the *policy*, not the
+ * data.
  *
- * The allowlist lives here rather than in `@chia/agent-core` because it is policy, not
- * infrastructure. A public-facing agent would want a cheaper, faster set.
+ * The gateway carries 26 vendors' models, most never exercised against this agent's tool schemas. A
+ * long-horizon authoring agent with write access to the blog is a bad place to discover that a
+ * cheap model ignores them, so the gateway is narrowed to the two vendors the agent is actually
+ * built against. The native providers need no such filter: a caller who supplied their own OpenAI
+ * key is asking for OpenAI models.
+ *
+ * This lives here rather than in `@chia/agent-core` because it is policy, not infrastructure. A
+ * public-facing agent would want a cheaper, wider set.
  */
-export const WRITING_MODEL_IDS = [
-  "anthropic/claude-sonnet-5",
-  "anthropic/claude-opus-5",
-  "anthropic/claude-sonnet-4.6",
-  "anthropic/claude-haiku-4.5",
-] as const;
+const GATEWAY_VENDOR_PREFIXES = ["anthropic/", "openai/"] as const;
 
-export type WritingModelId = (typeof WRITING_MODEL_IDS)[number];
+export const isWritingModel = (ref: AgentModelRef): boolean => {
+  switch (ref.providerId) {
+    case AGENT_PROVIDERS.gateway:
+      return GATEWAY_VENDOR_PREFIXES.some((prefix) =>
+        ref.modelId.startsWith(prefix)
+      );
+    case AGENT_PROVIDERS.openai:
+    case AGENT_PROVIDERS.anthropic:
+      return true;
+    default:
+      return false;
+  }
+};
 
-export const DEFAULT_WRITING_MODEL_ID: WritingModelId =
-  "anthropic/claude-sonnet-5";
+export const DEFAULT_WRITING_MODEL: AgentModelRef = {
+  providerId: AGENT_PROVIDERS.gateway,
+  modelId: "anthropic/claude-sonnet-5",
+};
 
-export const isWritingModelId = (modelId: string): modelId is WritingModelId =>
-  (WRITING_MODEL_IDS as readonly string[]).includes(modelId);
-
+/**
+ * Resolves a session's model.
+ *
+ * `models` defaults to a credential-free collection, which registers only the gateway — so a caller
+ * that forgets to thread BYOK credentials through gets a clean `UnknownAgentModelError` naming the
+ * provider, rather than a turn that silently bills the house account.
+ */
 export const resolveWritingModel = (
-  modelId: string,
-  models?: Models
-): Model<Api> => resolveModel(modelId, WRITING_MODEL_IDS, models);
+  ref: AgentModelRef,
+  models: Models = createAgentModels()
+): Model<Api> => resolveModel(ref, isWritingModel, models);
 
-export const listWritingModels = (models?: Models): AgentModelInfo[] =>
-  listModels(WRITING_MODEL_IDS, models);
+export const listWritingModels = (
+  options?: ListModelsOptions
+): AgentModelInfo[] => listModels(isWritingModel, options);
 
 /** Defaults a new writing session is created with. */
 export const WRITING_SESSION_DEFAULTS: AgentSessionDefaults = {
-  providerId: AGENT_PROVIDER_ID,
-  modelId: DEFAULT_WRITING_MODEL_ID,
+  providerId: DEFAULT_WRITING_MODEL.providerId,
+  modelId: DEFAULT_WRITING_MODEL.modelId,
   thinkingLevel: "off",
 };
 

--- a/packages/agent-writing/src/runtime.ts
+++ b/packages/agent-writing/src/runtime.ts
@@ -1,5 +1,6 @@
 import type { Models } from "@earendil-works/pi-ai";
 
+import { createAgentModels } from "@chia/agent-core";
 import type {
   AgentSessionSettings,
   AgentWireEvent,
@@ -58,6 +59,7 @@ export const createWritingEngine = (
   options: CreateWritingEngineOptions
 ): Promise<WritingEngine> => {
   const defaultLocale = options.defaultLocale ?? Locale.zhTW;
+  const models = options.models ?? createAgentModels();
 
   const toolContext: WritingToolContext = {
     agentSessionId: options.agentSessionId,
@@ -70,7 +72,8 @@ export const createWritingEngine = (
   return createPiAgentEngine<WritingToolContext>({
     session: options.session,
     settings: options.settings,
-    model: resolveWritingModel(options.settings.modelId, options.models),
+    model: resolveWritingModel(options.settings, models),
+    models,
     agentSessionId: options.agentSessionId,
     tools: createWritingTools(),
     toolContext,
@@ -93,7 +96,6 @@ export const createWritingEngine = (
     preAuthorizedToolNames: options.preAuthorizedToolNames,
     pending: options.pending,
     onEvent: options.onEvent,
-    models: options.models,
   });
 };
 
@@ -110,14 +112,16 @@ export interface CreateWritingMaintenanceEngineOptions extends AgentMaintenanceC
  */
 export const createWritingMaintenanceEngine = (
   options: CreateWritingMaintenanceEngineOptions
-): Promise<AgentMaintenanceEngineHandle> =>
-  createPiMaintenanceEngine({
+): Promise<AgentMaintenanceEngineHandle> => {
+  const models = options.models ?? createAgentModels();
+  return createPiMaintenanceEngine({
     agentSessionId: options.agentSessionId,
     session: options.session,
     settings: options.settings,
-    model: resolveWritingModel(options.settings.modelId, options.models),
-    models: options.models,
+    model: resolveWritingModel(options.settings, models),
+    models,
   });
+};
 
 export const writingAgentDefinition = {
   kind: WRITING_AGENT_KIND,

--- a/packages/api/orpc/agent-runtime.ts
+++ b/packages/api/orpc/agent-runtime.ts
@@ -52,6 +52,7 @@ export interface AgentRuntime {
     input: {
       title?: string;
       targetFeedId?: number;
+      providerId?: string;
       modelId?: string;
       thinkingLevel?: string;
       autoApprove?: string[];
@@ -74,6 +75,7 @@ export interface AgentRuntime {
     input: {
       sessionId: string;
       title?: string;
+      providerId?: string;
       modelId?: string;
       thinkingLevel?: string;
       activeToolNames?: string[] | null;
@@ -153,7 +155,11 @@ export interface AgentRuntime {
     input: { sessionId: string }
   ): Promise<agentContracts.AgentDraftPayload | null>;
 
-  listModels(): Promise<
+  /**
+   * Takes the caller because `requiresApiKey` depends on which provider keys *they* have
+   * registered. The catalogue itself is caller-independent.
+   */
+  listModels(caller: AgentRuntimeCaller): Promise<
     {
       providerId: string;
       modelId: string;
@@ -161,6 +167,7 @@ export interface AgentRuntime {
       contextWindow: number;
       supportsReasoning: boolean;
       supportsImageInput: boolean;
+      requiresApiKey: boolean;
     }[]
   >;
 

--- a/packages/api/orpc/agent-runtime.ts
+++ b/packages/api/orpc/agent-runtime.ts
@@ -38,6 +38,17 @@ export interface AgentStreamCursor {
   startIndex: number;
 }
 
+/**
+ * Model identity, mirroring `agentModelRefSchema`.
+ *
+ * Restated structurally rather than imported from `@chia/agent-core` so this package keeps no
+ * dependency on a provider SDK — the port is a contract, not an implementation.
+ */
+export interface AgentModelRef {
+  providerId: string;
+  modelId: string;
+}
+
 export interface AgentRuntime {
   listSessions(
     caller: AgentRuntimeCaller,
@@ -52,8 +63,7 @@ export interface AgentRuntime {
     input: {
       title?: string;
       targetFeedId?: number;
-      providerId?: string;
-      modelId?: string;
+      model?: AgentModelRef;
       thinkingLevel?: string;
       autoApprove?: string[];
       runtimeConfig?: Record<string, unknown>;
@@ -75,8 +85,7 @@ export interface AgentRuntime {
     input: {
       sessionId: string;
       title?: string;
-      providerId?: string;
-      modelId?: string;
+      model?: AgentModelRef;
       thinkingLevel?: string;
       activeToolNames?: string[] | null;
       autoApprove?: string[];
@@ -154,6 +163,16 @@ export interface AgentRuntime {
     caller: AgentRuntimeCaller,
     input: { sessionId: string }
   ): Promise<agentContracts.AgentDraftPayload | null>;
+
+  /**
+   * Checks a model selection before anything persists it.
+   *
+   * Returns a human-readable reason when the pair is unusable, or `null` when it is fine. A return
+   * value rather than a thrown error, because the caller is a middleware that has to turn this into
+   * a `BAD_REQUEST` — and because which models a kind admits is the kind's own policy, so the
+   * *reason* has to come from here rather than be reconstructed at the transport.
+   */
+  validateModel(ref: AgentModelRef): Promise<string | null>;
 
   /**
    * Takes the caller because `requiresApiKey` depends on which provider keys *they* have

--- a/packages/api/orpc/contracts/agent.contract.ts
+++ b/packages/api/orpc/contracts/agent.contract.ts
@@ -136,6 +136,13 @@ export const createAgentSessionContract = oc
       title: z.string().max(200).optional(),
       /** Seeds the draft buffer from this post so the agent edits rather than starts fresh. */
       targetFeedId: z.number().int().optional(),
+      /**
+       * Model identity is the `(providerId, modelId)` pair — the same model carries different ids
+       * under different providers. Omitting `providerId` while setting `modelId` is rejected by the
+       * runtime rather than defaulted, because guessing the provider would silently pick whose
+       * account pays.
+       */
+      providerId: z.string().optional(),
       modelId: z.string().optional(),
       thinkingLevel: thinkingLevelSchema.optional(),
       autoApprove: z.array(toolTierSchema).optional(),
@@ -174,6 +181,8 @@ export const updateAgentSessionSettingsContract = oc
       kind: z.string().optional(),
       sessionId: z.string(),
       title: z.string().max(200).optional(),
+      /** See `createAgentSessionContract`: the pair is the identity. */
+      providerId: z.string().optional(),
       modelId: z.string().optional(),
       thinkingLevel: thinkingLevelSchema.optional(),
       activeToolNames: z.array(z.string()).nullable().optional(),
@@ -413,6 +422,12 @@ export const listAgentModelsContract = oc
         contextWindow: z.number(),
         supportsReasoning: z.boolean(),
         supportsImageInput: z.boolean(),
+        /**
+         * True when the provider runs on a caller-supplied key the caller has not registered yet.
+         * Such models are still listed — the picker offers them and prompts for a key, rather than
+         * hiding an option the operator could have had.
+         */
+        requiresApiKey: z.boolean(),
       })
     )
   );

--- a/packages/api/orpc/contracts/agent.contract.ts
+++ b/packages/api/orpc/contracts/agent.contract.ts
@@ -36,6 +36,20 @@ const thinkingLevelSchema = z.enum([
  */
 const toolTierSchema = z.string();
 
+/**
+ * Model identity: the `(providerId, modelId)` pair, always together.
+ *
+ * One nested object rather than two sibling optionals, so "a model id with no provider" is not a
+ * state a caller can express. The same model carries different ids under different providers
+ * (`anthropic/claude-haiku-4.5` through a gateway is `claude-haiku-4-5` natively), and inferring the
+ * missing half would silently decide whose account pays. Whether the pair actually *exists* is
+ * per-kind policy, checked by the runtime — see `agentSessionGuard`.
+ */
+export const agentModelRefSchema = z.object({
+  providerId: z.string().min(1),
+  modelId: z.string().min(1),
+});
+
 export const agentSessionSummarySchema = z.object({
   id: z.string(),
   title: z.string().nullable(),
@@ -136,14 +150,7 @@ export const createAgentSessionContract = oc
       title: z.string().max(200).optional(),
       /** Seeds the draft buffer from this post so the agent edits rather than starts fresh. */
       targetFeedId: z.number().int().optional(),
-      /**
-       * Model identity is the `(providerId, modelId)` pair — the same model carries different ids
-       * under different providers. Omitting `providerId` while setting `modelId` is rejected by the
-       * runtime rather than defaulted, because guessing the provider would silently pick whose
-       * account pays.
-       */
-      providerId: z.string().optional(),
-      modelId: z.string().optional(),
+      model: agentModelRefSchema.optional(),
       thinkingLevel: thinkingLevelSchema.optional(),
       autoApprove: z.array(toolTierSchema).optional(),
       runtimeConfig: z.record(z.string(), z.unknown()).optional(),
@@ -181,9 +188,7 @@ export const updateAgentSessionSettingsContract = oc
       kind: z.string().optional(),
       sessionId: z.string(),
       title: z.string().max(200).optional(),
-      /** See `createAgentSessionContract`: the pair is the identity. */
-      providerId: z.string().optional(),
-      modelId: z.string().optional(),
+      model: agentModelRefSchema.optional(),
       thinkingLevel: thinkingLevelSchema.optional(),
       activeToolNames: z.array(z.string()).nullable().optional(),
       autoApprove: z.array(toolTierSchema).optional(),

--- a/packages/api/orpc/guards/agent-session.guard.ts
+++ b/packages/api/orpc/guards/agent-session.guard.ts
@@ -1,0 +1,114 @@
+import { os } from "@orpc/server";
+
+import type { Session } from "@chia/auth/types";
+import type { DB } from "@chia/db";
+import { getAgentSession } from "@chia/db/repos/agent";
+
+import { getAgentRuntime } from "../agent-runtime";
+import type {
+  AgentModelRef,
+  AgentRuntime,
+  AgentRuntimeCaller,
+} from "../agent-runtime";
+import type { BaseOSContext } from "../utils";
+
+/**
+ * Resolves a session-scoped agent request once, for every route that needs it.
+ *
+ * Every session route used to repeat the same four steps inline — load the row, check it is not
+ * deleted, check the caller owns it, then look up the runtime for its `kind`. Twelve copies of an
+ * authorization check is twelve chances for one of them to drift, and the drift would be silent:
+ * a missing ownership check reads exactly like a working route.
+ *
+ * The kind comes from the **stored session**, never from the request, so a client cannot drive a
+ * session through another kind's tools by supplying a different registry key. An explicit `kind` in
+ * the input is only ever a cross-check.
+ *
+ * Runs after `adminGuard()`, whose context it consumes.
+ */
+
+type AdminContext = BaseOSContext & {
+  adminId: string;
+  session: Session;
+};
+
+/** What the guard hands downstream. */
+export interface AgentSessionContext {
+  agent: {
+    caller: AgentRuntimeCaller;
+    runtime: AgentRuntime;
+    kind: string;
+  };
+}
+
+const agentOS = os.$context<AdminContext>();
+
+/**
+ * The subset of a route's input this guard reads.
+ *
+ * Declared narrowly on purpose: oRPC checks the middleware's parameter against each procedure's
+ * input, so anything wider would refuse to compose with routes that do not carry it.
+ */
+interface AgentSessionInput {
+  sessionId: string;
+  kind?: string;
+  model?: AgentModelRef;
+}
+
+export const agentSessionGuard = () =>
+  agentOS
+    .errors({ NOT_FOUND: {}, BAD_REQUEST: {} })
+    .middleware(async ({ context, errors, next }, input: AgentSessionInput) => {
+      const caller: AgentRuntimeCaller = {
+        adminId: context.adminId,
+        userId: context.session.user.id,
+        context,
+      };
+
+      const row = await getAgentSession(context.db as DB, input.sessionId);
+      /**
+       * One `NOT_FOUND` for "absent", "deleted" and "someone else's".
+       *
+       * Distinguishing them would let a caller probe which session ids exist, and there is nothing
+       * the legitimate operator can do differently in any of the three cases anyway.
+       */
+      if (!row || row.deletedAt !== null || row.userId !== caller.userId) {
+        throw errors.NOT_FOUND();
+      }
+      if (input.kind && input.kind !== row.kind) {
+        throw errors.NOT_FOUND();
+      }
+
+      const runtime = getAgentRuntime(row.kind);
+
+      if (input.model) {
+        const reason = await runtime.validateModel(input.model);
+        if (reason) throw errors.BAD_REQUEST({ message: reason });
+      }
+
+      return next({
+        context: { agent: { caller, runtime, kind: row.kind } },
+      });
+    });
+
+/**
+ * Model validation for routes with **no** session to resolve — creation, where the kind arrives in
+ * the input because there is nothing stored to read it from.
+ */
+export const agentModelGuard = () =>
+  agentOS
+    .errors({ BAD_REQUEST: {} })
+    .middleware(
+      async (
+        { errors, next },
+        input: { kind: string; model?: AgentModelRef }
+      ) => {
+        if (input.model) {
+          const reason = await getAgentRuntime(input.kind).validateModel(
+            input.model
+          );
+          if (reason) throw errors.BAD_REQUEST({ message: reason });
+        }
+        return next();
+      }
+    );

--- a/packages/api/orpc/routes/agent.route.ts
+++ b/packages/api/orpc/routes/agent.route.ts
@@ -279,7 +279,9 @@ export const getAgentDraftRoute = contractOS.agent.sessions.draft
 
 export const listAgentModelsRoute = contractOS.agent.models.list
   .use(adminGuard())
-  .handler(async (opts) => getAgentRuntime(opts.input.kind).listModels());
+  .handler(async (opts) =>
+    getAgentRuntime(opts.input.kind).listModels(callerOf(opts))
+  );
 
 export const listAgentCapabilitiesRoute = contractOS.agent.capabilities.list
   .use(adminGuard())

--- a/packages/api/orpc/routes/agent.route.ts
+++ b/packages/api/orpc/routes/agent.route.ts
@@ -1,10 +1,12 @@
 import { toTanStackAgentEventStream } from "@chia/agent-runtime/transports/tanstack-ai";
-import type { DB } from "@chia/db";
-import { getAgentSession } from "@chia/db/repos/agent";
 
 import { getAgentRuntime, registeredAgentKinds } from "../agent-runtime";
 import type { AgentRuntimeCaller } from "../agent-runtime";
 import { adminGuard } from "../guards/admin.guard";
+import {
+  agentModelGuard,
+  agentSessionGuard,
+} from "../guards/agent-session.guard";
 import { contractOS } from "../utils";
 
 /**
@@ -17,6 +19,10 @@ import { contractOS } from "../utils";
  * `adminGuard()` pins to the configured admin id, so a logged-in non-admin cannot reach these even
  * with a valid session. That matters more here than on the read routes: these tools can write to
  * and publish the blog.
+ *
+ * `agentSessionGuard()` then owns session resolution and ownership for every session-scoped route,
+ * so the handlers below are left with only their own work — see the guard for why that is not
+ * merely tidier.
  */
 
 const callerOf = (opts: {
@@ -26,18 +32,6 @@ const callerOf = (opts: {
   userId: opts.context.session.user.id,
   context: opts.context as unknown as AgentRuntimeCaller["context"],
 });
-
-const sessionRuntimeOf = async (
-  caller: AgentRuntimeCaller,
-  sessionId: string,
-  requestedKind?: string
-) => {
-  const row = await getAgentSession(caller.context.db as DB, sessionId);
-  if (!row || row.deletedAt !== null || row.userId !== caller.userId)
-    return null;
-  if (requestedKind && requestedKind !== row.kind) return null;
-  return getAgentRuntime(row.kind);
-};
 
 // ============================================
 // Sessions
@@ -63,36 +57,30 @@ export const listAgentSessionsRoute = contractOS.agent.sessions.list
     };
   });
 
+/** The one session route with no session to resolve, so it validates the model on its own. */
 export const createAgentSessionRoute = contractOS.agent.sessions.create
   .use(adminGuard())
+  .use(agentModelGuard())
   .handler(async (opts) =>
     getAgentRuntime(opts.input.kind).createSession(callerOf(opts), opts.input)
   );
 
 export const getAgentSessionRoute = contractOS.agent.sessions.get
   .use(adminGuard())
+  .use(agentSessionGuard())
   .handler(async (opts) => {
-    const caller = callerOf(opts);
-    const runtime = await sessionRuntimeOf(
-      caller,
-      opts.input.sessionId,
-      opts.input.kind
-    );
-    const detail = await runtime?.getSession(caller, opts.input);
+    const { caller, runtime } = opts.context.agent;
+    const detail = await runtime.getSession(caller, opts.input);
     if (!detail) throw opts.errors.NOT_FOUND();
     return detail;
   });
 
 export const deleteAgentSessionRoute = contractOS.agent.sessions.delete
   .use(adminGuard())
+  .use(agentSessionGuard())
   .handler(async (opts) => {
-    const caller = callerOf(opts);
-    const runtime = await sessionRuntimeOf(
-      caller,
-      opts.input.sessionId,
-      opts.input.kind
-    );
-    const deleted = await runtime?.deleteSession(caller, opts.input);
+    const { caller, runtime } = opts.context.agent;
+    const deleted = await runtime.deleteSession(caller, opts.input);
     if (!deleted) throw opts.errors.NOT_FOUND();
     return { sessionId: opts.input.sessionId };
   });
@@ -101,14 +89,10 @@ export const updateAgentSessionSettingsRoute = contractOS.agent.sessions[
   "settings:update"
 ]
   .use(adminGuard())
+  .use(agentSessionGuard())
   .handler(async (opts) => {
-    const caller = callerOf(opts);
-    const runtime = await sessionRuntimeOf(
-      caller,
-      opts.input.sessionId,
-      opts.input.kind
-    );
-    const detail = await runtime?.updateSettings(caller, opts.input);
+    const { caller, runtime } = opts.context.agent;
+    const detail = await runtime.updateSettings(caller, opts.input);
     if (!detail) throw opts.errors.NOT_FOUND();
     return detail;
   });
@@ -123,40 +107,25 @@ export const updateAgentSessionSettingsRoute = contractOS.agent.sessions[
  */
 export const promptAgentRoute = contractOS.agent.sessions.prompt
   .use(adminGuard())
+  .use(agentSessionGuard())
   .handler(async (opts) => {
-    const caller = callerOf(opts);
-    const runtime = await sessionRuntimeOf(
-      caller,
-      opts.input.sessionId,
-      opts.input.kind
-    );
-    if (!runtime) throw opts.errors.NOT_FOUND();
+    const { caller, runtime } = opts.context.agent;
     return await runtime.prompt(caller, opts.input);
   });
 
 export const streamAgentRoute = contractOS.agent.sessions.stream
   .use(adminGuard())
+  .use(agentSessionGuard())
   .handler(async (opts) => {
-    const caller = callerOf(opts);
-    const runtime = await sessionRuntimeOf(
-      caller,
-      opts.input.sessionId,
-      opts.input.kind
-    );
-    if (!runtime) throw opts.errors.NOT_FOUND();
+    const { caller, runtime } = opts.context.agent;
     return runtime.stream(caller, opts.input);
   });
 
 export const chatAgentRoute = contractOS.agent.sessions.chat
   .use(adminGuard())
+  .use(agentSessionGuard())
   .handler(async (opts) => {
-    const caller = callerOf(opts);
-    const runtime = await sessionRuntimeOf(
-      caller,
-      opts.input.sessionId,
-      opts.input.kind
-    );
-    if (!runtime) throw opts.errors.NOT_FOUND();
+    const { caller, runtime } = opts.context.agent;
 
     const cursor =
       opts.input.action.type === "prompt"
@@ -186,40 +155,26 @@ export const chatAgentRoute = contractOS.agent.sessions.chat
 
 export const abortAgentRoute = contractOS.agent.sessions.abort
   .use(adminGuard())
+  .use(agentSessionGuard())
   .handler(async (opts) => {
-    const caller = callerOf(opts);
-    const runtime = await sessionRuntimeOf(
-      caller,
-      opts.input.sessionId,
-      opts.input.kind
-    );
-    if (!runtime) throw opts.errors.NOT_FOUND();
+    const { caller, runtime } = opts.context.agent;
     return { aborted: await runtime.abort(caller, opts.input) };
   });
 
 export const steerAgentRoute = contractOS.agent.sessions.steer
   .use(adminGuard())
+  .use(agentSessionGuard())
   .handler(async (opts) => {
-    const caller = callerOf(opts);
-    const runtime = await sessionRuntimeOf(
-      caller,
-      opts.input.sessionId,
-      opts.input.kind
-    );
-    if (!runtime) throw opts.errors.NOT_FOUND();
+    const { caller, runtime } = opts.context.agent;
     return { queued: await runtime.steer(caller, opts.input) };
   });
 
 export const approveAgentToolRoute = contractOS.agent.sessions.approve
   .use(adminGuard())
+  .use(agentSessionGuard())
   .handler(async (opts) => {
-    const caller = callerOf(opts);
-    const runtime = await sessionRuntimeOf(
-      caller,
-      opts.input.sessionId,
-      opts.input.kind
-    );
-    const cursor = await runtime?.approve(caller, opts.input);
+    const { caller, runtime } = opts.context.agent;
+    const cursor = await runtime.approve(caller, opts.input);
     if (!cursor) throw opts.errors.NOT_FOUND();
     return {
       toolCallId: opts.input.toolCallId,
@@ -233,42 +188,30 @@ export const approveAgentToolRoute = contractOS.agent.sessions.approve
 
 export const compactAgentSessionRoute = contractOS.agent.sessions.compact
   .use(adminGuard())
+  .use(agentSessionGuard())
   .handler(async (opts) => {
-    const caller = callerOf(opts);
-    const runtime = await sessionRuntimeOf(
-      caller,
-      opts.input.sessionId,
-      opts.input.kind
-    );
-    const result = await runtime?.compact(caller, opts.input);
+    const { caller, runtime } = opts.context.agent;
+    const result = await runtime.compact(caller, opts.input);
     if (!result) throw opts.errors.NOT_FOUND();
     return result;
   });
 
 export const navigateAgentSessionRoute = contractOS.agent.sessions.navigate
   .use(adminGuard())
+  .use(agentSessionGuard())
   .handler(async (opts) => {
-    const caller = callerOf(opts);
-    const runtime = await sessionRuntimeOf(
-      caller,
-      opts.input.sessionId,
-      opts.input.kind
-    );
-    const result = await runtime?.navigate(caller, opts.input);
+    const { caller, runtime } = opts.context.agent;
+    const result = await runtime.navigate(caller, opts.input);
     if (!result) throw opts.errors.NOT_FOUND();
     return result;
   });
 
 export const getAgentDraftRoute = contractOS.agent.sessions.draft
   .use(adminGuard())
+  .use(agentSessionGuard())
   .handler(async (opts) => {
-    const caller = callerOf(opts);
-    const runtime = await sessionRuntimeOf(
-      caller,
-      opts.input.sessionId,
-      opts.input.kind
-    );
-    const draft = await runtime?.getDraft?.(caller, opts.input);
+    const { caller, runtime } = opts.context.agent;
+    const draft = await runtime.getDraft?.(caller, opts.input);
     if (!draft) throw opts.errors.NOT_FOUND();
     return draft;
   });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a provider-organized model picker for agent sessions.
  * Added support for selecting OpenAI and Anthropic provider/model combinations.
  * Models requiring API keys are identified and unavailable until credentials are configured.
  * Added secure use of user-provided API keys during agent requests.
* **Bug Fixes**
  * Improved validation for invalid, incomplete, or unavailable model selections.
  * Added clearer credential error reporting.
  * Preserved updated credentials across ongoing conversations and approval steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->