### PR TITLE
perf(service): defer heavy dependencies out of the boot path

### DIFF
--- a/apps/service/src/routes/ai.route.ts
+++ b/apps/service/src/routes/ai.route.ts
@@ -1,4 +1,3 @@
-import { gateway } from "@ai-sdk/gateway";
 import { zValidator } from "@hono/zod-validator";
 import { streamText, createTextStreamResponse } from "ai";
 import { Hono } from "hono";
@@ -28,7 +27,6 @@ import {
 import { SupportedTools } from "@chia/ai/types";
 import { baseRequestSchema } from "@chia/ai/types";
 import { Provider } from "@chia/ai/types";
-import { createModel } from "@chia/ai/utils";
 import { encodeApiKey } from "@chia/ai/utils";
 import { getCookieDomain } from "@chia/auth/utils";
 import { errorGenerator } from "@chia/utils/server";
@@ -38,6 +36,19 @@ import { ai, AI_AUTH_TOKEN } from "../guards/ai.guard";
 import { verifyAuth } from "../guards/auth.guard";
 import { rateLimiterGuard } from "../guards/rate-limiter.guard";
 import { errorResponse } from "../utils/error.util";
+
+/**
+ * The provider SDKs and the gateway client are reached through these rather than imported:
+ * `server.ts` mounts every route into one Hono app, so a static import here loads all three
+ * provider SDKs at boot for a process that may only ever serve content routes.
+ *
+ * `ai` itself stays a static import — `baseRequestSchema` needs `modelMessageSchema` to build
+ * the `/generate` validator, which is evaluated when the route is defined.
+ */
+const getCreateModel = async () =>
+  (await import("@chia/ai/utils/model")).createModel;
+
+const getGateway = async () => (await import("@ai-sdk/gateway")).gateway;
 
 const cookieName = (provider?: Provider) => {
   switch (provider) {
@@ -105,8 +116,9 @@ const api = new Hono<HonoContext>()
       }
     ),
     ai(),
-    (c) => {
+    async (c) => {
       const { model, messages, system } = c.req.valid("json");
+      const createModel = await getCreateModel();
       const result = streamText({
         model: createModel({
           model,
@@ -124,7 +136,7 @@ const api = new Hono<HonoContext>()
     }
   )
   .get("/models", async (c) => {
-    const availableModels = await gateway.getAvailableModels();
+    const availableModels = await (await getGateway()).getAvailableModels();
     return c.json(availableModels.models);
   })
   .post(

--- a/apps/service/src/services/agent.service.ts
+++ b/apps/service/src/services/agent.service.ts
@@ -1,790 +1,84 @@
-import { getHookByToken, getRun, start } from "workflow/api";
-
-import {
-  BYOK_PROVIDER_IDS,
-  createAgentModels,
-  entriesToWireEvents,
-  PgSessionRepo,
-  UnknownAgentModelError,
-  writeSessionSettings,
-} from "@chia/agent-runtime";
-import type {
-  AgentSessionSettings,
-  AgentWireEvent,
-  ThinkingLevel,
-  ToolTier,
-} from "@chia/agent-runtime";
-import {
-  compactWritingSession,
-  createWritingTools,
-  assertWritingModel,
-  listWritingModels,
-  navigateWritingSession,
-  PgDraftStore,
-  WRITING_AGENT_KIND,
-  WRITING_SESSION_DEFAULTS,
-  writingPolicy,
-  writingPromptTemplates,
-  writingSkills,
-} from "@chia/agent-writing";
 import { registerAgentKindService } from "@chia/api/orpc/agent-service";
-import type {
-  AgentKindService,
-  AgentServiceCaller,
-} from "@chia/api/orpc/agent-service";
-import type { DB } from "@chia/db";
-import {
-  completeAgentRun,
-  createAgentRun,
-  createWritingAgentSession,
-  decideAgentApproval,
-  deleteAgentSession,
-  getActiveAgentRun,
-  getAgentApprovals,
-  getAgentSession,
-  getWritingAgentSession,
-  softDeleteAgentSession,
-} from "@chia/db/repos/agent";
-
-import { AGENT_DELTA_NAMESPACE } from "../steps/agent-turn.step";
-import { agentSessionWorkflow } from "../workflows/agent-session.workflow";
-import {
-  AGENT_END_SENTINEL,
-  agentApprovalHook,
-  agentApprovalToken,
-  agentMessageHook,
-  agentMessageToken,
-} from "../workflows/hooks/agent.hooks";
-
-import { createAgentContentPort } from "./agent-content.port";
-import {
-  decryptAgentCredentials,
-  readEncryptedAgentCredentials,
-} from "./agent-credentials";
+import type { AgentKindService } from "@chia/api/orpc/agent-service";
 
 /**
- * The **writing** agent service, registered under `agent_session.kind = "writing"`.
+ * Registration for the writing agent kind, split from its implementation.
  *
- * Pi execution, session persistence, approval and wire primitives are `@chia/agent-runtime`;
- * the writing domain is `@chia/agent-writing`. This module is the
- * transport-facing glue between them and the durable workflow run. A second agent kind is a
- * sibling of this file plus its own domain package.
+ * `rpc.route.ts` imports this module at boot so the kind is registered before the first request.
+ * The implementation reaches `@chia/agent-runtime` and `@chia/agent-writing`, which carry the whole
+ * provider stack — importing it here would put that stack in the eager module graph of a process
+ * whose other routes never touch an agent. The delegate below defers it to the first agent call.
  *
- * **Stateless.** There is no in-process registry: each session is driven by a durable workflow run,
- * and every piece of state lives somewhere durable —
- *
- * - transcript → `agent_session_entry` (queried directly by the dashboard, and the source pi
- *   rebuilds context from)
- * - draft buffer → `writing_agent_session` + `writing_agent_draft`
- * - approval decisions → `agent_tool_approval`
- * - turn execution metadata → `agent_run`; pauses and event stream → the workflow backend
- *
- * That split is why a deploy mid-turn is survivable and why an approval can be granted a day later.
- * It is also why this module can be replicated across instances without a coordination layer.
+ * The registry key is the literal rather than `WRITING_AGENT_KIND` for the same reason: importing
+ * that constant pulls the domain package. It is matched against `agent_session.kind`, a database
+ * string, and `writingAgentService` asserts the constant once its module is loaded.
  */
+const impl = async (): Promise<AgentKindService> =>
+  (await import("./writing-agent.service")).writingAgentService;
 
-// ============================================
-// Helpers
-// ============================================
-
-const repoFor = (db: DB) =>
-  new PgSessionRepo(db, {
-    kind: WRITING_AGENT_KIND,
-    defaults: WRITING_SESSION_DEFAULTS,
-  });
-
-const dependenciesFor = (caller: AgentServiceCaller) => {
-  const db = caller.context.db as DB;
-  return {
-    db,
-    repo: repoFor(db),
-    draft: new PgDraftStore(db),
-    content: createAgentContentPort({
-      db,
-      kv: caller.context.kv,
-      adminId: caller.adminId,
-    }),
-  };
-};
-
-/**
- * Loads a session **scoped to the caller**.
- *
- * The session id arrives from client input, so ownership is re-checked here rather than trusted —
- * `adminGuard` proves who is calling, not what they may open.
- */
-const loadOwnedSession = async (
-  caller: AgentServiceCaller,
-  sessionId: string
-) => {
-  const db = caller.context.db as DB;
-  const row = await getAgentSession(db, sessionId);
-  if (!row || row.deletedAt !== null) return null;
-  if (row.userId !== caller.userId) return null;
-  if (row.kind !== WRITING_AGENT_KIND) return null;
-
-  const [writingState, activeRun] = await Promise.all([
-    getWritingAgentSession(db, sessionId),
-    getActiveAgentRun(db, sessionId),
-  ]);
-  if (!writingState) return null;
-
-  return {
-    ...row,
-    targetFeedId: writingState.targetFeedId,
-    feedMeta: writingState.feedMeta,
-    activeRunId: activeRun?.id ?? null,
-    workflowRunId: activeRun?.externalRunId ?? null,
-  };
-};
-
-const settingsOf = (row: {
-  id: string;
-  providerId: string | null;
-  modelId: string | null;
-  thinkingLevel: string | null;
-  activeToolNames: string[] | null;
-  autoApprove: string[];
-}): AgentSessionSettings => {
-  if (!row.providerId || !row.modelId || !row.thinkingLevel) {
-    throw new Error(`Writing session ${row.id} has incomplete LLM settings.`);
-  }
-  return {
-    providerId: row.providerId,
-    modelId: row.modelId,
-    thinkingLevel: row.thinkingLevel as ThinkingLevel,
-    activeToolNames: row.activeToolNames,
-    autoApprove: row.autoApprove as ToolTier[],
-  };
-};
-
-const summaryOf = (row: {
-  id: string;
-  title: string | null;
-  kind: string;
-  providerId: string | null;
-  modelId: string | null;
-  thinkingLevel: string | null;
-  activeToolNames: string[] | null;
-  autoApprove: string[];
-  targetFeedId: number | null;
-  createdAt: Date;
-  updatedAt: Date;
-}) => {
-  const settings = settingsOf(row);
-  return {
-    id: row.id,
-    title: row.title,
-    kind: row.kind,
-    modelId: settings.modelId,
-    thinkingLevel: settings.thinkingLevel,
-    targetFeedId: row.targetFeedId,
-    createdAt: row.createdAt.getTime(),
-    updatedAt: row.updatedAt.getTime(),
-  };
-};
-
-/**
- * Loads the Pi session inputs used by explicit maintenance operations.
- *
- * These operations only walk the session tree, so the concrete Pi operations receive no tools,
- * skills, approval gate or event subscriptions. The draft store and content port are skipped for
- * the same reason, which is why this reaches for `repoFor` rather than the full `dependenciesFor`.
- */
-const writingSessionOperationOptions = async (
-  caller: AgentServiceCaller,
-  sessionId: string,
-  row: Parameters<typeof settingsOf>[0]
-) => {
-  const session = await repoFor(caller.context.db as DB).openById(sessionId);
-  return {
-    session,
-    settings: settingsOf(row),
-    /**
-     * Compaction calls the model too, so a BYOK session needs its key here just as much as in a
-     * turn. This path runs inside the request, so the cookie is read and decrypted directly rather
-     * than travelling through the workflow.
-     */
-    models: modelsFor(caller),
-  };
-};
-
-/** Per-request `Models`, carrying whatever provider keys the caller has registered. */
-const modelsFor = (caller: AgentServiceCaller) =>
-  createAgentModels(
-    decryptAgentCredentials(
-      readEncryptedAgentCredentials(caller.context.headers)
-    )
-  );
-
-const replayOptions = {
-  tierOf: writingPolicy.tierOf,
-  labelOf: writingPolicy.labelOf,
-  summarize: writingPolicy.summarize,
-};
-
-/**
- * A promise that never settles, used to drop an exhausted reader out of the two-stream race in
- * {@link writingAgentService.stream} without it winning again.
- */
-const NEVER = new Promise<never>(() => undefined);
-
-/** Run states in which the session's workflow run can still accept a message. */
-const isRunLive = async (runId: string): Promise<boolean> => {
-  try {
-    const run = getRun(runId);
-    if (!(await run.exists)) return false;
-    const status = await run.status;
-    return status === "pending" || status === "running";
-  } catch {
-    // A run from a previous deployment may no longer resolve; treat it as gone.
-    return false;
-  }
-};
-
-/**
- * Whether a hook token is registered and can be resumed.
- *
- * `createHook()` does not register on call. This workflow registers through `getConflict()` before
- * its first turn, but `start()` may return before the workflow reaches that line. Checking once
- * turns that startup race into a retryable answer instead of a failed `resume()`; it is not a
- * timer or polling loop.
- */
-const isHookReady = async (token: string): Promise<boolean> => {
-  try {
-    return Boolean(await getHookByToken(token));
-  } catch {
-    return false;
-  }
-};
-
-/**
- * Approvals still awaiting a decision.
- *
- * Used to refuse a new prompt while the run is parked on an approval hook. The message would
- * otherwise sit in the event log unread until the approval resolved, which looks to the operator
- * like their message vanished.
- */
-const undecidedApprovals = async (
-  db: DB,
-  sessionId: string
-): Promise<string[]> => {
-  const approvals = await getAgentApprovals(db, sessionId);
-  return approvals
-    .filter((approval) => approval.decidedAt === null)
-    .map((approval) => approval.toolName);
-};
-
-const detailFor = async (caller: AgentServiceCaller, sessionId: string) => {
-  const row = await loadOwnedSession(caller, sessionId);
-  if (!row) return null;
-
-  const { db, repo, draft } = dependenciesFor(caller);
-  const session = await repo.openById(sessionId);
-
-  const [branch, draftState, stats, approvals] = await Promise.all([
-    session.getBranch(),
-    draft.get(sessionId),
-    session.getSessionStats(),
-    getAgentApprovals(db, sessionId),
-  ]);
-
-  // Older rows written before PgSessionStorage advanced `leafEntryId` have persisted entries but
-  // an empty active branch. Replay those entries in insertion order so existing development
-  // sessions remain visible after a refresh. Correctly linked sessions always use their branch.
-  let transcriptEntries = branch;
-  if (
-    branch.length === 0 &&
-    row.leafEntryId === null &&
-    stats.messageCount > 0
-  ) {
-    const storedEntries = await session.getStorage().getEntries();
-    if (storedEntries.every((entry) => entry.parentId === null)) {
-      transcriptEntries = storedEntries;
-    }
-  }
-  const events = entriesToWireEvents(transcriptEntries, replayOptions);
-
-  // Surface approvals still waiting on a decision, so a reload restores the prompt.
-  const pendingApprovals = approvals
-    .filter((approval) => approval.status === "pending")
-    .map((approval) => ({
-      toolCallId: approval.toolCallId,
-      toolName: approval.toolName,
-      args: approval.args ?? undefined,
-    }));
-
-  return {
-    session: summaryOf(row),
-    settings: settingsOf(row),
-    runtimeConfig: row.runtimeConfig,
-    configVersion: row.configVersion,
-    draft: draftState as never,
-    events,
-    pendingApprovals,
-    stats: {
-      messageCount: stats.messageCount,
-      totalTokens: stats.totalTokens,
-      costTotal: stats.costTotal,
-    },
-  };
-};
-
-// ============================================
-// Service
-// ============================================
-
-export const writingAgentService: AgentKindService = {
+const writingAgentServiceDelegate: AgentKindService = {
   async listSessions(caller, input) {
-    const { db, repo } = dependenciesFor(caller);
-    const metadata = await repo.list({
-      userId: caller.userId,
-      limit: input?.limit,
-      includeDeleted: input?.includeDeleted,
-    });
-
-    const rows = await Promise.all(
-      metadata.map(async (entry) => {
-        const [row, writingState] = await Promise.all([
-          getAgentSession(db, entry.id),
-          getWritingAgentSession(db, entry.id),
-        ]);
-        return row && writingState
-          ? { ...row, targetFeedId: writingState.targetFeedId }
-          : null;
-      })
-    );
-
-    return {
-      items: rows.flatMap((row) => (row ? [summaryOf(row)] : [])),
-      // Sessions are listed newest-first with a hard limit; there is no cursor to page yet.
-      nextCursor: null,
-    };
+    return await (await impl()).listSessions(caller, input);
   },
 
   async createSession(caller, input) {
-    const { repo, draft, content } = dependenciesFor(caller);
-
-    const session = await repo.create({
-      userId: caller.userId,
-      title: input.title,
-      settings: {
-        providerId: input.model?.providerId,
-        modelId: input.model?.modelId,
-        thinkingLevel: input.thinkingLevel as ThinkingLevel | undefined,
-        autoApprove: input.autoApprove as ToolTier[] | undefined,
-      },
-      runtimeConfig: input.runtimeConfig,
-    });
-    const { id } = await session.getMetadata();
-    try {
-      await createWritingAgentSession(caller.context.db as DB, {
-        sessionId: id,
-        targetFeedId: input.targetFeedId,
-      });
-
-      // Opening a session against an existing post seeds the buffer, so the agent edits the real
-      // content instead of guessing at it.
-      if (input.targetFeedId !== undefined) {
-        const post = await content.getPost({ feedId: input.targetFeedId });
-        if (post) await draft.seedFromPost(id, post);
-      }
-
-      const detail = await detailFor(caller, id);
-      if (!detail)
-        throw new Error("Session vanished immediately after creation");
-      return detail;
-    } catch (error) {
-      // Core and writing state live in separate repositories. Compensate if extension setup or
-      // draft seeding fails so callers never receive an unusable half-created session.
-      await deleteAgentSession(caller.context.db as DB, id);
-      throw error;
-    }
+    return await (await impl()).createSession(caller, input);
   },
 
-  getSession(caller, input) {
-    return detailFor(caller, input.sessionId);
+  async getSession(caller, input) {
+    return await (await impl()).getSession(caller, input);
   },
 
   async deleteSession(caller, input) {
-    const row = await loadOwnedSession(caller, input.sessionId);
-    if (!row) return false;
-
-    // End the run before soft-deleting, so it is not left parked on a hook forever.
-    if (row.workflowRunId && (await isRunLive(row.workflowRunId))) {
-      await agentMessageHook.resume(agentMessageToken(input.sessionId), {
-        text: AGENT_END_SENTINEL,
-      });
-    }
-    if (row.activeRunId) {
-      await completeAgentRun(
-        caller.context.db as DB,
-        row.activeRunId,
-        "cancelled"
-      );
-    }
-
-    await softDeleteAgentSession(caller.context.db as DB, input.sessionId);
-    return true;
+    return await (await impl()).deleteSession(caller, input);
   },
 
   async updateSettings(caller, input) {
-    const row = await loadOwnedSession(caller, input.sessionId);
-    if (!row) return null;
-    await writeSessionSettings(caller.context.db as DB, input.sessionId, {
-      title: input.title,
-      providerId: input.model?.providerId,
-      modelId: input.model?.modelId,
-      thinkingLevel: input.thinkingLevel as ThinkingLevel | undefined,
-      activeToolNames: input.activeToolNames,
-      autoApprove: input.autoApprove as ToolTier[] | undefined,
-      runtimeConfig: input.runtimeConfig,
-    });
-
-    return detailFor(caller, input.sessionId);
+    return await (await impl()).updateSettings(caller, input);
   },
 
-  /**
-   * Enqueues a turn.
-   *
-   * If the session already has a live run, its reusable hook durably queues the message. The
-   * workflow consumes it after the current turn and any approval handshake finish. Otherwise a new
-   * run is started and its id recorded.
-   *
-   * Either way this returns as soon as the message is accepted; the turn itself runs in the run.
-   */
   async prompt(caller, input) {
-    const row = await loadOwnedSession(caller, input.sessionId);
-    if (!row) throw new Error(`Unknown agent session: ${input.sessionId}`);
-
-    if (input.text === AGENT_END_SENTINEL) {
-      throw new Error(
-        `"${AGENT_END_SENTINEL}" is reserved; it ends the session's run.`
-      );
-    }
-
-    const message = {
-      text: input.text,
-      template: input.template,
-      preAuthorizeToolNames: input.preAuthorizeToolNames,
-      // Refreshed on every prompt: the run outlives any one request, and the operator may have
-      // registered or rotated a key since the last turn.
-      credentials: readEncryptedAgentCredentials(caller.context.headers),
-    };
-
-    /**
-     * Refuse while an approval is outstanding.
-     *
-     * The run is parked on the *approval* hook, not the message hook. A resumed message would be
-     * persisted and then sit unread until the approval resolved — from the operator's side their
-     * message would simply appear to do nothing. Better to say why.
-     */
-    const outstanding = await undecidedApprovals(
-      caller.context.db as DB,
-      input.sessionId
-    );
-    if (outstanding.length > 0) {
-      throw new Error(
-        `Waiting on your decision for \`${outstanding.join("`, `")}\`. Approve or reject it before sending another message.`
-      );
-    }
-
-    if (row.workflowRunId && (await isRunLive(row.workflowRunId))) {
-      const token = agentMessageToken(input.sessionId);
-
-      if (!(await isHookReady(token))) {
-        throw new Error(
-          "The session's run is still starting up. Retry in a moment."
-        );
-      }
-
-      const run = getRun(row.workflowRunId);
-      // Capture the tail before enqueuing. If another turn is active, its remaining events and the
-      // queued turn share this continuation stream in durable emission order.
-      const startIndex = (await run.getReadable().getTailIndex()) + 1;
-      await agentMessageHook.resume(token, message);
-      return { runId: row.workflowRunId, startIndex, startedRun: false };
-    }
-
-    const run = await start(agentSessionWorkflow, [
-      {
-        sessionId: input.sessionId,
-        adminId: caller.adminId,
-        userId: caller.userId,
-        firstMessage: message,
-      },
-    ]);
-
-    await createAgentRun(caller.context.db as DB, {
-      id: run.runId,
-      sessionId: input.sessionId,
-      harnessKind: "workflow",
-      externalRunId: run.runId,
-      metadata: { agentKind: WRITING_AGENT_KIND },
-    });
-
-    return { runId: run.runId, startIndex: 0, startedRun: true };
+    return await (await impl()).prompt(caller, input);
   },
 
-  /**
-   * Tails a run's durable stream.
-   *
-   * The heavy lifting is the SDK's: `getReadable({ startIndex })` replays from the requested point
-   * and then delivers live chunks, which is what makes reconnection and multi-viewer work without
-   * any coordination on our side.
-   */
   async *stream(caller, input) {
-    const row = await loadOwnedSession(caller, input.sessionId);
-    if (!row) throw new Error(`Unknown agent session: ${input.sessionId}`);
-
-    const runId = input.runId ?? row.workflowRunId;
-    if (!runId) return;
-
-    const readable = getRun(runId).getReadable<AgentWireEvent>({
-      startIndex: input.startIndex,
-    });
-    const reader = readable.getReader();
-
-    // Deltas live on their own namespace and arrive batched; merging them here keeps the client's
-    // reducer identical whether or not it asked for them.
-    const deltaReader = input.deltas
-      ? getRun(runId)
-          .getReadable<AgentWireEvent[]>({
-            namespace: AGENT_DELTA_NAMESPACE,
-            startIndex: 0,
-          })
-          .getReader()
-      : undefined;
-
-    try {
-      if (!deltaReader) {
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
-          if (value) yield value;
-        }
-        return;
-      }
-
-      /**
-       * Two streams, drained as whichever has data next.
-       *
-       * Racing the two reads (rather than draining one then the other) is what keeps deltas
-       * interleaved with the coarse events they belong to.
-       */
-      let coarsePending = reader.read();
-      let deltaPending = deltaReader.read();
-      let coarseDone = false;
-      let deltaDone = false;
-
-      while (!coarseDone || !deltaDone) {
-        const winner = await Promise.race([
-          coarsePending.then((result) => ({ kind: "coarse" as const, result })),
-          deltaPending.then((result) => ({ kind: "delta" as const, result })),
-        ]);
-
-        if (winner.kind === "coarse") {
-          if (winner.result.done) {
-            coarseDone = true;
-            // A never-settling promise keeps the exhausted side out of the race.
-            coarsePending = NEVER;
-          } else {
-            if (winner.result.value) yield winner.result.value;
-            coarsePending = reader.read();
-          }
-        } else {
-          if (winner.result.done) {
-            deltaDone = true;
-            deltaPending = NEVER;
-          } else {
-            for (const event of winner.result.value ?? []) yield event;
-            deltaPending = deltaReader.read();
-          }
-        }
-      }
-    } finally {
-      await reader.cancel().catch(() => undefined);
-      await deltaReader?.cancel().catch(() => undefined);
-    }
+    yield* (await impl()).stream(caller, input);
   },
 
   async abort(caller, input) {
-    const row = await loadOwnedSession(caller, input.sessionId);
-    if (!row?.workflowRunId) return false;
-    if (!(await isRunLive(row.workflowRunId))) return false;
-
-    // Cancels the whole run, which is the session's driver — the next prompt starts a fresh one and
-    // picks the transcript back up from Postgres.
-    await getRun(row.workflowRunId).cancel();
-    if (row.activeRunId) {
-      await completeAgentRun(
-        caller.context.db as DB,
-        row.activeRunId,
-        "cancelled"
-      );
-    }
-    return true;
+    return await (await impl()).abort(caller, input);
   },
 
   async approve(caller, input) {
-    const row = await loadOwnedSession(caller, input.sessionId);
-    if (!row?.workflowRunId) return null;
-
-    // Persist first: the decision must outlive the run, and the permission gate reads it back from
-    // here when the tool call is re-issued.
-    const decided = await decideAgentApproval(caller.context.db as DB, {
-      sessionId: input.sessionId,
-      toolCallId: input.toolCallId,
-      approved: input.approved,
-      comment: input.comment,
-      decidedBy: caller.userId,
-    });
-    if (!decided) return null;
-
-    // Capture the cursor before waking the workflow. The TanStack compatibility transport opens a
-    // fresh request for an approval continuation, unlike the native dashboard's old long-lived
-    // subscription, so it needs the same exact replay boundary as a normal prompt.
-    const run = getRun(row.workflowRunId);
-    const startIndex = (await run.getReadable().getTailIndex()) + 1;
-
-    // Then wake the run, which has been parked on this hook with no compute consumed.
-    await agentApprovalHook.resume(
-      agentApprovalToken(input.sessionId, input.toolCallId),
-      {
-        approved: input.approved,
-        comment: input.comment,
-        // The turns the workflow synthesises after this decision have no request of their own.
-        credentials: readEncryptedAgentCredentials(caller.context.headers),
-      }
-    );
-
-    return { runId: row.workflowRunId, startIndex };
+    return await (await impl()).approve(caller, input);
   },
 
   async compact(caller, input) {
-    const row = await loadOwnedSession(caller, input.sessionId);
-    if (!row) return null;
-    await assertNoTurnRunning(row.workflowRunId, "compact");
-
-    const options = await writingSessionOperationOptions(
-      caller,
-      input.sessionId,
-      row
-    );
-    return await compactWritingSession(options, input.customInstructions);
+    return await (await impl()).compact(caller, input);
   },
 
   async navigate(caller, input) {
-    const row = await loadOwnedSession(caller, input.sessionId);
-    if (!row) return null;
-    await assertNoTurnRunning(row.workflowRunId, "rewind");
-
-    const options = await writingSessionOperationOptions(
-      caller,
-      input.sessionId,
-      row
-    );
-    const result = await navigateWritingSession(options, input.entryId, {
-      summarize: input.summarize,
-      label: input.label,
-    });
-    const branch = await options.session.getBranch();
-    return {
-      cancelled: result.cancelled,
-      events: entriesToWireEvents(branch, replayOptions),
-    };
+    return await (await impl()).navigate(caller, input);
   },
 
   async getDraft(caller, input) {
-    const row = await loadOwnedSession(caller, input.sessionId);
-    if (!row) return null;
-    const { draft } = dependenciesFor(caller);
-    return (await draft.get(input.sessionId)) as never;
+    return (await (await impl()).getDraft?.(caller, input)) ?? null;
   },
 
-  /**
-   * The pre-persistence check the transport calls.
-   *
-   * Returns a reason instead of throwing because the caller is a middleware turning this into a
-   * `BAD_REQUEST`. `assertWritingModel` checks policy *and* catalogue membership — the latter is
-   * what stops a typo on a native provider from being stored and then failing on every subsequent
-   * turn, deep in the workflow step where the operator cannot see why.
-   */
-  validateModel(ref) {
-    try {
-      assertWritingModel(ref);
-      return Promise.resolve(null);
-    } catch (error) {
-      return Promise.resolve(
-        error instanceof UnknownAgentModelError
-          ? error.message
-          : `Could not validate model "${ref.modelId}".`
-      );
-    }
+  async validateModel(ref) {
+    return await (await impl()).validateModel(ref);
   },
 
-  listModels(caller) {
-    /**
-     * Which BYOK providers this caller has a key for. Read from the cookie rather than decrypted:
-     * the picker only needs to know whether a key is *present*, and decrypting to answer a listing
-     * request would put plaintext keys on a path that has no use for them.
-     */
-    const registered = readEncryptedAgentCredentials(caller.context.headers);
-    const configured = BYOK_PROVIDER_IDS.filter(
-      (providerId) => registered?.[providerId]
-    );
-    return Promise.resolve(listWritingModels({ configured }));
+  async listModels(caller) {
+    return await (await impl()).listModels(caller);
   },
 
-  listCapabilities() {
-    return Promise.resolve({
-      tools: createWritingTools().map((tool) => ({
-        name: tool.name,
-        label: tool.label,
-        tier: writingPolicy.tierOf(tool.name),
-        description: tool.description,
-      })),
-      promptTemplates: writingPromptTemplates.map((template) => ({
-        name: template.name,
-        description: template.description,
-      })),
-      skills: writingSkills.map((skill) => ({
-        name: skill.name,
-        description: skill.description,
-      })),
-    });
+  async listCapabilities() {
+    return await (await impl()).listCapabilities();
   },
-};
-
-/**
- * Compaction and rewinding both mutate the session tree, so they cannot run while a turn is
- * appending to it.
- *
- * A live run is not enough to refuse on — it may simply be parked on the message hook, which is the
- * normal idle state. Only an actually-executing turn conflicts, and `running` is the closest signal
- * the run exposes.
- */
-const assertNoTurnRunning = async (
-  runId: string | null,
-  action: string
-): Promise<void> => {
-  if (!runId) return;
-  try {
-    const run = getRun(runId);
-    if (!(await run.exists)) return;
-    if ((await run.status) === "running") {
-      throw new Error(
-        `Cannot ${action} while a turn is running. Wait for it to finish or abort it.`
-      );
-    }
-  } catch (error) {
-    // Re-throw our own refusal; swallow lookup failures for runs that no longer resolve.
-    if (error instanceof Error && error.message.startsWith("Cannot "))
-      throw error;
-  }
 };
 
 /** Registers this host service under its kind. Called once at module load. */
 export const registerAgentKindServices = (): void => {
-  registerAgentKindService(WRITING_AGENT_KIND, writingAgentService);
+  registerAgentKindService("writing", writingAgentServiceDelegate);
 };

--- a/apps/service/src/services/writing-agent.service.ts
+++ b/apps/service/src/services/writing-agent.service.ts
@@ -1,0 +1,784 @@
+import { getHookByToken, getRun, start } from "workflow/api";
+
+import {
+  BYOK_PROVIDER_IDS,
+  createAgentModels,
+  entriesToWireEvents,
+  PgSessionRepo,
+  UnknownAgentModelError,
+  writeSessionSettings,
+} from "@chia/agent-runtime";
+import type {
+  AgentSessionSettings,
+  AgentWireEvent,
+  ThinkingLevel,
+  ToolTier,
+} from "@chia/agent-runtime";
+import {
+  compactWritingSession,
+  createWritingTools,
+  assertWritingModel,
+  listWritingModels,
+  navigateWritingSession,
+  PgDraftStore,
+  WRITING_AGENT_KIND,
+  WRITING_SESSION_DEFAULTS,
+  writingPolicy,
+  writingPromptTemplates,
+  writingSkills,
+} from "@chia/agent-writing";
+import type {
+  AgentKindService,
+  AgentServiceCaller,
+} from "@chia/api/orpc/agent-service";
+import type { DB } from "@chia/db";
+import {
+  completeAgentRun,
+  createAgentRun,
+  createWritingAgentSession,
+  decideAgentApproval,
+  deleteAgentSession,
+  getActiveAgentRun,
+  getAgentApprovals,
+  getAgentSession,
+  getWritingAgentSession,
+  softDeleteAgentSession,
+} from "@chia/db/repos/agent";
+
+import { AGENT_DELTA_NAMESPACE } from "../steps/agent-turn.step";
+import { agentSessionWorkflow } from "../workflows/agent-session.workflow";
+import {
+  AGENT_END_SENTINEL,
+  agentApprovalHook,
+  agentApprovalToken,
+  agentMessageHook,
+  agentMessageToken,
+} from "../workflows/hooks/agent.hooks";
+
+import { createAgentContentPort } from "./agent-content.port";
+import {
+  decryptAgentCredentials,
+  readEncryptedAgentCredentials,
+} from "./agent-credentials";
+
+/**
+ * The **writing** agent service, registered under `agent_session.kind = "writing"`.
+ *
+ * Pi execution, session persistence, approval and wire primitives are `@chia/agent-runtime`;
+ * the writing domain is `@chia/agent-writing`. This module is the
+ * transport-facing glue between them and the durable workflow run. A second agent kind is a
+ * sibling of this file plus its own domain package.
+ *
+ * **Stateless.** There is no in-process registry: each session is driven by a durable workflow run,
+ * and every piece of state lives somewhere durable —
+ *
+ * - transcript → `agent_session_entry` (queried directly by the dashboard, and the source pi
+ *   rebuilds context from)
+ * - draft buffer → `writing_agent_session` + `writing_agent_draft`
+ * - approval decisions → `agent_tool_approval`
+ * - turn execution metadata → `agent_run`; pauses and event stream → the workflow backend
+ *
+ * That split is why a deploy mid-turn is survivable and why an approval can be granted a day later.
+ * It is also why this module can be replicated across instances without a coordination layer.
+ */
+
+// ============================================
+// Helpers
+// ============================================
+
+const repoFor = (db: DB) =>
+  new PgSessionRepo(db, {
+    kind: WRITING_AGENT_KIND,
+    defaults: WRITING_SESSION_DEFAULTS,
+  });
+
+const dependenciesFor = (caller: AgentServiceCaller) => {
+  const db = caller.context.db as DB;
+  return {
+    db,
+    repo: repoFor(db),
+    draft: new PgDraftStore(db),
+    content: createAgentContentPort({
+      db,
+      kv: caller.context.kv,
+      adminId: caller.adminId,
+    }),
+  };
+};
+
+/**
+ * Loads a session **scoped to the caller**.
+ *
+ * The session id arrives from client input, so ownership is re-checked here rather than trusted —
+ * `adminGuard` proves who is calling, not what they may open.
+ */
+const loadOwnedSession = async (
+  caller: AgentServiceCaller,
+  sessionId: string
+) => {
+  const db = caller.context.db as DB;
+  const row = await getAgentSession(db, sessionId);
+  if (!row || row.deletedAt !== null) return null;
+  if (row.userId !== caller.userId) return null;
+  if (row.kind !== WRITING_AGENT_KIND) return null;
+
+  const [writingState, activeRun] = await Promise.all([
+    getWritingAgentSession(db, sessionId),
+    getActiveAgentRun(db, sessionId),
+  ]);
+  if (!writingState) return null;
+
+  return {
+    ...row,
+    targetFeedId: writingState.targetFeedId,
+    feedMeta: writingState.feedMeta,
+    activeRunId: activeRun?.id ?? null,
+    workflowRunId: activeRun?.externalRunId ?? null,
+  };
+};
+
+const settingsOf = (row: {
+  id: string;
+  providerId: string | null;
+  modelId: string | null;
+  thinkingLevel: string | null;
+  activeToolNames: string[] | null;
+  autoApprove: string[];
+}): AgentSessionSettings => {
+  if (!row.providerId || !row.modelId || !row.thinkingLevel) {
+    throw new Error(`Writing session ${row.id} has incomplete LLM settings.`);
+  }
+  return {
+    providerId: row.providerId,
+    modelId: row.modelId,
+    thinkingLevel: row.thinkingLevel as ThinkingLevel,
+    activeToolNames: row.activeToolNames,
+    autoApprove: row.autoApprove as ToolTier[],
+  };
+};
+
+const summaryOf = (row: {
+  id: string;
+  title: string | null;
+  kind: string;
+  providerId: string | null;
+  modelId: string | null;
+  thinkingLevel: string | null;
+  activeToolNames: string[] | null;
+  autoApprove: string[];
+  targetFeedId: number | null;
+  createdAt: Date;
+  updatedAt: Date;
+}) => {
+  const settings = settingsOf(row);
+  return {
+    id: row.id,
+    title: row.title,
+    kind: row.kind,
+    modelId: settings.modelId,
+    thinkingLevel: settings.thinkingLevel,
+    targetFeedId: row.targetFeedId,
+    createdAt: row.createdAt.getTime(),
+    updatedAt: row.updatedAt.getTime(),
+  };
+};
+
+/**
+ * Loads the Pi session inputs used by explicit maintenance operations.
+ *
+ * These operations only walk the session tree, so the concrete Pi operations receive no tools,
+ * skills, approval gate or event subscriptions. The draft store and content port are skipped for
+ * the same reason, which is why this reaches for `repoFor` rather than the full `dependenciesFor`.
+ */
+const writingSessionOperationOptions = async (
+  caller: AgentServiceCaller,
+  sessionId: string,
+  row: Parameters<typeof settingsOf>[0]
+) => {
+  const session = await repoFor(caller.context.db as DB).openById(sessionId);
+  return {
+    session,
+    settings: settingsOf(row),
+    /**
+     * Compaction calls the model too, so a BYOK session needs its key here just as much as in a
+     * turn. This path runs inside the request, so the cookie is read and decrypted directly rather
+     * than travelling through the workflow.
+     */
+    models: modelsFor(caller),
+  };
+};
+
+/** Per-request `Models`, carrying whatever provider keys the caller has registered. */
+const modelsFor = (caller: AgentServiceCaller) =>
+  createAgentModels(
+    decryptAgentCredentials(
+      readEncryptedAgentCredentials(caller.context.headers)
+    )
+  );
+
+const replayOptions = {
+  tierOf: writingPolicy.tierOf,
+  labelOf: writingPolicy.labelOf,
+  summarize: writingPolicy.summarize,
+};
+
+/**
+ * A promise that never settles, used to drop an exhausted reader out of the two-stream race in
+ * {@link writingAgentService.stream} without it winning again.
+ */
+const NEVER = new Promise<never>(() => undefined);
+
+/** Run states in which the session's workflow run can still accept a message. */
+const isRunLive = async (runId: string): Promise<boolean> => {
+  try {
+    const run = getRun(runId);
+    if (!(await run.exists)) return false;
+    const status = await run.status;
+    return status === "pending" || status === "running";
+  } catch {
+    // A run from a previous deployment may no longer resolve; treat it as gone.
+    return false;
+  }
+};
+
+/**
+ * Whether a hook token is registered and can be resumed.
+ *
+ * `createHook()` does not register on call. This workflow registers through `getConflict()` before
+ * its first turn, but `start()` may return before the workflow reaches that line. Checking once
+ * turns that startup race into a retryable answer instead of a failed `resume()`; it is not a
+ * timer or polling loop.
+ */
+const isHookReady = async (token: string): Promise<boolean> => {
+  try {
+    return Boolean(await getHookByToken(token));
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Approvals still awaiting a decision.
+ *
+ * Used to refuse a new prompt while the run is parked on an approval hook. The message would
+ * otherwise sit in the event log unread until the approval resolved, which looks to the operator
+ * like their message vanished.
+ */
+const undecidedApprovals = async (
+  db: DB,
+  sessionId: string
+): Promise<string[]> => {
+  const approvals = await getAgentApprovals(db, sessionId);
+  return approvals
+    .filter((approval) => approval.decidedAt === null)
+    .map((approval) => approval.toolName);
+};
+
+const detailFor = async (caller: AgentServiceCaller, sessionId: string) => {
+  const row = await loadOwnedSession(caller, sessionId);
+  if (!row) return null;
+
+  const { db, repo, draft } = dependenciesFor(caller);
+  const session = await repo.openById(sessionId);
+
+  const [branch, draftState, stats, approvals] = await Promise.all([
+    session.getBranch(),
+    draft.get(sessionId),
+    session.getSessionStats(),
+    getAgentApprovals(db, sessionId),
+  ]);
+
+  // Older rows written before PgSessionStorage advanced `leafEntryId` have persisted entries but
+  // an empty active branch. Replay those entries in insertion order so existing development
+  // sessions remain visible after a refresh. Correctly linked sessions always use their branch.
+  let transcriptEntries = branch;
+  if (
+    branch.length === 0 &&
+    row.leafEntryId === null &&
+    stats.messageCount > 0
+  ) {
+    const storedEntries = await session.getStorage().getEntries();
+    if (storedEntries.every((entry) => entry.parentId === null)) {
+      transcriptEntries = storedEntries;
+    }
+  }
+  const events = entriesToWireEvents(transcriptEntries, replayOptions);
+
+  // Surface approvals still waiting on a decision, so a reload restores the prompt.
+  const pendingApprovals = approvals
+    .filter((approval) => approval.status === "pending")
+    .map((approval) => ({
+      toolCallId: approval.toolCallId,
+      toolName: approval.toolName,
+      args: approval.args ?? undefined,
+    }));
+
+  return {
+    session: summaryOf(row),
+    settings: settingsOf(row),
+    runtimeConfig: row.runtimeConfig,
+    configVersion: row.configVersion,
+    draft: draftState as never,
+    events,
+    pendingApprovals,
+    stats: {
+      messageCount: stats.messageCount,
+      totalTokens: stats.totalTokens,
+      costTotal: stats.costTotal,
+    },
+  };
+};
+
+// ============================================
+// Service
+// ============================================
+
+export const writingAgentService: AgentKindService = {
+  async listSessions(caller, input) {
+    const { db, repo } = dependenciesFor(caller);
+    const metadata = await repo.list({
+      userId: caller.userId,
+      limit: input?.limit,
+      includeDeleted: input?.includeDeleted,
+    });
+
+    const rows = await Promise.all(
+      metadata.map(async (entry) => {
+        const [row, writingState] = await Promise.all([
+          getAgentSession(db, entry.id),
+          getWritingAgentSession(db, entry.id),
+        ]);
+        return row && writingState
+          ? { ...row, targetFeedId: writingState.targetFeedId }
+          : null;
+      })
+    );
+
+    return {
+      items: rows.flatMap((row) => (row ? [summaryOf(row)] : [])),
+      // Sessions are listed newest-first with a hard limit; there is no cursor to page yet.
+      nextCursor: null,
+    };
+  },
+
+  async createSession(caller, input) {
+    const { repo, draft, content } = dependenciesFor(caller);
+
+    const session = await repo.create({
+      userId: caller.userId,
+      title: input.title,
+      settings: {
+        providerId: input.model?.providerId,
+        modelId: input.model?.modelId,
+        thinkingLevel: input.thinkingLevel as ThinkingLevel | undefined,
+        autoApprove: input.autoApprove as ToolTier[] | undefined,
+      },
+      runtimeConfig: input.runtimeConfig,
+    });
+    const { id } = await session.getMetadata();
+    try {
+      await createWritingAgentSession(caller.context.db as DB, {
+        sessionId: id,
+        targetFeedId: input.targetFeedId,
+      });
+
+      // Opening a session against an existing post seeds the buffer, so the agent edits the real
+      // content instead of guessing at it.
+      if (input.targetFeedId !== undefined) {
+        const post = await content.getPost({ feedId: input.targetFeedId });
+        if (post) await draft.seedFromPost(id, post);
+      }
+
+      const detail = await detailFor(caller, id);
+      if (!detail)
+        throw new Error("Session vanished immediately after creation");
+      return detail;
+    } catch (error) {
+      // Core and writing state live in separate repositories. Compensate if extension setup or
+      // draft seeding fails so callers never receive an unusable half-created session.
+      await deleteAgentSession(caller.context.db as DB, id);
+      throw error;
+    }
+  },
+
+  getSession(caller, input) {
+    return detailFor(caller, input.sessionId);
+  },
+
+  async deleteSession(caller, input) {
+    const row = await loadOwnedSession(caller, input.sessionId);
+    if (!row) return false;
+
+    // End the run before soft-deleting, so it is not left parked on a hook forever.
+    if (row.workflowRunId && (await isRunLive(row.workflowRunId))) {
+      await agentMessageHook.resume(agentMessageToken(input.sessionId), {
+        text: AGENT_END_SENTINEL,
+      });
+    }
+    if (row.activeRunId) {
+      await completeAgentRun(
+        caller.context.db as DB,
+        row.activeRunId,
+        "cancelled"
+      );
+    }
+
+    await softDeleteAgentSession(caller.context.db as DB, input.sessionId);
+    return true;
+  },
+
+  async updateSettings(caller, input) {
+    const row = await loadOwnedSession(caller, input.sessionId);
+    if (!row) return null;
+    await writeSessionSettings(caller.context.db as DB, input.sessionId, {
+      title: input.title,
+      providerId: input.model?.providerId,
+      modelId: input.model?.modelId,
+      thinkingLevel: input.thinkingLevel as ThinkingLevel | undefined,
+      activeToolNames: input.activeToolNames,
+      autoApprove: input.autoApprove as ToolTier[] | undefined,
+      runtimeConfig: input.runtimeConfig,
+    });
+
+    return detailFor(caller, input.sessionId);
+  },
+
+  /**
+   * Enqueues a turn.
+   *
+   * If the session already has a live run, its reusable hook durably queues the message. The
+   * workflow consumes it after the current turn and any approval handshake finish. Otherwise a new
+   * run is started and its id recorded.
+   *
+   * Either way this returns as soon as the message is accepted; the turn itself runs in the run.
+   */
+  async prompt(caller, input) {
+    const row = await loadOwnedSession(caller, input.sessionId);
+    if (!row) throw new Error(`Unknown agent session: ${input.sessionId}`);
+
+    if (input.text === AGENT_END_SENTINEL) {
+      throw new Error(
+        `"${AGENT_END_SENTINEL}" is reserved; it ends the session's run.`
+      );
+    }
+
+    const message = {
+      text: input.text,
+      template: input.template,
+      preAuthorizeToolNames: input.preAuthorizeToolNames,
+      // Refreshed on every prompt: the run outlives any one request, and the operator may have
+      // registered or rotated a key since the last turn.
+      credentials: readEncryptedAgentCredentials(caller.context.headers),
+    };
+
+    /**
+     * Refuse while an approval is outstanding.
+     *
+     * The run is parked on the *approval* hook, not the message hook. A resumed message would be
+     * persisted and then sit unread until the approval resolved — from the operator's side their
+     * message would simply appear to do nothing. Better to say why.
+     */
+    const outstanding = await undecidedApprovals(
+      caller.context.db as DB,
+      input.sessionId
+    );
+    if (outstanding.length > 0) {
+      throw new Error(
+        `Waiting on your decision for \`${outstanding.join("`, `")}\`. Approve or reject it before sending another message.`
+      );
+    }
+
+    if (row.workflowRunId && (await isRunLive(row.workflowRunId))) {
+      const token = agentMessageToken(input.sessionId);
+
+      if (!(await isHookReady(token))) {
+        throw new Error(
+          "The session's run is still starting up. Retry in a moment."
+        );
+      }
+
+      const run = getRun(row.workflowRunId);
+      // Capture the tail before enqueuing. If another turn is active, its remaining events and the
+      // queued turn share this continuation stream in durable emission order.
+      const startIndex = (await run.getReadable().getTailIndex()) + 1;
+      await agentMessageHook.resume(token, message);
+      return { runId: row.workflowRunId, startIndex, startedRun: false };
+    }
+
+    const run = await start(agentSessionWorkflow, [
+      {
+        sessionId: input.sessionId,
+        adminId: caller.adminId,
+        userId: caller.userId,
+        firstMessage: message,
+      },
+    ]);
+
+    await createAgentRun(caller.context.db as DB, {
+      id: run.runId,
+      sessionId: input.sessionId,
+      harnessKind: "workflow",
+      externalRunId: run.runId,
+      metadata: { agentKind: WRITING_AGENT_KIND },
+    });
+
+    return { runId: run.runId, startIndex: 0, startedRun: true };
+  },
+
+  /**
+   * Tails a run's durable stream.
+   *
+   * The heavy lifting is the SDK's: `getReadable({ startIndex })` replays from the requested point
+   * and then delivers live chunks, which is what makes reconnection and multi-viewer work without
+   * any coordination on our side.
+   */
+  async *stream(caller, input) {
+    const row = await loadOwnedSession(caller, input.sessionId);
+    if (!row) throw new Error(`Unknown agent session: ${input.sessionId}`);
+
+    const runId = input.runId ?? row.workflowRunId;
+    if (!runId) return;
+
+    const readable = getRun(runId).getReadable<AgentWireEvent>({
+      startIndex: input.startIndex,
+    });
+    const reader = readable.getReader();
+
+    // Deltas live on their own namespace and arrive batched; merging them here keeps the client's
+    // reducer identical whether or not it asked for them.
+    const deltaReader = input.deltas
+      ? getRun(runId)
+          .getReadable<AgentWireEvent[]>({
+            namespace: AGENT_DELTA_NAMESPACE,
+            startIndex: 0,
+          })
+          .getReader()
+      : undefined;
+
+    try {
+      if (!deltaReader) {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          if (value) yield value;
+        }
+        return;
+      }
+
+      /**
+       * Two streams, drained as whichever has data next.
+       *
+       * Racing the two reads (rather than draining one then the other) is what keeps deltas
+       * interleaved with the coarse events they belong to.
+       */
+      let coarsePending = reader.read();
+      let deltaPending = deltaReader.read();
+      let coarseDone = false;
+      let deltaDone = false;
+
+      while (!coarseDone || !deltaDone) {
+        const winner = await Promise.race([
+          coarsePending.then((result) => ({ kind: "coarse" as const, result })),
+          deltaPending.then((result) => ({ kind: "delta" as const, result })),
+        ]);
+
+        if (winner.kind === "coarse") {
+          if (winner.result.done) {
+            coarseDone = true;
+            // A never-settling promise keeps the exhausted side out of the race.
+            coarsePending = NEVER;
+          } else {
+            if (winner.result.value) yield winner.result.value;
+            coarsePending = reader.read();
+          }
+        } else {
+          if (winner.result.done) {
+            deltaDone = true;
+            deltaPending = NEVER;
+          } else {
+            for (const event of winner.result.value ?? []) yield event;
+            deltaPending = deltaReader.read();
+          }
+        }
+      }
+    } finally {
+      await reader.cancel().catch(() => undefined);
+      await deltaReader?.cancel().catch(() => undefined);
+    }
+  },
+
+  async abort(caller, input) {
+    const row = await loadOwnedSession(caller, input.sessionId);
+    if (!row?.workflowRunId) return false;
+    if (!(await isRunLive(row.workflowRunId))) return false;
+
+    // Cancels the whole run, which is the session's driver — the next prompt starts a fresh one and
+    // picks the transcript back up from Postgres.
+    await getRun(row.workflowRunId).cancel();
+    if (row.activeRunId) {
+      await completeAgentRun(
+        caller.context.db as DB,
+        row.activeRunId,
+        "cancelled"
+      );
+    }
+    return true;
+  },
+
+  async approve(caller, input) {
+    const row = await loadOwnedSession(caller, input.sessionId);
+    if (!row?.workflowRunId) return null;
+
+    // Persist first: the decision must outlive the run, and the permission gate reads it back from
+    // here when the tool call is re-issued.
+    const decided = await decideAgentApproval(caller.context.db as DB, {
+      sessionId: input.sessionId,
+      toolCallId: input.toolCallId,
+      approved: input.approved,
+      comment: input.comment,
+      decidedBy: caller.userId,
+    });
+    if (!decided) return null;
+
+    // Capture the cursor before waking the workflow. The TanStack compatibility transport opens a
+    // fresh request for an approval continuation, unlike the native dashboard's old long-lived
+    // subscription, so it needs the same exact replay boundary as a normal prompt.
+    const run = getRun(row.workflowRunId);
+    const startIndex = (await run.getReadable().getTailIndex()) + 1;
+
+    // Then wake the run, which has been parked on this hook with no compute consumed.
+    await agentApprovalHook.resume(
+      agentApprovalToken(input.sessionId, input.toolCallId),
+      {
+        approved: input.approved,
+        comment: input.comment,
+        // The turns the workflow synthesises after this decision have no request of their own.
+        credentials: readEncryptedAgentCredentials(caller.context.headers),
+      }
+    );
+
+    return { runId: row.workflowRunId, startIndex };
+  },
+
+  async compact(caller, input) {
+    const row = await loadOwnedSession(caller, input.sessionId);
+    if (!row) return null;
+    await assertNoTurnRunning(row.workflowRunId, "compact");
+
+    const options = await writingSessionOperationOptions(
+      caller,
+      input.sessionId,
+      row
+    );
+    return await compactWritingSession(options, input.customInstructions);
+  },
+
+  async navigate(caller, input) {
+    const row = await loadOwnedSession(caller, input.sessionId);
+    if (!row) return null;
+    await assertNoTurnRunning(row.workflowRunId, "rewind");
+
+    const options = await writingSessionOperationOptions(
+      caller,
+      input.sessionId,
+      row
+    );
+    const result = await navigateWritingSession(options, input.entryId, {
+      summarize: input.summarize,
+      label: input.label,
+    });
+    const branch = await options.session.getBranch();
+    return {
+      cancelled: result.cancelled,
+      events: entriesToWireEvents(branch, replayOptions),
+    };
+  },
+
+  async getDraft(caller, input) {
+    const row = await loadOwnedSession(caller, input.sessionId);
+    if (!row) return null;
+    const { draft } = dependenciesFor(caller);
+    return (await draft.get(input.sessionId)) as never;
+  },
+
+  /**
+   * The pre-persistence check the transport calls.
+   *
+   * Returns a reason instead of throwing because the caller is a middleware turning this into a
+   * `BAD_REQUEST`. `assertWritingModel` checks policy *and* catalogue membership — the latter is
+   * what stops a typo on a native provider from being stored and then failing on every subsequent
+   * turn, deep in the workflow step where the operator cannot see why.
+   */
+  validateModel(ref) {
+    try {
+      assertWritingModel(ref);
+      return Promise.resolve(null);
+    } catch (error) {
+      return Promise.resolve(
+        error instanceof UnknownAgentModelError
+          ? error.message
+          : `Could not validate model "${ref.modelId}".`
+      );
+    }
+  },
+
+  listModels(caller) {
+    /**
+     * Which BYOK providers this caller has a key for. Read from the cookie rather than decrypted:
+     * the picker only needs to know whether a key is *present*, and decrypting to answer a listing
+     * request would put plaintext keys on a path that has no use for them.
+     */
+    const registered = readEncryptedAgentCredentials(caller.context.headers);
+    const configured = BYOK_PROVIDER_IDS.filter(
+      (providerId) => registered?.[providerId]
+    );
+    return Promise.resolve(listWritingModels({ configured }));
+  },
+
+  listCapabilities() {
+    return Promise.resolve({
+      tools: createWritingTools().map((tool) => ({
+        name: tool.name,
+        label: tool.label,
+        tier: writingPolicy.tierOf(tool.name),
+        description: tool.description,
+      })),
+      promptTemplates: writingPromptTemplates.map((template) => ({
+        name: template.name,
+        description: template.description,
+      })),
+      skills: writingSkills.map((skill) => ({
+        name: skill.name,
+        description: skill.description,
+      })),
+    });
+  },
+};
+
+/**
+ * Compaction and rewinding both mutate the session tree, so they cannot run while a turn is
+ * appending to it.
+ *
+ * A live run is not enough to refuse on — it may simply be parked on the message hook, which is the
+ * normal idle state. Only an actually-executing turn conflicts, and `running` is the closest signal
+ * the run exposes.
+ */
+const assertNoTurnRunning = async (
+  runId: string | null,
+  action: string
+): Promise<void> => {
+  if (!runId) return;
+  try {
+    const run = getRun(runId);
+    if (!(await run.exists)) return;
+    if ((await run.status) === "running") {
+      throw new Error(
+        `Cannot ${action} while a turn is running. Wait for it to finish or abort it.`
+      );
+    }
+  } catch (error) {
+    // Re-throw our own refusal; swallow lookup failures for runs that no longer resolve.
+    if (error instanceof Error && error.message.startsWith("Cannot "))
+      throw error;
+  }
+};

--- a/apps/service/src/steps/agent-turn.step.ts
+++ b/apps/service/src/steps/agent-turn.step.ts
@@ -1,17 +1,10 @@
 import { FatalError, getWritable } from "workflow";
 
-import { createAgentModels, PgSessionRepo } from "@chia/agent-runtime";
 import type {
   AgentWireEvent,
   ThinkingLevel,
   ToolTier,
 } from "@chia/agent-runtime";
-import {
-  PgDraftStore,
-  runWritingTurn,
-  WRITING_AGENT_KIND,
-  WRITING_SESSION_DEFAULTS,
-} from "@chia/agent-writing";
 import type { DB } from "@chia/db";
 import { connectDatabase } from "@chia/db/client";
 import {
@@ -124,9 +117,15 @@ export const runAgentTurnStep = async (
 /**
  * Static registration is intentional: workflow steps are deployment-versioned bundles. A new kind
  * adds a handler here and a sibling HTTP runtime, while the workflow stays free of domain imports.
+ *
+ * Keyed by the literal rather than `WRITING_AGENT_KIND`, because importing that constant pulls
+ * `@chia/agent-writing` and the whole provider stack behind it. This module is registered at boot
+ * for every process that hosts the workflow, so a domain import here is an eager one. The key is
+ * matched against `agent_session.kind`, which is a database string either way; the handler asserts
+ * the constant once its domain module is loaded.
  */
 const AGENT_TURN_HANDLERS: Readonly<Record<string, AgentTurnHandler>> = {
-  [WRITING_AGENT_KIND]: runWritingAgentTurn,
+  writing: runWritingAgentTurn,
 };
 
 async function runWritingAgentTurn(
@@ -134,9 +133,27 @@ async function runWritingAgentTurn(
   row: AgentSessionRow,
   request: AgentTurnRequest
 ): Promise<AgentTurnOutcome> {
-  const kv = await import("@chia/kv/redis").then((module) =>
-    module.getRedisKv()
-  );
+  const [
+    { createAgentModels, PgSessionRepo },
+    {
+      PgDraftStore,
+      runWritingTurn,
+      WRITING_AGENT_KIND,
+      WRITING_SESSION_DEFAULTS,
+    },
+    kv,
+  ] = await Promise.all([
+    import("@chia/agent-runtime"),
+    import("@chia/agent-writing"),
+    import("@chia/kv/redis").then((module) => module.getRedisKv()),
+  ]);
+
+  if (row.kind !== WRITING_AGENT_KIND) {
+    throw new FatalError(
+      `Agent session ${request.sessionId} dispatched to the writing turn as kind "${row.kind}".`
+    );
+  }
+
   const writingState = await getWritingAgentSession(db, request.sessionId);
   if (!writingState) {
     throw new FatalError(

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -33,6 +33,10 @@
       "types": "./src/utils/index.ts",
       "default": "./src/utils/index.ts"
     },
+    "./utils/model": {
+      "types": "./src/utils/model.ts",
+      "default": "./src/utils/model.ts"
+    },
     "./embeddings/openai": {
       "types": "./src/embeddings/openai.ts",
       "default": "./src/embeddings/openai.ts"

--- a/packages/ai/src/embeddings/provider.ts
+++ b/packages/ai/src/embeddings/provider.ts
@@ -1,7 +1,6 @@
 import { isOllamaEnabled } from "../ollama/utils.ts";
 
 import { ollamaEmbeddings } from "./ollama.ts";
-import { generateEmbeddings } from "./openai.ts";
 import {
   EMBEDDING_DIMENSIONS,
   EMBEDDING_INDEX_VERSION,
@@ -38,13 +37,20 @@ export interface OpenAIProviderOptions {
   ) => Promise<Response>;
 }
 
+/**
+ * `./openai.ts` is imported inside `embed` rather than at module scope: resolving a
+ * provider is part of the boot path of everything that indexes, but `@ai-sdk/openai`
+ * and `ai` are only needed once vectors are actually requested.
+ */
 export const openAIEmbeddingProvider = (
   options: OpenAIProviderOptions = {}
 ): EmbeddingProvider => ({
   id: OPENAI_EMBEDDING_MODEL,
   dimensions: EMBEDDING_DIMENSIONS,
-  embed: (texts) =>
-    generateEmbeddings(texts, {
+  embed: async (texts) =>
+    await (
+      await import("./openai.ts")
+    ).generateEmbeddings(texts, {
       model: OPENAI_EMBEDDING_MODEL,
       apiKey: options.apiKey,
       fetch: options.fetch,

--- a/packages/ai/src/utils/index.ts
+++ b/packages/ai/src/utils/index.ts
@@ -4,17 +4,22 @@ import {
   privateDecrypt,
 } from "node:crypto";
 
-import { createAnthropic } from "@ai-sdk/anthropic";
-import { createGoogleGenerativeAI } from "@ai-sdk/google";
-import { createOpenAI } from "@ai-sdk/openai";
-import type { LanguageModel } from "ai";
 import GithubSlugger from "github-slugger";
+import * as z from "zod";
 
-import type { BaseRequest } from "./types";
-import { Provider } from "./types";
-import { authTokenSchema } from "./types";
+/**
+ * This module is imported by the API-key guards, so it must stay free of provider SDKs.
+ * `createModel` lives in `./model` for that reason, and the auth-token schema is declared here
+ * rather than pulled from `./types` — that module reaches `ai` for `modelMessageSchema`.
+ */
 
 export const slugger = new GithubSlugger();
+
+export const authTokenSchema = z.object({
+  apiKey: z.string().min(1),
+});
+
+export type AuthToken = z.infer<typeof authTokenSchema>;
 
 export function generateKeys() {
   const { publicKey, privateKey } = generateKeyPairSync("rsa", {
@@ -52,40 +57,4 @@ export const verifyApiKey = (token: string, privateKey: string) => {
   return authTokenSchema.parse({
     apiKey: decodeApiKey(token, privateKey),
   });
-};
-
-export const createModel = (
-  options: Pick<BaseRequest, "model" | "authToken" | "proxyUrl">,
-  formater?: ((model: BaseRequest["model"]) => LanguageModel) | "ai-gateway-v3"
-): LanguageModel => {
-  if (formater) {
-    if (typeof formater === "function") {
-      return formater(options.model);
-    }
-    switch (formater) {
-      case "ai-gateway-v3":
-        return `${options.model.provider}/${options.model.id}`;
-      default:
-        throw new Error("Invalid formater");
-    }
-  }
-  switch (options.model.provider) {
-    case Provider.OpenAI:
-      return createOpenAI({
-        apiKey: options.authToken,
-        baseURL: options.proxyUrl,
-      })(options.model.id);
-    case Provider.Anthropic:
-      return createAnthropic({
-        apiKey: options.authToken,
-        baseURL: options.proxyUrl,
-      })(options.model.id);
-    case Provider.Google:
-      return createGoogleGenerativeAI({
-        apiKey: options.authToken,
-        baseURL: options.proxyUrl,
-      })(options.model.id);
-    default:
-      throw new Error("Invalid provider");
-  }
 };

--- a/packages/ai/src/utils/model.ts
+++ b/packages/ai/src/utils/model.ts
@@ -1,0 +1,48 @@
+import { createAnthropic } from "@ai-sdk/anthropic";
+import { createGoogleGenerativeAI } from "@ai-sdk/google";
+import { createOpenAI } from "@ai-sdk/openai";
+import type { LanguageModel } from "ai";
+
+import type { BaseRequest } from "./types";
+import { Provider } from "./types";
+
+/**
+ * Kept out of `@chia/ai/utils` because that module is on the request-auth path — the API-key
+ * guards import `verifyApiKey` from it. Sharing a module with these three provider SDKs would
+ * put all of them in the eager graph of every process that authenticates a request.
+ */
+export const createModel = (
+  options: Pick<BaseRequest, "model" | "authToken" | "proxyUrl">,
+  formater?: ((model: BaseRequest["model"]) => LanguageModel) | "ai-gateway-v3"
+): LanguageModel => {
+  if (formater) {
+    if (typeof formater === "function") {
+      return formater(options.model);
+    }
+    switch (formater) {
+      case "ai-gateway-v3":
+        return `${options.model.provider}/${options.model.id}`;
+      default:
+        throw new Error("Invalid formater");
+    }
+  }
+  switch (options.model.provider) {
+    case Provider.OpenAI:
+      return createOpenAI({
+        apiKey: options.authToken,
+        baseURL: options.proxyUrl,
+      })(options.model.id);
+    case Provider.Anthropic:
+      return createAnthropic({
+        apiKey: options.authToken,
+        baseURL: options.proxyUrl,
+      })(options.model.id);
+    case Provider.Google:
+      return createGoogleGenerativeAI({
+        apiKey: options.authToken,
+        baseURL: options.proxyUrl,
+      })(options.model.id);
+    default:
+      throw new Error("Invalid provider");
+  }
+};

--- a/packages/ai/src/utils/types.ts
+++ b/packages/ai/src/utils/types.ts
@@ -105,10 +105,4 @@ export const baseRequestSchema = z.object({
 
 export type BaseRequest = z.infer<typeof baseRequestSchema>;
 
-export const authTokenSchema = z.object({
-  apiKey: z.string().min(1),
-});
-
-export type AuthToken = z.infer<typeof authTokenSchema>;
-
 export { ModelMessage };

--- a/packages/api/orpc/routes/file.route.ts
+++ b/packages/api/orpc/routes/file.route.ts
@@ -1,6 +1,13 @@
-import { s3Service } from "../../s3/s3.service";
 import { adminGuard } from "../guards/admin.guard";
 import { contractOS, slugger } from "../utils";
+
+/**
+ * Loaded on demand rather than imported statically: the router imports every route
+ * module at boot, so a static import would put the whole AWS SDK in the eager module
+ * graph of processes that never touch a file route.
+ */
+const getS3Service = async () =>
+  (await import("../../s3/s3.service")).s3Service;
 
 export const createSignedUrlForUploadRoute = contractOS.file[
   "signed-url:create"
@@ -21,7 +28,9 @@ export const createSignedUrlForUploadRoute = contractOS.file[
       const uuid = crypto.randomUUID();
       const name = `${opts.input.area}/${sluggedFilename}-${uuid}${extension}`;
 
-      const { url } = await s3Service.createSignedUrlForUpload(name, {
+      const { url } = await (
+        await getS3Service()
+      ).createSignedUrlForUpload(name, {
         sha256Checksum: opts.input.sha256Checksum,
         type: opts.input.type,
         size: opts.input.size,
@@ -35,7 +44,7 @@ export const createSignedUrlForUploadRoute = contractOS.file[
 export const listObjectsRoute = contractOS.file.list
   .use(adminGuard())
   .handler(async (opts) => {
-    const objects = await s3Service.listObjects();
+    const objects = await (await getS3Service()).listObjects();
     if (!objects) {
       throw opts.errors.BAD_REQUEST();
     }
@@ -51,7 +60,7 @@ export const deleteObjectRoute = contractOS.file.delete
   .use(adminGuard())
   .handler(async (opts) => {
     try {
-      await s3Service.deleteFile(opts.input.key);
+      await (await getS3Service()).deleteFile(opts.input.key);
       return { success: true };
     } catch {
       throw opts.errors.INTERNAL_SERVER_ERROR();

--- a/packages/auth/src/base-auth.ts
+++ b/packages/auth/src/base-auth.ts
@@ -4,18 +4,14 @@ import type { BetterAuthOptions } from "better-auth";
 import { magicLink } from "better-auth/plugins";
 import { admin } from "better-auth/plugins";
 import { organization } from "better-auth/plugins";
-import { Resend } from "resend";
 
 import { Role } from "@chia/db/types";
-import AuthEmailTemplate from "@chia/ui/features/AuthEmailTemplate";
 import { AUTH_EMAIL } from "@chia/utils/config";
 
 import { env } from "./env";
 import { useSecureCookies, getCookieDomain, X_CH_API_KEY } from "./utils";
 
 export const name = "auth-core";
-
-const resend = new Resend(env.RESEND_API_KEY);
 
 const getOrigin = (url?: string) => {
   if (!url) {
@@ -97,8 +93,19 @@ export const baseAuthConfig = {
 
   plugins: [
     magicLink({
+      /**
+       * `resend` and the React template are imported lazily: this config is part of
+       * every service's boot path, and a static import would pull `@react-email/render`
+       * plus the whole component library into the eager module graph for a code path
+       * that only runs when someone requests a magic link.
+       */
       sendMagicLink: async ({ email, url }) => {
-        await resend.emails.send({
+        const [{ Resend }, { default: AuthEmailTemplate }] = await Promise.all([
+          import("resend"),
+          import("@chia/ui/features/AuthEmailTemplate"),
+        ]);
+
+        await new Resend(env.RESEND_API_KEY).emails.send({
           from: AUTH_EMAIL,
           to: email,
           subject: "Sign in to Chia1104.dev",


### PR DESCRIPTION
## Why

`service` sits at a high memory baseline. Investigating a ~70 MB step on Railway showed that step was just V8 reaching its steady-state working set after a restart — not a leak — but it surfaced the real issue: **the process loads almost the whole app at boot.**

`server.ts` mounts every route into one Hono app, and `packages/api/orpc/router.ts` imports all 13 route modules to build the handler. So anything a route reaches at module scope is eager. A `POST /api/v1/rpc/content/feeds/list` — which needs drizzle and a repo — was booting the AWS SDK, react-email + react-dom, the agent runtime and three provider SDKs.

**Correction to an earlier revision of this description:** it listed a per-package RSS table measured by importing each package alone in a fresh process. Those numbers are real but they are *standalone* costs, and they are badly misleading as a guide to savings — these costs are not additive.

Measured properly (same process, cumulative):

| set | +RSS |
| --- | ---: |
| `drizzle-orm` alone | 42.9 MB |
| `better-auth` alone | 56.1 MB |
| `workflow` alone | 65.7 MB |
| all three together | **118.3 MB** (not 164.7) |
| + `hono`, `@orpc/server`, `@ai-sdk/anthropic`, `ai`, `zod` | **133.8 MB** (+15.5 for five more packages) |

The reason is that most of that RSS is not retained data. Importing `drizzle-orm` moves `heapUsed` by 0.5 MB while adding 42 MB of RSS: the rest is V8 growing its heap plus allocator arenas touched during module evaluation and never returned to the OS. A control that allocates 400k short-lived objects and then drops every one of them holds 3.5 MB live and still leaves RSS 149 MB higher after five forced GCs. Packages loaded together share that already-grown arena, so each additional one is much cheaper than it looks alone.

So the honest framing: the win here is real but modest, and it is about **deferring** work, not eliminating it.

## What changed

Each of these defers a dependency to first use; none change a public contract.

- **`packages/auth/src/base-auth.ts`** — magic-link imports `resend` and the React template inside `sendMagicLink`, matching what `packages/api/email/index.ts` already did. This was the actual source of `@react-email/render` / `react-dom` / `css-tree` in the eager graph: it comes in through the auth config, which every service boots.
- **`packages/api/orpc/routes/file.route.ts`** — S3 loaded on demand. `new S3Client()` previously ran at module scope.
- **`apps/service/src/steps/agent-turn.step.ts`** — domain runtime loaded inside the turn. Workflow steps register at boot, so their domain imports were eager by construction. The handler map is keyed by literal for the same reason, and the handler asserts the kind once its module is loaded.
- **`apps/service/src/services/agent.service.ts`** — split into registration plus `writing-agent.service.ts`. `rpc.route.ts`'s import path and symbol are unchanged.
- **`packages/ai/src/embeddings/provider.ts`** — `./openai.ts` loaded inside `embed()`. Covers `rag-indexing.service`, `resource-index.step` and `feed-indexing.step` in one place.
- **`packages/ai/src/utils/index.ts`** — this barrel mixed API-key crypto (imported by the request-auth guards) with `createModel` and its three provider SDKs. `createModel` moves to `@chia/ai/utils/model`; `authTokenSchema` is declared locally to avoid `./types`, which reaches `ai`.
- **`apps/service/src/routes/ai.route.ts`** — `createModel` and the gateway client reached through those seams.

## Result

**Eager bundled code: 10.85 MB → 6.67 MB (−39%).**

Measured marginal RSS: loading the still-eager set costs 130 MB, and adding back `@aws-sdk/client-s3`, `@react-email/render`, `pi-agent-core` and `@ai-sdk/google` costs **+23.9 MB** on top. That — plus `resend`, `pi-ai`, `react-dom`, `css-tree` and `js-tiktoken`, not in that measurement — is what no longer loads at boot. Call it roughly 25–35 MB off the steady-state baseline, not the 60–90 MB a naive sum of standalone costs would suggest.

Now lazy: `@aws-sdk/client-s3`, `@react-email/render`, `react-dom`, `css-tree`, `resend`, `pi-agent-core`, `pi-ai`, `@ai-sdk/google`.

## Deliberately not changed

- `workflow`, `better-auth`, `drizzle-orm` are genuinely needed at boot.
- **`ai` stays eager** — `baseRequestSchema` needs `modelMessageSchema` to build the `/generate` `zValidator`, which is evaluated when the route is defined. Removing it would mean giving up that validation.
- **`@ai-sdk/openai` and `@ai-sdk/anthropic` stay for a bundler reason, not a source one** — rolldown co-locates `zod` inside their chunks (`ai-sdk__openai+zod.mjs`), so drizzle importing `zod` retains them. Fixing this needs chunking config, not a source change.
- **The 2.68 MB inline sourcemap in `index.mjs` could not be removed.** `@workflow/builders` hardcodes `sourcemap: 'inline'`; neither Nitro's `sourcemap: false` nor `rollupConfig.output.sourcemap` overrides it, so no dead config was left behind.

## Verification

`pnpm type:check`, `pnpm lint` and `pnpm test` (313 passed / 2 skipped) all pass, and `service` builds. The three remaining lint warnings are byte-identical to `develop` and pre-existing.

Not verified against a running server — no local `.env` or Postgres/Redis. Worth re-reading Railway metrics an hour or two after deploy to confirm the steady-state drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added writing-agent capabilities, including streaming prompts, approvals, drafts, navigation, session management, and workflow persistence.
  * Added model creation support for OpenAI, Anthropic, and Google providers.
  * Added a reusable model utility export and authentication token validation.

* **Improvements**
  * Deferred AI, storage, email, and embedding services until needed, improving application startup efficiency.
  * Enhanced writing-agent session safety and support for pending approvals and legacy transcripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
