### PR TITLE
feat(rag): retrieval-quality eval harness + measured retrieval fixes

### DIFF
--- a/apps/service/src/services/agent-content.port.ts
+++ b/apps/service/src/services/agent-content.port.ts
@@ -27,7 +27,6 @@ import {
   ContentType as ContentTypeEnum,
   FeedType as FeedTypeEnum,
 } from "@chia/db/types";
-import type { Keyv } from "@chia/kv";
 import request from "@chia/utils/request";
 
 import { feedHooks } from "./feed-indexing.service";
@@ -59,11 +58,6 @@ interface TranslationPayload {
 
 export interface CreateContentPortOptions {
   db: DB;
-  /**
-   * Retained for callers even though search no longer caches query embeddings —
-   * the port is constructed from a workflow step that has one to hand.
-   */
-  kv?: Keyv;
   /** Already verified by `adminGuard` before the workflow run was started. */
   adminId: string;
 }
@@ -74,6 +68,14 @@ export interface CreateContentPortOptions {
  */
 const stripHighlight = (snippet: string | null): string =>
   snippet?.replaceAll(/<\/?b>/g, "") ?? "";
+
+/** A chunk is up to ~512 tokens; a search hit only needs enough to orient. */
+const SNIPPET_MAX_CHARS = 500;
+
+const truncateSnippet = (content: string): string =>
+  content.length <= SNIPPET_MAX_CHARS
+    ? content
+    : `${content.slice(0, SNIPPET_MAX_CHARS)}…`;
 
 /** Byte cap for a fetched page; `MAX_PAGE_CHARS` alone caps only after the full download. */
 const MAX_PAGE_BYTES = 2 * 1024 * 1024;
@@ -124,8 +126,13 @@ export const createAgentContentPort = (
         slug: item.slug,
         locale: (item.summary.locale ?? "zh-TW") as Locale,
         title: item.summary.title,
+        // hybrid hits carry no highlighted snippet (ParadeDB cannot combine
+        // one with the fused query), so fall back to the matched chunk's own
+        // text before the generic description — the agent needs to see *why*
+        // a post matched, not just that it did
         snippet:
           stripHighlight(item.bestChunk.snippet) ||
+          truncateSnippet(item.bestChunk.content) ||
           item.summary.description ||
           "",
         headingPath: item.bestChunk.headingPath ?? undefined,

--- a/apps/service/src/services/feed-indexing.service.ts
+++ b/apps/service/src/services/feed-indexing.service.ts
@@ -17,11 +17,11 @@ export const feedHooks: FeedHooks = {
   /**
    * Drops a feed's translations from the search index.
    *
-   * A *hard* delete needs nothing here — `feed_search_document` and
-   * `feed_embedding` both cascade from `feed_translation`. A *soft* delete is why
-   * this exists: the rows survive, so without an explicit removal the post stays
-   * searchable after being unpublished. Restoring re-emits `changed`, which
-   * rebuilds them.
+   * A *hard* delete needs nothing here — `resource_chunk` cascades from
+   * `feed_translation` and `resource_embedding` from the chunk. A *soft* delete
+   * is why this exists: the rows survive, so without an explicit removal the
+   * post stays searchable after being unpublished. Restoring re-emits
+   * `changed`, which rebuilds them.
    */
   async onFeedRemoved(translationIDs) {
     if (translationIDs.length === 0) {

--- a/apps/service/src/services/writing-agent.service.ts
+++ b/apps/service/src/services/writing-agent.service.ts
@@ -100,7 +100,6 @@ const dependenciesFor = (caller: AgentServiceCaller) => {
     draft: new PgDraftStore(db),
     content: createAgentContentPort({
       db,
-      kv: caller.context.kv,
       adminId: caller.adminId,
     }),
   };

--- a/apps/service/src/steps/agent-turn.step.ts
+++ b/apps/service/src/steps/agent-turn.step.ts
@@ -141,11 +141,9 @@ async function runWritingAgentTurn(
       WRITING_AGENT_KIND,
       WRITING_SESSION_DEFAULTS,
     },
-    kv,
   ] = await Promise.all([
     import("@chia/agent-runtime"),
     import("@chia/agent-writing"),
-    import("@chia/kv/redis").then((module) => module.getRedisKv()),
   ]);
 
   if (row.kind !== WRITING_AGENT_KIND) {
@@ -172,7 +170,7 @@ async function runWritingAgentTurn(
   });
   const session = await repo.openById(request.sessionId);
   const draft = new PgDraftStore(db);
-  const content = createAgentContentPort({ db, kv, adminId: request.adminId });
+  const content = createAgentContentPort({ db, adminId: request.adminId });
 
   const approvedToolCallIds = new Set(
     await getApprovedAgentToolCallIds(db, request.sessionId)

--- a/apps/service/src/steps/resource-index.step.ts
+++ b/apps/service/src/steps/resource-index.step.ts
@@ -79,7 +79,10 @@ export const embedPendingChunksStep = async (request: ResourceIndexRequest) => {
 
     let vectors: number[][];
     try {
-      vectors = await provider.embed(batch.map((chunk) => chunk.content));
+      vectors = await provider.embed(
+        batch.map((chunk) => chunk.content),
+        "search_document"
+      );
     } catch (error) {
       const status =
         typeof error === "object" && error !== null && "status" in error
@@ -145,6 +148,8 @@ export type ResourceIndexResult =
       status: "indexed";
       written: number;
       unchanged: number;
+      /** chunks that changed position but kept their content and vectors */
+      moved: number;
       removed: number;
       embedded: number;
     };
@@ -170,6 +175,7 @@ export const indexResource = async (
     status: "indexed",
     written: synced.written,
     unchanged: synced.unchanged,
+    moved: synced.moved,
     removed: synced.removed,
     embedded,
   };

--- a/docs/rag-architecture.md
+++ b/docs/rag-architecture.md
@@ -204,9 +204,12 @@ MDX 原文
                               （code block ≤24 行完整保留，更長則保留前 12 行 + "…"）
   → splitByHeadings()         以 heading 邊界切 section 並追蹤 heading path
                               （code fence 內的 "#" 不會被誤判成 heading）
+  → withHeadingPrefix()       把完整 heading path 接在每個 section 文字開頭
   → 小的 section 打包在一起，超過 512 token 的交給 splitOversized()
   → < 8 token 的成品丟棄（MIN_CHUNK_TOKENS）
 ```
+
+**Heading path 會烙進 chunk 的 `content` 第一行**（`"HNSW 調校 > 參數"` 這樣的一行）。`splitByHeadings` 會把 heading 行從正文剝掉，而 `content` 同時是 BM25 索引欄位和 embedding 輸入——不烙進去的話，查 heading 的字（"CSRF"、"hydrateRoot"）打不到回答它的那個 section，因為 heading 的字正是正文最不會重複的字。超長 section 切出來的每一片都各自重複這個前綴，因為每一片都是獨立的 chunk。
 
 `splitOversized` 的層級：先段落（`\n{2,}`），還是太大才用句末標點（`。．！？!?;；\n`）。切開的單位重組時會記住自己來自哪一層——同一段落內的句子用 `""` 接回去，不是 `"\n\n"`。chunk 的 `content` 會被存起來並用來產生搜尋 snippet，不是只拿去嵌入，所以重組後的文字必須跟原文一致。
 
@@ -235,13 +238,13 @@ Hybrid 的融合是兩個 CTE 各自 `row_number()` 出排名，`FULL OUTER JOIN
 ```
 chunk hits
   → aggregateChunkHits()：依 (source_type, source_id) 分組
-      分數 = 該 resource 前 3 高 chunk 的平均分
+      分數 = 前 3 高 chunk 的衰減加權和（權重 1, ¼, ¹⁄₁₆）
       bestChunk = 最高分的那個（citation / 預覽用）
   → 依分數排序、slice(limit)
   → adapter.hydrate()：批次取回 title / description / href / locale
 ```
 
-分數用「前 N 高的平均」而不是「單一最高分」：一個剛好用詞相符的段落，不應該贏過通篇都相關的文章。chunk 數不足 N 的就對現有的取平均。
+分數是**衰減加權和**而不是平均或純加總，兩個都試過、都輸給它（`toolings/scripts/rag-eval` 有數據）：平均無法獎勵廣度——多一個相關 chunk 只會拉低或持平分數，通篇相關的文章贏不了單一僥倖段落；純加總在 RRF 的平坦分數下（rank 1 ≈ 0.016、rank 30 ≈ 0.011）會讓長文章三個平庸 chunk 的總分壓過短文章一個 rank-1 chunk。衰減讓最佳 chunk 主導、廣度仍加分。
 
 `hydrate` 是每個 resource type 各自負責的一次批次查詢，並且會過濾掉已刪除的來源。它用的刪除判定必須和 `buildChunks` 索引時用的**同一個**——不一致的話 chunk 進得了結果、hydrate 卻把它丟掉，使用者只會看到少一筆。
 
@@ -275,7 +278,7 @@ full（原文全文）
 
 ### 什麼時候 bump `EMBEDDING_INDEX_VERSION`
 
-常數在 `packages/ai/src/embeddings/utils.ts`（目前 `"2026-08-11.2"`）。它和 provider id 一起構成「這個向量是用什麼算出來的」，所以以下改動要 bump：
+常數在 `packages/ai/src/embeddings/utils.ts`（目前 `"2026-08-16.1"`）。它和 provider id 一起構成「這個向量是用什麼算出來的」，所以以下改動要 bump：
 
 - 改 `cleanMdxKeepStructure` / `stripMdx` / `buildEmbeddingInput` 的前處理
 - 改 chunk 目標大小、最小 chunk 門檻、切分策略
@@ -335,4 +338,5 @@ full（原文全文）
 - **Hybrid 模式沒有 snippet**：ParadeDB 不允許 snippet 和 window function 並存，需要高亮就得用 `bm25` 模式。
 - **`feed_translation.published` / `deleted` 是會過期的鏡像**：只有 `createFeed` 會寫，`updateFeed` / `softDeleteFeed` / `restoreFeed` 都不維護。chunk 的可見性是從 `feed` 表算出來的，所以搜尋不受影響，但別把這兩欄當成真相來源。
 - **兩個沒接線的函式**：`pruneStaleEmbeddings`（`chunk.ts`）和 `buildIndexKey`（`provider.ts`）目前沒有任何呼叫端，`feed_translation.index_key` 這個欄位也不存在。
+- **HNSW 索引目前沒被用到**：這個語料量下 planner 對向量查詢選 seq scan + sort（精確結果，`EXPLAIN` 可驗證）。語料成長到 planner 改走 HNSW 時，pgvector 預設的 `hnsw.ef_search = 40` 會把過濾後的候選截到低於 hybrid 要的數量——屆時要在查詢的交易內 `SET LOCAL hnsw.ef_search`（≥ candidateLimit），並考慮 `hnsw.iterative_scan = relaxed_order`（pgvector 0.8+，現行版本支援）。
 - **Extension 不由 migration 建立**：`vector` 和 ParadeDB 的 `pg_search` 都得由資料庫本身提供，migration 沒有 `CREATE EXTENSION`。

--- a/docs/rag-architecture.md
+++ b/docs/rag-architecture.md
@@ -1,7 +1,7 @@
 # RAG 架構：Chunk、Embedding 與檢索
 
 > 狀態：現行架構（as-built）
-> 最後更新：2026-08-12
+> 最後更新：2026-08-16
 
 本文件說明部落格的檢索系統：內容如何被切成可檢索的單位、向量如何產生與儲存、查詢端如何檢索與排序，以及維護時該從哪裡改。
 
@@ -204,17 +204,20 @@ Ollama 分支目前**會在解析時直接丟錯**，因為 768 ≠ `EMBEDDING_D
 
 實作在 `packages/ai/src/embeddings/chunking.ts`，目標大小 `SECTION_CHUNK_TOKENS = 512`。
 
-```
+````
 MDX 原文
-  → cleanMdxKeepStructure()   移除 import/export 與 JSX tag；保留 heading、list、code fence
-                              （code block ≤24 行完整保留，更長則保留前 12 行 + "…"）
-  → splitByHeadings()         以 heading 邊界切 section 並追蹤 heading path
-                              （code fence 內的 "#" 不會被誤判成 heading）
+  → cleanMdxKeepStructure()   remark (mdx+gfm) 解析後按節點位置就地移除 import/export、
+                              JSX tag（保留 children）、{expression}；保留 heading、list。
+                              code fence 一律重建為 ```lang（meta 移除），≤24 行完整保留，
+                              更長則保留前 12 行 + "…"。無效 MDX 退回純 markdown 解析
+  → splitByHeadings()         以 top-level heading 邊界切 section 並追蹤 heading path
+                              （heading 標題取純文字，`code` 與 **bold** 標記會被剝掉——
+                              和渲染頁面產生 anchor 的行為一致）
   → withHeadingPrefix()       把完整 heading path 接在每個 section 文字開頭
   → 小的 section 打包在一起（不跨 top-level heading group），
     超過 512 token 的交給 splitOversized()
   → < 8 token 的成品丟棄（MIN_CHUNK_TOKENS）
-```
+````
 
 打包不跨 group，**每個 H1 / H2 heading 都是 group 邊界**：全文件貪婪打包會級聯——在開頭插一段文字就改變之後每個 chunk 的組成，所有 hash 全變，`planChunkReplacement`（§3.3）看到的是整篇改寫而不是搬移。邊界規則只看該 heading 自己的 level（刻意不做「相對全文結構」的自適應——那會讓文件他處的編輯改變 group 定義，級聯就回來了），所以一處編輯的重嵌入範圍被限制在它所在的 group。
 
@@ -287,7 +290,7 @@ full（原文全文）
 
 ### 什麼時候 bump `EMBEDDING_INDEX_VERSION`
 
-常數在 `packages/ai/src/embeddings/utils.ts`（目前 `"2026-08-16.2"`）。它和 provider id 一起構成「這個向量是用什麼算出來的」，所以以下改動要 bump：
+常數在 `packages/ai/src/embeddings/utils.ts`（目前 `"2026-08-16.3"`）。它和 provider id 一起構成「這個向量是用什麼算出來的」，所以以下改動要 bump：
 
 - 改 `cleanMdxKeepStructure` / `stripMdx` / `buildEmbeddingInput` 的前處理
 - 改 chunk 目標大小、最小 chunk 門檻、切分策略

--- a/docs/rag-architecture.md
+++ b/docs/rag-architecture.md
@@ -146,14 +146,15 @@ flowchart TD
 
 ```
 adapter.buildChunks() → 得到 card + sections，每個都帶 content_hash
-  → 在一個交易內比對現有 rows（key = kind:chunk_index）
-      hash 相同 → 只更新鏡像的可見性欄位（unchanged）
-      hash 不同 → 更新 chunk 並刪掉它的向量（written）
-      新的      → insert（written）
-      多出來的  → 刪掉（removed）
+  → planChunkReplacement()：以「內容」而非「位置」比對現有 rows
+      (kind, index, hash) 全同 → 只更新鏡像的可見性欄位（unchanged）
+      (kind, hash) 同、位置不同 → 移動 row，向量保留（moved）
+      (kind, index) 同、內容不同 → 原地改寫並刪掉向量（written）
+      配不到的新 chunk → insert（written）
+      配不到的舊 row   → 刪掉（removed）
 ```
 
-這就是「改一個段落只花一次 embedding」的原因：向量掛在 chunk 上，只有 hash 變了的 chunk 會失去向量。回傳 `{ written, unchanged, removed }`。
+Identity 是內容不是位置：以前的 key 是 `(kind, chunk_index)`，在文章前面插一段會讓後面所有 chunk 的 index 位移、逐一跟「位置上的前任」比對失敗，整條尾巴重新嵌入。改成 hash 優先配對後，位移只是 move——「改一個段落只花一次 embedding」對插入、刪除、搬動段落都成立。搬動要分兩階段落位（先停到負數 index 再放到目標位），因為 `(source, kind, chunk_index)` 的唯一索引在中間狀態可能撞到還沒搬走的 row。回傳 `{ written, unchanged, moved, removed }`。
 
 ### 3.4 `embedPendingChunksStep`：把 backlog 抽乾
 
@@ -176,9 +177,14 @@ while (true):
 interface EmbeddingProvider {
   readonly id: string; // 折進 index key，換 provider 自動使所有舊向量失效
   readonly dimensions: number;
-  embed(texts: string[]): Promise<number[][]>;
+  embed(
+    texts: string[],
+    task: "search_document" | "search_query"
+  ): Promise<number[][]>;
 }
 ```
+
+`task` 是必填：下一個值得試的模型多半是非對稱的（nomic、mxbai、e5、voyage），查詢誤用 document prefix 會安靜地劣化檢索品質，所以每個呼叫端都得聲明自己在搜尋的哪一側。對稱模型（OpenAI text-embedding-3-*）忽略它。
 
 | `EMBEDDING_PROVIDER` | provider | id                       | 維度 |
 | -------------------- | -------- | ------------------------ | ---- |
@@ -191,7 +197,7 @@ Ollama 分支目前**會在解析時直接丟錯**，因為 768 ≠ `EMBEDDING_D
 
 - **Token 保護**：`guardEmbeddingInput(s)` 是打 API 前的最後一道防線。OpenAI 用 `EMBEDDING_MAX_TOKENS`（8000，text-embedding-3 上限是 8191）；Ollama 用 per-model 的限制（mxbai 512、nomic 8192、all-minilm 256）並預留 32 token 給 task prefix，因為 prefix 是 guard 之後才接上的。
 - **Batch 切分**：`generateEmbeddings` 同時尊重「一次幾筆」（32）和「一次幾個 token」（250k）兩個上限。
-- **Task prefix**：非對稱的本地模型需要 `search_document:` / `search_query:` 前綴，由 `ollamaEmbeddings` 自動加。
+- **Task prefix**：非對稱的本地模型需要 `search_document:` / `search_query:` 前綴，`ollamaEmbeddings` 依 `embed()` 收到的 task 自動加。
 - **Tokenizer 是動態載入且 memoized 的**。`js-tiktoken` 的 cl100k_base 編碼表要 ~32MB 常駐堆積且無法釋放，所以只在「悲觀估算都超過預算」時才載。搜尋查詢上限 256 字元，永遠走估算路徑，不會把編碼表拖進長壽的 web process。估算函式（CJK 算 2 token/字、其他 0.5）刻意高估，「估算過關」就蘊含「精確計數也過關」。
 
 ## 5. Chunking
@@ -205,9 +211,12 @@ MDX 原文
   → splitByHeadings()         以 heading 邊界切 section 並追蹤 heading path
                               （code fence 內的 "#" 不會被誤判成 heading）
   → withHeadingPrefix()       把完整 heading path 接在每個 section 文字開頭
-  → 小的 section 打包在一起，超過 512 token 的交給 splitOversized()
+  → 小的 section 打包在一起（不跨 top-level heading group），
+    超過 512 token 的交給 splitOversized()
   → < 8 token 的成品丟棄（MIN_CHUNK_TOKENS）
 ```
+
+打包不跨 group，**每個 H1 / H2 heading 都是 group 邊界**：全文件貪婪打包會級聯——在開頭插一段文字就改變之後每個 chunk 的組成，所有 hash 全變，`planChunkReplacement`（§3.3）看到的是整篇改寫而不是搬移。邊界規則只看該 heading 自己的 level（刻意不做「相對全文結構」的自適應——那會讓文件他處的編輯改變 group 定義，級聯就回來了），所以一處編輯的重嵌入範圍被限制在它所在的 group。
 
 **Heading path 會烙進 chunk 的 `content` 第一行**（`"HNSW 調校 > 參數"` 這樣的一行）。`splitByHeadings` 會把 heading 行從正文剝掉，而 `content` 同時是 BM25 索引欄位和 embedding 輸入——不烙進去的話，查 heading 的字（"CSRF"、"hydrateRoot"）打不到回答它的那個 section，因為 heading 的字正是正文最不會重複的字。超長 section 切出來的每一片都各自重複這個前綴，因為每一片都是獨立的 chunk。
 
@@ -229,7 +238,7 @@ MDX 原文
 | `semantic` | 純 cosine 距離，走 HNSW                                                           |
 | `hybrid`   | 兩邊各取候選，在**一個 statement 內**用 RRF 融合                                  |
 
-Hybrid 的融合是兩個 CTE 各自 `row_number()` 出排名，`FULL OUTER JOIN`（讓只被一邊找到的 chunk 也能存活），分數是 `Σ 1/(60 + rank)`。融合後的查詢**不會**回傳 snippet：ParadeDB 不允許 `pdb.snippet()` 和 window function 同時出現。需要高亮片段時用 `bm25` 模式。
+Hybrid 的融合是兩個 CTE 各自 `row_number()` 出排名，`FULL OUTER JOIN`（讓只被一邊找到的 chunk 也能存活），分數是 `Σ 1/(60 + rank)`。融合後的查詢**不會**回傳高亮 snippet：ParadeDB 不允許 `pdb.snippet()` 和 window function 同時出現，需要 `<b>` 高亮就用 `bm25` 模式。不過每個 `ChunkHit` 都帶回 `content`（chunk 原文），所以 hybrid / semantic 的命中仍然看得到「為什麼命中」——agent 的搜尋結果就用它當 snippet 的 fallback。
 
 取數有兩層緩衝，因為 chunk 命中之後還要聚合成 resource：`searchResources` 先要 `max(limit × 6, 30)` 個 chunk，hybrid 內部再讓兩邊各取這個數字的三倍（下限 40）當融合前的候選。
 
@@ -278,7 +287,7 @@ full（原文全文）
 
 ### 什麼時候 bump `EMBEDDING_INDEX_VERSION`
 
-常數在 `packages/ai/src/embeddings/utils.ts`（目前 `"2026-08-16.1"`）。它和 provider id 一起構成「這個向量是用什麼算出來的」，所以以下改動要 bump：
+常數在 `packages/ai/src/embeddings/utils.ts`（目前 `"2026-08-16.2"`）。它和 provider id 一起構成「這個向量是用什麼算出來的」，所以以下改動要 bump：
 
 - 改 `cleanMdxKeepStructure` / `stripMdx` / `buildEmbeddingInput` 的前處理
 - 改 chunk 目標大小、最小 chunk 門檻、切分策略
@@ -337,6 +346,5 @@ full（原文全文）
 - **檢索品質基準在 `toolings/scripts/rag-eval`**：golden query + Recall@K / MRR / citation accuracy，動排序相關的程式前先跑一次留 baseline。RRF 的 `k = 60`、top-N 平均的 `N = 3` 仍未校正過。
 - **Hybrid 模式沒有 snippet**：ParadeDB 不允許 snippet 和 window function 並存，需要高亮就得用 `bm25` 模式。
 - **`feed_translation.published` / `deleted` 是會過期的鏡像**：只有 `createFeed` 會寫，`updateFeed` / `softDeleteFeed` / `restoreFeed` 都不維護。chunk 的可見性是從 `feed` 表算出來的，所以搜尋不受影響，但別把這兩欄當成真相來源。
-- **兩個沒接線的函式**：`pruneStaleEmbeddings`（`chunk.ts`）和 `buildIndexKey`（`provider.ts`）目前沒有任何呼叫端，`feed_translation.index_key` 這個欄位也不存在。
 - **HNSW 索引目前沒被用到**：這個語料量下 planner 對向量查詢選 seq scan + sort（精確結果，`EXPLAIN` 可驗證）。語料成長到 planner 改走 HNSW 時，pgvector 預設的 `hnsw.ef_search = 40` 會把過濾後的候選截到低於 hybrid 要的數量——屆時要在查詢的交易內 `SET LOCAL hnsw.ef_search`（≥ candidateLimit），並考慮 `hnsw.iterative_scan = relaxed_order`（pgvector 0.8+，現行版本支援）。
 - **Extension 不由 migration 建立**：`vector` 和 ParadeDB 的 `pg_search` 都得由資料庫本身提供，migration 沒有 `CREATE EXTENSION`。

--- a/docs/rag-architecture.md
+++ b/docs/rag-architecture.md
@@ -331,7 +331,7 @@ full（原文全文）
 
 ## 9. 已知限制
 
-- **沒有檢索品質基準**：golden query + Recall@5 / MRR 的評測腳本尚未建立。RRF 的 `k = 60`、top-N 平均的 `N = 3` 都還沒校正過。
+- **檢索品質基準在 `toolings/scripts/rag-eval`**：golden query + Recall@K / MRR / citation accuracy，動排序相關的程式前先跑一次留 baseline。RRF 的 `k = 60`、top-N 平均的 `N = 3` 仍未校正過。
 - **Hybrid 模式沒有 snippet**：ParadeDB 不允許 snippet 和 window function 並存，需要高亮就得用 `bm25` 模式。
 - **`feed_translation.published` / `deleted` 是會過期的鏡像**：只有 `createFeed` 會寫，`updateFeed` / `softDeleteFeed` / `restoreFeed` 都不維護。chunk 的可見性是從 `feed` 表算出來的，所以搜尋不受影響，但別把這兩欄當成真相來源。
 - **兩個沒接線的函式**：`pruneStaleEmbeddings`（`chunk.ts`）和 `buildIndexKey`（`provider.ts`）目前沒有任何呼叫端，`feed_translation.index_key` 這個欄位也不存在。

--- a/packages/agent-writing/src/tools/retrieval.tool.ts
+++ b/packages/agent-writing/src/tools/retrieval.tool.ts
@@ -38,7 +38,8 @@ export const searchPostsTool = defineTool({
     "Search existing published posts. Use this BEFORE writing anything new: it is how you avoid " +
     "duplicating a post that already exists, and how you find posts worth cross-linking. " +
     "`semantic` matches on meaning (best for topics); `keyword` matches on literal terms (best for " +
-    "names, APIs, error messages).",
+    "names, APIs, error messages). Each hit's `headingPath` names the section that matched — pass " +
+    "it to `get_post`'s `focusHeadings` to read that section first.",
   parameters: Type.Object({
     keyword: Type.String({
       description: "The topic or phrase to look for.",
@@ -102,6 +103,13 @@ export const getPostTool = defineTool({
     locale: Type.Optional(
       LocaleSchema("Return only this locale. Omit for all locales.")
     ),
+    focusHeadings: Type.Optional(
+      Type.Array(Type.String(), {
+        description:
+          "Heading paths (from search results' `headingPath`) to keep first when the post is too " +
+          "long to return in full.",
+      })
+    ),
   }),
   executionMode: "parallel",
   async execute(_toolCallId, params, _signal, _onUpdate, context) {
@@ -140,6 +148,9 @@ export const getPostTool = defineTool({
         title: translation.title,
         summary: translation.summary ?? translation.description,
         content: translation.content ?? "",
+        // when the body degrades to sections, the ones the search matched
+        // survive first instead of whichever happens to fit
+        matchedHeadingPaths: params.focusHeadings,
       })),
       { budget: POST_BODY_TOKEN_BUDGET }
     );

--- a/packages/ai/__tests__/embeddings-context.spec.mts
+++ b/packages/ai/__tests__/embeddings-context.spec.mts
@@ -28,8 +28,10 @@ const long = (sections: number, repeat: number) =>
   ).join("\n\n");
 
 describe("buildHeadingAnchors", () => {
-  it("produces github-style anchors per heading", () => {
-    const anchors = buildHeadingAnchors("# Hello World\n\n## ef_search 調校");
+  it("produces github-style anchors per heading", async () => {
+    const anchors = await buildHeadingAnchors(
+      "# Hello World\n\n## ef_search 調校"
+    );
     expect(anchors.map((anchor) => anchor.anchor)).toEqual([
       "#hello-world",
       "#ef_search-調校",
@@ -37,14 +39,14 @@ describe("buildHeadingAnchors", () => {
     expect(anchors[1]?.path).toBe("Hello World > ef_search 調校");
   });
 
-  it("restarts numbering per document so repeated headings do not drift", () => {
+  it("restarts numbering per document so repeated headings do not drift", async () => {
     const content = "## Setup\n\ntext\n\n## Setup\n\ntext";
-    expect(buildHeadingAnchors(content).map((a) => a.anchor)).toEqual([
+    expect((await buildHeadingAnchors(content)).map((a) => a.anchor)).toEqual([
       "#setup",
       "#setup-1",
     ]);
     // a second call must behave identically, not continue from -1
-    expect(buildHeadingAnchors(content).map((a) => a.anchor)).toEqual([
+    expect((await buildHeadingAnchors(content)).map((a) => a.anchor)).toEqual([
       "#setup",
       "#setup-1",
     ]);
@@ -144,7 +146,9 @@ describe("buildDocumentContext", () => {
       { budget: 4000 }
     );
     // the second document still made it in
-    expect(result.documents.map((document) => document.slug)).toContain("small");
+    expect(result.documents.map((document) => document.slug)).toContain(
+      "small"
+    );
     expect(result.droppedSlugs).toEqual([]);
   });
 

--- a/packages/ai/__tests__/embeddings-document-card.spec.mts
+++ b/packages/ai/__tests__/embeddings-document-card.spec.mts
@@ -194,4 +194,34 @@ describe("chunkMarkdown", () => {
   it("returns nothing for empty content", async () => {
     expect(await chunkMarkdown({ content: "   ", encoding })).toEqual([]);
   });
+
+  it("does not pack across top-level groups, so an edit cannot cascade", async () => {
+    const groups = Array.from(
+      { length: 3 },
+      (_, index) =>
+        `## 主題 ${index}\n\n第一段。\n\n### 主題 ${index} 的細節\n\n第二段。`
+    ).join("\n\n");
+
+    const before = await chunkMarkdown({ content: groups, encoding });
+    // small sections still pack within their group, never across groups
+    for (const chunk of before) {
+      const tops = new Set(
+        chunk.headingPaths.map((path) => path.split(" > ")[0])
+      );
+      expect(tops.size).toBe(1);
+    }
+
+    // prepending a whole new group must leave every later group's chunk
+    // byte-identical — that is what lets replaceResourceChunks treat them as
+    // moves and keep their vectors
+    const after = await chunkMarkdown({
+      content: `## 新主題\n\n新的段落。\n\n${groups}`,
+      encoding,
+    });
+    const beforeContents = new Set(before.map((chunk) => chunk.content));
+    const surviving = after.filter((chunk) =>
+      beforeContents.has(chunk.content)
+    );
+    expect(surviving).toHaveLength(before.length);
+  });
 });

--- a/packages/ai/__tests__/embeddings-document-card.spec.mts
+++ b/packages/ai/__tests__/embeddings-document-card.spec.mts
@@ -1,7 +1,10 @@
 import { getEncoding } from "js-tiktoken";
 import { describe, expect, it } from "vitest";
 
-import { chunkMarkdown, SECTION_CHUNK_TOKENS } from "../src/embeddings/chunking";
+import {
+  chunkMarkdown,
+  SECTION_CHUNK_TOKENS,
+} from "../src/embeddings/chunking";
 import {
   buildHeadingOutline,
   extractHeadings,
@@ -164,6 +167,27 @@ describe("chunkMarkdown", () => {
     expect(chunks.length).toBeGreaterThan(1);
     for (const chunk of chunks) {
       expect(chunk.tokenCount).toBeLessThan(SECTION_CHUNK_TOKENS * 2);
+    }
+  });
+
+  it("bakes the heading path into every chunk's content", async () => {
+    const chunks = await chunkMarkdown({ content: ARTICLE, encoding });
+    const hnswChunk = chunks.find((chunk) =>
+      chunk.headingPaths.some((path) => path.includes("HNSW 調校"))
+    );
+
+    // the section body never mentions its own heading — only the baked-in
+    // prefix makes the chunk findable by the heading's words
+    expect(hnswChunk?.content).toContain("向量搜尋與嵌入技術 > HNSW 調校");
+
+    const splitChunks = await chunkMarkdown({
+      content: `## 只有一節\n\n${"很長的一段內文。".repeat(2000)}`,
+      encoding,
+    });
+    // every piece of an oversized section repeats the prefix — each is its own
+    // chunk and must carry the heading context itself
+    for (const chunk of splitChunks) {
+      expect(chunk.content.startsWith("只有一節\n\n")).toBe(true);
     }
   });
 

--- a/packages/ai/__tests__/embeddings-document-card.spec.mts
+++ b/packages/ai/__tests__/embeddings-document-card.spec.mts
@@ -44,8 +44,8 @@ SET hnsw.ef_search = 100;
 `;
 
 describe("extractHeadings", () => {
-  it("tracks ancestor paths and ignores headings inside code fences", () => {
-    const headings = extractHeadings(ARTICLE);
+  it("tracks ancestor paths and ignores headings inside code fences", async () => {
+    const headings = await extractHeadings(ARTICLE);
     expect(headings.map((heading) => heading.path)).toEqual([
       "向量搜尋與嵌入技術",
       "向量搜尋與嵌入技術 > 什麼是 embedding",
@@ -57,8 +57,8 @@ describe("extractHeadings", () => {
 });
 
 describe("buildHeadingOutline", () => {
-  it("indents relative to the shallowest kept level and honours maxDepth", () => {
-    expect(buildHeadingOutline(ARTICLE)).toBe(
+  it("indents relative to the shallowest kept level and honours maxDepth", async () => {
+    expect(await buildHeadingOutline(ARTICLE)).toBe(
       [
         "- 向量搜尋與嵌入技術",
         "  - 什麼是 embedding",
@@ -68,14 +68,14 @@ describe("buildHeadingOutline", () => {
     );
   });
 
-  it("returns empty for content without headings", () => {
-    expect(buildHeadingOutline("just a paragraph")).toBe("");
+  it("returns empty for content without headings", async () => {
+    expect(await buildHeadingOutline("just a paragraph")).toBe("");
   });
 });
 
 describe("buildEmbeddingInput (document card)", () => {
-  it("builds a card from title, summary, tags and outline", () => {
-    const card = buildEmbeddingInput({
+  it("builds a card from title, summary, tags and outline", async () => {
+    const card = await buildEmbeddingInput({
       title: "向量搜尋",
       summary: "介紹 pgvector 與 HNSW。",
       tags: ["postgres", "rag"],
@@ -87,8 +87,8 @@ describe("buildEmbeddingInput (document card)", () => {
     expect(card).toContain("Outline:\n- 向量搜尋與嵌入技術");
   });
 
-  it("does not embed the body when a summary and outline exist", () => {
-    const card = buildEmbeddingInput({
+  it("does not embed the body when a summary and outline exist", async () => {
+    const card = await buildEmbeddingInput({
       title: "向量搜尋",
       summary: "介紹 pgvector 與 HNSW。",
       content: ARTICLE,
@@ -97,10 +97,10 @@ describe("buildEmbeddingInput (document card)", () => {
     expect(card).not.toContain("前言段落");
   });
 
-  it("stays bounded no matter how long the article is", () => {
+  it("stays bounded no matter how long the article is", async () => {
     // 500 copies of the body under the same outline: the card must not grow
     const long = ARTICLE + "\n\n" + "很長的內文段落。".repeat(5000);
-    const card = buildEmbeddingInput({
+    const card = await buildEmbeddingInput({
       title: "向量搜尋",
       summary: "介紹 pgvector 與 HNSW。",
       content: long,
@@ -108,17 +108,25 @@ describe("buildEmbeddingInput (document card)", () => {
     expect(tokens(card)).toBeLessThan(500);
   });
 
-  it("falls back through summary → description → excerpt", () => {
+  it("falls back through summary → description → excerpt", async () => {
     expect(
-      buildEmbeddingInput({ title: "t", description: "desc", content: ARTICLE })
+      await buildEmbeddingInput({
+        title: "t",
+        description: "desc",
+        content: ARTICLE,
+      })
     ).toContain("Summary: desc");
     expect(
-      buildEmbeddingInput({ title: "t", excerpt: "exc", content: ARTICLE })
+      await buildEmbeddingInput({
+        title: "t",
+        excerpt: "exc",
+        content: ARTICLE,
+      })
     ).toContain("Summary: exc");
   });
 
-  it("uses a bounded body excerpt only when there is no summary and no outline", () => {
-    const card = buildEmbeddingInput({
+  it("uses a bounded body excerpt only when there is no summary and no outline", async () => {
+    const card = await buildEmbeddingInput({
       title: "t",
       content: "沒有標題的純文字內容。".repeat(2000),
     });

--- a/packages/ai/__tests__/embeddings.spec.mts
+++ b/packages/ai/__tests__/embeddings.spec.mts
@@ -1,4 +1,4 @@
-import { stripMdx } from "../src/embeddings/utils";
+import { stripMdx } from "../src/embeddings/markdown";
 
 const CONTENT = `
 # Heading 1 - Foo
@@ -42,10 +42,12 @@ console.log('Hello World');
 `;
 
 describe("stripMdx", () => {
-  it("should strip mdx tags from a string", () => {
-    const result = stripMdx(CONTENT);
+  it("flattens MDX to plain prose without code or markup", async () => {
+    const result = await stripMdx(CONTENT);
     expect(result).toBe(
-      "Heading 1 - Foo Heading 2 - Bar Heading 3 - Baz Heading 4 Hello World, Bold, Italic, Hidden Hello World 1. First 2. Second 3. Third Item 1 Item 2 Quote here chia1104 Image | Table | Description | | ----- | ----------- | | Hello | World | | foo | bar | Javascript is weird Rust is fast"
+      "Heading 1 - Foo Heading 2 - Bar Heading 3 - Baz Heading 4 Hello World, Bold, Italic, Hidden Hello World First Second Third Item 1 Item 2 Quote here chia1104 Image Table Description Hello World foo bar Javascript is weird Rust is fast"
     );
+    // fenced code must not reach the topic vector
+    expect(result).not.toContain("console.log");
   });
 });

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -91,13 +91,20 @@
     "ai": "catalog:ai",
     "github-slugger": "^2.0.0",
     "js-tiktoken": "^1.0.21",
+    "mdast-util-to-string": "catalog:",
     "next": "catalog:next",
     "ollama": "catalog:ai",
     "openai": "catalog:ai",
+    "remark-gfm": "catalog:",
+    "remark-mdx": "catalog:",
+    "remark-parse": "catalog:",
+    "unified": "catalog:",
+    "unist-util-visit": "catalog:",
     "zod": "catalog:"
   },
   "devDependencies": {
     "@chiastack/tsconfig": "catalog:chiastack",
+    "@types/mdast": "catalog:",
     "@types/node": "catalog:",
     "typescript": "catalog:"
   }

--- a/packages/ai/src/embeddings/chunking.ts
+++ b/packages/ai/src/embeddings/chunking.ts
@@ -117,10 +117,23 @@ const splitOversized = (
 };
 
 /**
+ * A section's heading path, baked into the chunk text as its first line.
+ *
+ * `splitByHeadings` strips heading lines, and the chunk `content` is what gets
+ * embedded and BM25-indexed — without this, a query for the heading's words
+ * ("CSRF", "hydrateRoot") cannot reach the section that answers it, because
+ * headings are precisely the words a body rarely repeats. The full ancestor
+ * path rather than the leaf, so "參數" arrives as "HNSW 調校 > 參數".
+ */
+const withHeadingPrefix = (headingPath: string | null, text: string): string =>
+  headingPath ? `${headingPath}\n\n${text}` : text;
+
+/**
  * Splits a document into section chunks at heading boundaries, packing small
  * sections together and splitting oversized ones.
  *
- * `headingPath` is carried through for citation anchors.
+ * `headingPath` is carried through for citation anchors, and additionally
+ * prefixed onto each section's text (see `withHeadingPrefix`).
  */
 export const chunkMarkdown = async (params: {
   content: string;
@@ -166,16 +179,25 @@ export const chunkMarkdown = async (params: {
   };
 
   for (const section of splitByHeadings(cleaned)) {
-    const sectionTokens = countEmbeddingTokens(section.text, encoding);
+    const text = withHeadingPrefix(section.headingPath, section.text);
+    const sectionTokens = countEmbeddingTokens(text, encoding);
 
     if (sectionTokens > targetTokens) {
       flush();
+      // every piece repeats the prefix — each becomes its own chunk and must
+      // carry the heading context itself — so the split budget pays for it
+      const prefixTokens = section.headingPath
+        ? sectionTokens - countEmbeddingTokens(section.text, encoding)
+        : 0;
       for (const piece of splitOversized(
         section.text,
-        targetTokens,
+        Math.max(targetTokens - prefixTokens, 1),
         encoding
       )) {
-        buffer.push({ headingPath: section.headingPath, text: piece });
+        buffer.push({
+          headingPath: section.headingPath,
+          text: withHeadingPrefix(section.headingPath, piece),
+        });
         flush();
       }
       continue;
@@ -184,7 +206,7 @@ export const chunkMarkdown = async (params: {
     if (bufferTokens + sectionTokens > targetTokens) {
       flush();
     }
-    buffer.push({ headingPath: section.headingPath, text: section.text });
+    buffer.push({ headingPath: section.headingPath, text });
     bufferTokens += sectionTokens;
   }
   flush();

--- a/packages/ai/src/embeddings/chunking.ts
+++ b/packages/ai/src/embeddings/chunking.ts
@@ -129,8 +129,21 @@ const withHeadingPrefix = (headingPath: string | null, text: string): string =>
   headingPath ? `${headingPath}\n\n${text}` : text;
 
 /**
+ * Headings at or above this level start a new pack group.
+ *
+ * Packing may not cross group boundaries, because a greedy pack over the whole
+ * document cascades: text inserted at the top changes which sections land in
+ * every later chunk, so every hash changes and `planChunkReplacement` sees a
+ * full rewrite instead of moves. A boundary at every H1/H2 bounds that cascade
+ * to one group — and the rule reads only the heading's own level, so an edit
+ * elsewhere in the document can never change where a group starts.
+ */
+const GROUP_BOUNDARY_LEVEL = 2;
+
+/**
  * Splits a document into section chunks at heading boundaries, packing small
- * sections together and splitting oversized ones.
+ * sections together (never across an H1/H2 boundary — see
+ * `GROUP_BOUNDARY_LEVEL`) and splitting oversized ones.
  *
  * `headingPath` is carried through for citation anchors, and additionally
  * prefixed onto each section's text (see `withHeadingPrefix`).
@@ -179,6 +192,10 @@ export const chunkMarkdown = async (params: {
   };
 
   for (const section of splitByHeadings(cleaned)) {
+    if (section.level !== null && section.level <= GROUP_BOUNDARY_LEVEL) {
+      flush();
+    }
+
     const text = withHeadingPrefix(section.headingPath, section.text);
     const sectionTokens = countEmbeddingTokens(text, encoding);
 

--- a/packages/ai/src/embeddings/chunking.ts
+++ b/packages/ai/src/embeddings/chunking.ts
@@ -153,7 +153,7 @@ export const chunkMarkdown = async (params: {
   targetTokens?: number;
   encoding?: Tiktoken | null;
 }): Promise<MarkdownChunk[]> => {
-  const cleaned = cleanMdxKeepStructure(params.content);
+  const cleaned = await cleanMdxKeepStructure(params.content);
   if (!cleaned) {
     return [];
   }
@@ -191,7 +191,7 @@ export const chunkMarkdown = async (params: {
     bufferTokens = 0;
   };
 
-  for (const section of splitByHeadings(cleaned)) {
+  for (const section of await splitByHeadings(cleaned)) {
     if (section.level !== null && section.level <= GROUP_BOUNDARY_LEVEL) {
       flush();
     }

--- a/packages/ai/src/embeddings/context.ts
+++ b/packages/ai/src/embeddings/context.ts
@@ -78,12 +78,12 @@ export interface BuildContextResult {
  * `#setup` for one the page renders as `#setup-1`. A fresh instance per
  * document, since the rendered page starts from scratch too.
  */
-export const buildHeadingAnchors = (
+export const buildHeadingAnchors = async (
   content: string,
   keepPaths?: ReadonlySet<string>
-): HeadingAnchor[] => {
+): Promise<HeadingAnchor[]> => {
   const slugger = new GithubSlugger();
-  const anchors = extractHeadings(content).map((heading) => ({
+  const anchors = (await extractHeadings(content)).map((heading) => ({
     path: heading.path,
     title: heading.title,
     anchor: `#${slugger.slug(heading.title)}`,
@@ -118,12 +118,12 @@ const truncateTokens = (
  * Sections whose heading path was matched by the retriever, in match order,
  * then the rest — so degrading keeps the parts the query actually hit.
  */
-const buildSectionsView = (
+const buildSectionsView = async (
   input: DocumentContextInput,
   maxTokens: number,
   encoding: Awaited<ReturnType<typeof tryLoadTokenizer>>
-): { text: string; keptPaths: Set<string> } => {
-  const sections = splitByHeadings(input.content);
+): Promise<{ text: string; keptPaths: Set<string> }> => {
+  const sections = await splitByHeadings(input.content);
   const matched = new Set(
     (input.matchedHeadingPaths ?? []).filter((path): path is string => !!path)
   );
@@ -160,10 +160,10 @@ const buildSectionsView = (
 };
 
 /** Cheapest representation: what the post is about and how it is organised. */
-const buildOutlineView = (input: DocumentContextInput): string =>
+const buildOutlineView = async (input: DocumentContextInput): Promise<string> =>
   [
     input.summary?.trim() ? input.summary.trim() : null,
-    buildHeadingOutline(input.content),
+    await buildHeadingOutline(input.content),
   ]
     .filter((part): part is string => !!part)
     .join("\n\n");
@@ -200,7 +200,8 @@ export const buildDocumentContext = async (
       Math.max(1, Math.floor(budget * MAX_SHARE_PER_DOCUMENT))
     );
 
-    const sections = buildSectionsView(input, allowance, encoding);
+    const sections = await buildSectionsView(input, allowance, encoding);
+    const outlineView = await buildOutlineView(input);
     // anchors always come from the untouched document, so their slugs match the
     // rendered page whichever view survives; `keepPaths` narrows them to what
     // the view actually contains
@@ -215,7 +216,7 @@ export const buildDocumentContext = async (
         text: sections.text,
         keepPaths: sections.keptPaths,
       },
-      { detail: "outline", text: buildOutlineView(input) },
+      { detail: "outline", text: outlineView },
     ];
 
     let chosen: DocumentContext | null = null;
@@ -232,7 +233,10 @@ export const buildDocumentContext = async (
           detail: candidate.detail,
           text: candidate.text,
           tokenCount: cost,
-          anchors: buildHeadingAnchors(input.content, candidate.keepPaths),
+          anchors: await buildHeadingAnchors(
+            input.content,
+            candidate.keepPaths
+          ),
         };
         break;
       }
@@ -242,7 +246,7 @@ export const buildDocumentContext = async (
     // document, so the model at least knows the post exists
     if (!chosen) {
       const text = truncateTokens(
-        buildOutlineView(input) || input.title,
+        outlineView || input.title,
         allowance,
         encoding
       );

--- a/packages/ai/src/embeddings/markdown.ts
+++ b/packages/ai/src/embeddings/markdown.ts
@@ -1,23 +1,157 @@
 /**
- * Pure MDX/Markdown structure helpers.
+ * MDX/Markdown structure helpers, built on the remark parser (mdast).
  *
  * Kept separate from `chunking.ts` so the concerns stay apart: this module is
  * about document structure (the document card in `utils.ts`, citation anchors
  * at read time), `chunking.ts` is about turning that structure into vectors.
+ *
+ * Parser, not regexes: the corpus is MDX, and the regex predecessor missed
+ * multi-line JSX opening tags, left `{expressions}` in chunk text, and failed
+ * to condense fences carrying a meta string (```ts title="x"). Everything here
+ * works on node positions over the original source, so the surviving text is
+ * the author's text, not a re-serialization.
+ *
+ * The parser stack is imported dynamically per call: these helpers sit under
+ * `utils.ts`, whose constants are on the boot path of every process that
+ * touches embeddings, and micromark + acorn have no business in a boot.
  */
+import type { Code, Heading, Root, RootContent } from "mdast";
 
 /** Code blocks up to this many lines are kept verbatim in chunks. */
 const MAX_CODE_BLOCK_LINES = 24;
 /** Longer code blocks keep their head — identifiers, imports, comments live there. */
 const CODE_BLOCK_HEAD_LINES = 12;
 
-const condenseCodeBlock = (lang: string, code: string): string => {
-  const lines = code.replace(/\s+$/, "").split("\n");
+const loadParser = async () => {
+  const [{ unified }, parse, gfm, mdx, { toString: mdastToString }] =
+    await Promise.all([
+      import("unified"),
+      import("remark-parse"),
+      import("remark-gfm"),
+      import("remark-mdx"),
+      import("mdast-util-to-string"),
+    ]);
+  return {
+    mdx: unified().use(parse.default).use(gfm.default).use(mdx.default),
+    md: unified().use(parse.default).use(gfm.default),
+    toString: mdastToString,
+  };
+};
+
+type Parser = Awaited<ReturnType<typeof loadParser>>;
+
+/**
+ * Parses as MDX, falling back to plain markdown when the source is not valid
+ * MDX (a stray `<` or an unclosed tag throws in remark-mdx). The fallback
+ * keeps indexing alive for a malformed post — JSX degrades to text — instead
+ * of failing the whole run.
+ */
+const parseDocument = (parser: Parser, source: string): Root => {
+  try {
+    return parser.mdx.parse(source);
+  } catch (error) {
+    console.warn(
+      "[embeddings] source is not valid MDX, parsing as markdown",
+      error
+    );
+    return parser.md.parse(source);
+  }
+};
+
+interface SourceEdit {
+  start: number;
+  end: number;
+  replacement: string;
+}
+
+const spanOf = (node: {
+  position?: { start: { offset?: number }; end: { offset?: number } };
+}): { start: number; end: number } | null => {
+  const start = node.position?.start.offset;
+  const end = node.position?.end.offset;
+  return start === undefined || end === undefined ? null : { start, end };
+};
+
+const condenseCodeBlock = (node: Code): string => {
+  const lines = node.value.replace(/\s+$/, "").split("\n");
   const kept =
     lines.length <= MAX_CODE_BLOCK_LINES
       ? lines
       : [...lines.slice(0, CODE_BLOCK_HEAD_LINES), "…"];
-  return ["```" + lang, ...kept, "```"].join("\n");
+  return ["```" + (node.lang ?? ""), ...kept, "```"].join("\n");
+};
+
+/**
+ * Collects the source edits that turn MDX into plain markdown, walking the
+ * tree recursively. JSX elements and links lose only their tag/wrapper spans,
+ * so edits inside their children stay disjoint and everything can be applied
+ * in one back-to-front pass.
+ */
+const collectCleanEdits = (nodes: RootContent[], edits: SourceEdit[]): void => {
+  for (const node of nodes) {
+    const span = spanOf(node);
+    if (!span) {
+      continue;
+    }
+
+    switch (node.type) {
+      case "mdxjsEsm":
+      case "mdxFlowExpression":
+      case "mdxTextExpression":
+        edits.push({ ...span, replacement: "" });
+        continue;
+      case "mdxJsxFlowElement":
+      case "mdxJsxTextElement": {
+        const first = node.children[0] && spanOf(node.children[0]);
+        const last =
+          node.children[node.children.length - 1] &&
+          spanOf(node.children[node.children.length - 1]!);
+        if (first && last) {
+          edits.push({ start: span.start, end: first.start, replacement: "" });
+          edits.push({ start: last.end, end: span.end, replacement: "" });
+          collectCleanEdits(node.children, edits);
+        } else {
+          // no children (or none with a position) — drop the element whole
+          edits.push({ ...span, replacement: "" });
+        }
+        continue;
+      }
+      case "code":
+        // always rebuilt: normalizes the fence and drops the meta string
+        // (```ts title="…"), which is markup noise to BM25 and the embedding
+        edits.push({ ...span, replacement: condenseCodeBlock(node) });
+        continue;
+      case "image":
+      case "imageReference":
+        edits.push({ ...span, replacement: node.alt ?? "" });
+        continue;
+      case "link": {
+        const first = node.children[0] && spanOf(node.children[0]);
+        const last =
+          node.children[node.children.length - 1] &&
+          spanOf(node.children[node.children.length - 1]!);
+        if (first && last) {
+          edits.push({ start: span.start, end: first.start, replacement: "" });
+          edits.push({ start: last.end, end: span.end, replacement: "" });
+          collectCleanEdits(node.children, edits);
+        } else {
+          edits.push({ ...span, replacement: "" });
+        }
+        continue;
+      }
+      case "html": {
+        // raw HTML only appears on the plain-markdown fallback path; keep the
+        // inner text, drop the tags
+        const text = node.value.replace(/<\/?[A-Za-z][^>]*>/g, "");
+        edits.push({ ...span, replacement: text });
+        continue;
+      }
+      default:
+        if ("children" in node) {
+          collectCleanEdits(node.children as RootContent[], edits);
+        }
+    }
+  }
 };
 
 /**
@@ -26,17 +160,29 @@ const condenseCodeBlock = (lang: string, code: string): string => {
  * document vectors), this keeps code content — function names, CLI commands,
  * and error messages are exactly what technical queries search for.
  */
-export const cleanMdxKeepStructure = (source: string): string => {
-  return source
-    .replace(/^(?:import|export)\s[^\n]*$/gm, "") // ESM statements
-    .replace(/```(\w*)\n([\s\S]*?)```/g, (_match, lang: string, code: string) =>
-      condenseCodeBlock(lang, code)
-    )
-    .replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1") // images -> alt text
-    .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1") // links -> label
-    .replace(/<\/?[A-Za-z][^>\n]*>/g, "") // JSX / HTML tags, keep children
-    .replace(/\n{3,}/g, "\n\n")
-    .trim();
+export const cleanMdxKeepStructure = async (
+  source: string
+): Promise<string> => {
+  const parser = await loadParser();
+  const tree = parseDocument(parser, source);
+
+  const edits: SourceEdit[] = [];
+  collectCleanEdits(tree.children, edits);
+  edits.sort((a, b) => b.start - a.start);
+
+  let cleaned = source;
+  let lastAppliedStart = Number.POSITIVE_INFINITY;
+  for (const edit of edits) {
+    // edits are disjoint by construction; skip rather than corrupt if not
+    if (edit.end > lastAppliedStart) {
+      continue;
+    }
+    cleaned =
+      cleaned.slice(0, edit.start) + edit.replacement + cleaned.slice(edit.end);
+    lastAppliedStart = edit.start;
+  }
+
+  return cleaned.replace(/\n{3,}/g, "\n\n").trim();
 };
 
 export interface MarkdownSection {
@@ -48,52 +194,46 @@ export interface MarkdownSection {
 
 export interface MarkdownHeading {
   level: number;
+  /** plain text, markers stripped — what the rendered page slugs */
   title: string;
   /** `"HNSW > ef_search"` — ancestors joined with the heading itself */
   path: string;
 }
 
-// `[ \t]+` rather than `\s+`: both run per line, and `\s+` next to `(.+)` is a
-// polynomial-backtracking pattern on a line of nothing but spaces
-const HEADING_REGEX = /^(#{1,6})[ \t]+(.+)$/;
-const FENCE_REGEX = /^[ \t]*```/;
-
-/**
- * Walks lines, tracking fenced code blocks so a `# comment` inside a shell
- * snippet is never mistaken for a heading.
- */
-const forEachHeadingLine = (
-  content: string,
-  visit: (heading: { level: number; title: string }) => void,
-  onBody?: (line: string) => void
+const walkHeadings = (
+  nodes: RootContent[],
+  parser: Parser,
+  visit: (heading: Heading, title: string) => void
 ): void => {
-  let insideCodeFence = false;
-
-  for (const line of content.split("\n")) {
-    if (FENCE_REGEX.test(line)) {
-      insideCodeFence = !insideCodeFence;
+  for (const node of nodes) {
+    if (node.type === "heading") {
+      visit(node, parser.toString(node).trim());
+    } else if ("children" in node && node.type !== "mdxJsxTextElement") {
+      walkHeadings(node.children as RootContent[], parser, visit);
     }
-    const heading = insideCodeFence ? null : HEADING_REGEX.exec(line);
-    if (heading?.[1] && heading[2]) {
-      visit({ level: heading[1].length, title: heading[2].trim() });
-      continue;
-    }
-    onBody?.(line);
   }
 };
 
 /** Every heading in document order, each with its ancestor path. */
-export const extractHeadings = (content: string): MarkdownHeading[] => {
+export const extractHeadings = async (
+  content: string
+): Promise<MarkdownHeading[]> => {
+  const parser = await loadParser();
+  const tree = parseDocument(parser, content);
+
   const headings: MarkdownHeading[] = [];
   const stack: { level: number; title: string }[] = [];
 
-  forEachHeadingLine(content, ({ level, title }) => {
-    while (stack.length > 0 && stack[stack.length - 1]!.level >= level) {
+  walkHeadings(tree.children, parser, (heading, title) => {
+    while (
+      stack.length > 0 &&
+      stack[stack.length - 1]!.level >= heading.depth
+    ) {
       stack.pop();
     }
-    stack.push({ level, title });
+    stack.push({ level: heading.depth, title });
     headings.push({
-      level,
+      level: heading.depth,
       title,
       path: stack.map((entry) => entry.title).join(" > "),
     });
@@ -102,39 +242,53 @@ export const extractHeadings = (content: string): MarkdownHeading[] => {
   return headings;
 };
 
-/** Splits cleaned markdown into sections at heading boundaries, tracking the heading path. */
-export const splitByHeadings = (content: string): MarkdownSection[] => {
+/**
+ * Splits markdown into sections at top-level heading boundaries, tracking the
+ * heading path. Expects cleaned input (`cleanMdxKeepStructure`); sections are
+ * verbatim slices of it, so chunk text stays the author's text.
+ */
+export const splitByHeadings = async (
+  content: string
+): Promise<MarkdownSection[]> => {
+  const parser = await loadParser();
+  const tree = parseDocument(parser, content);
+
   const sections: MarkdownSection[] = [];
-  const headingStack: { level: number; title: string }[] = [];
-  let buffer: string[] = [];
+  const stack: { level: number; title: string }[] = [];
+  let range: { start: number; end: number } | null = null;
 
   const flush = () => {
-    const text = buffer.join("\n").trim();
+    if (!range) {
+      return;
+    }
+    const text = content.slice(range.start, range.end).trim();
     if (text) {
       sections.push({
-        headingPath:
-          headingStack.map((heading) => heading.title).join(" > ") || null,
-        level: headingStack[headingStack.length - 1]?.level ?? null,
+        headingPath: stack.map((entry) => entry.title).join(" > ") || null,
+        level: stack[stack.length - 1]?.level ?? null,
         text,
       });
     }
-    buffer = [];
+    range = null;
   };
 
-  forEachHeadingLine(
-    content,
-    ({ level, title }) => {
+  for (const node of tree.children) {
+    if (node.type === "heading") {
       flush();
-      while (
-        headingStack.length > 0 &&
-        headingStack[headingStack.length - 1]!.level >= level
-      ) {
-        headingStack.pop();
+      while (stack.length > 0 && stack[stack.length - 1]!.level >= node.depth) {
+        stack.pop();
       }
-      headingStack.push({ level, title });
-    },
-    (line) => buffer.push(line)
-  );
+      stack.push({ level: node.depth, title: parser.toString(node).trim() });
+      continue;
+    }
+    const span = spanOf(node);
+    if (!span) {
+      continue;
+    }
+    range = range
+      ? { start: range.start, end: span.end }
+      : { start: span.start, end: span.end };
+  }
   flush();
 
   return sections;
@@ -154,14 +308,14 @@ export interface HeadingOutlineOptions {
  * rather than document *length* — a 20k-token article and a 2k-token article
  * with the same outline produce the same size input.
  */
-export const buildHeadingOutline = (
+export const buildHeadingOutline = async (
   content: string,
   options: HeadingOutlineOptions = {}
-): string => {
+): Promise<string> => {
   const maxDepth = options.maxDepth ?? 3;
   const maxHeadings = options.maxHeadings ?? 40;
 
-  const headings = extractHeadings(content).filter(
+  const headings = (await extractHeadings(content)).filter(
     (heading) => heading.level <= maxDepth
   );
   if (headings.length === 0) {
@@ -178,4 +332,48 @@ export const buildHeadingOutline = (
       (heading) => `${"  ".repeat(heading.level - baseLevel)}- ${heading.title}`
     )
     .join("\n");
+};
+
+const STRIP_SKIP_TYPES = new Set([
+  "code",
+  "mdxjsEsm",
+  "mdxFlowExpression",
+  "mdxTextExpression",
+]);
+
+/** Block types flattened whole, so inline punctuation keeps its spacing. */
+const STRIP_TEXT_BLOCK_TYPES = new Set(["paragraph", "heading", "tableCell"]);
+
+const collectPlainText = (
+  nodes: RootContent[],
+  parser: Parser,
+  parts: string[]
+): void => {
+  for (const node of nodes) {
+    if (STRIP_SKIP_TYPES.has(node.type)) {
+      continue;
+    }
+    if (STRIP_TEXT_BLOCK_TYPES.has(node.type)) {
+      const text = parser.toString(node).trim();
+      if (text) {
+        parts.push(text);
+      }
+    } else if ("children" in node) {
+      collectPlainText(node.children as RootContent[], parser, parts);
+    }
+  }
+};
+
+/**
+ * Flattens MDX/Markdown to plain prose for the document card's body fallback:
+ * no code blocks, no markup, no expressions — the topic vector should capture
+ * what the post is about, not how it is marked up.
+ */
+export const stripMdx = async (source: string): Promise<string> => {
+  const parser = await loadParser();
+  const tree = parseDocument(parser, source);
+
+  const parts: string[] = [];
+  collectPlainText(tree.children, parser, parts);
+  return parts.join(" ").replace(/\s+/g, " ").trim();
 };

--- a/packages/ai/src/embeddings/markdown.ts
+++ b/packages/ai/src/embeddings/markdown.ts
@@ -41,6 +41,8 @@ export const cleanMdxKeepStructure = (source: string): string => {
 
 export interface MarkdownSection {
   headingPath: string | null;
+  /** level of the section's own heading; null for preamble text */
+  level: number | null;
   text: string;
 }
 
@@ -112,6 +114,7 @@ export const splitByHeadings = (content: string): MarkdownSection[] => {
       sections.push({
         headingPath:
           headingStack.map((heading) => heading.title).join(" > ") || null,
+        level: headingStack[headingStack.length - 1]?.level ?? null,
         text,
       });
     }

--- a/packages/ai/src/embeddings/openai.ts
+++ b/packages/ai/src/embeddings/openai.ts
@@ -1,9 +1,7 @@
 import { createOpenAI as createAiSdkOpenAI } from "@ai-sdk/openai";
 import { embedMany } from "ai";
-import type OpenAI from "openai";
-import type { ClientOptions } from "openai";
 
-import { guardEmbeddingInput, guardEmbeddingInputs } from "./tokenizer.ts";
+import { guardEmbeddingInputs } from "./tokenizer.ts";
 import {
   EMBEDDING_BATCH_MAX_INPUTS,
   EMBEDDING_BATCH_MAX_TOKENS,
@@ -14,36 +12,6 @@ import {
 export type TextEmbeddingModel =
   | "text-embedding-3-small"
   | "text-embedding-3-large";
-
-export interface Options {
-  client?: OpenAI;
-  model?: TextEmbeddingModel;
-  clientOptions?: ClientOptions;
-}
-
-export const generateEmbedding = async (value: string, options?: Options) => {
-  options ??= {};
-  const {
-    client = (await import("../index.ts").then((m) => m.createOpenAI))(
-      options?.clientOptions
-    ),
-    model = "text-embedding-3-small",
-  } = options;
-  // keep the input within the model's token limit; long articles would
-  // otherwise be rejected by the API
-  const { text: input } = await guardEmbeddingInput(
-    value.replaceAll("\n", " "),
-    { model }
-  );
-
-  const { data } = await client.embeddings.create({
-    model,
-    input,
-    dimensions: EMBEDDING_DIMENSIONS,
-  });
-
-  return data[0]?.embedding;
-};
 
 export interface BatchOptions {
   model?: TextEmbeddingModel;

--- a/packages/ai/src/embeddings/provider.ts
+++ b/packages/ai/src/embeddings/provider.ts
@@ -3,10 +3,10 @@ import { isOllamaEnabled } from "../ollama/utils.ts";
 import { ollamaEmbeddings } from "./ollama.ts";
 import {
   EMBEDDING_DIMENSIONS,
-  EMBEDDING_INDEX_VERSION,
   OLLAMA_EMBEDDING_DIMENSIONS,
   OllamaEmbeddingModel,
 } from "./utils.ts";
+import type { EmbeddingTask } from "./utils.ts";
 
 /**
  * The one seam for swapping embedding models.
@@ -18,11 +18,16 @@ import {
  *
  * `id` is folded into the index key, so switching providers invalidates every
  * stored vector automatically instead of silently comparing across models.
+ *
+ * `task` is required, not defaulted: most embedding models worth trying next
+ * (nomic, mxbai, e5, voyage) are asymmetric — a query embedded with the
+ * document prefix silently degrades retrieval — so every caller has to state
+ * which side of the search it is on. Symmetric models ignore it.
  */
 export interface EmbeddingProvider {
   readonly id: string;
   readonly dimensions: number;
-  embed(texts: string[]): Promise<number[][]>;
+  embed(texts: string[], task: EmbeddingTask): Promise<number[][]>;
 }
 
 export const OPENAI_EMBEDDING_MODEL = "text-embedding-3-small";
@@ -47,7 +52,8 @@ export const openAIEmbeddingProvider = (
 ): EmbeddingProvider => ({
   id: OPENAI_EMBEDDING_MODEL,
   dimensions: EMBEDDING_DIMENSIONS,
-  embed: async (texts) =>
+  // text-embedding-3-* are symmetric; the task carries no prefix here
+  embed: async (texts, _task) =>
     await (
       await import("./openai.ts")
     ).generateEmbeddings(texts, {
@@ -68,11 +74,11 @@ export const ollamaEmbeddingProvider = (
 ): EmbeddingProvider => ({
   id: model,
   dimensions: OLLAMA_EMBEDDING_DIMENSIONS[model],
-  embed: async (texts) => {
+  embed: async (texts, task) => {
     if (!(await isOllamaEnabled(model))) {
       throw new Error(`Ollama model "${model}" is unavailable`);
     }
-    return await ollamaEmbeddings(texts, model, "search_document");
+    return await ollamaEmbeddings(texts, model, task);
   },
 });
 
@@ -107,15 +113,3 @@ export const resolveEmbeddingProvider = (
       ? ollamaEmbeddingProvider()
       : openAIEmbeddingProvider(options)
   );
-
-/**
- * The value stored in `feed_translation.index_key`.
- *
- * Folds the strategy version and the provider id together with the content
- * hash, so a change to any of the three re-indexes exactly the rows it should.
- */
-export const buildIndexKey = (params: {
-  provider: EmbeddingProvider;
-  contentHash: string;
-}): string =>
-  `${EMBEDDING_INDEX_VERSION}:${params.provider.id}:${params.contentHash}`;

--- a/packages/ai/src/embeddings/utils.ts
+++ b/packages/ai/src/embeddings/utils.ts
@@ -16,15 +16,7 @@ export const EMBEDDING_DIMENSIONS = 1536;
  * a way that requires re-embedding. Folded into `index_key` together with the
  * provider id, so stale rows re-embed in place.
  */
-export const EMBEDDING_INDEX_VERSION = "2026-08-16.1";
-
-/**
- * Normalizes a search query for cache identity: collapse whitespace and
- * lowercase, but keep punctuation — "pg-vector" and "pg vector" are different
- * queries. Hash the result (sha-256) to build the cache key.
- */
-export const normalizeQueryForEmbedding = (query: string): string =>
-  query.trim().replace(/\s+/g, " ").toLowerCase();
+export const EMBEDDING_INDEX_VERSION = "2026-08-16.2";
 
 /**
  * Asymmetric embedding task type. Models like nomic-embed-text require

--- a/packages/ai/src/embeddings/utils.ts
+++ b/packages/ai/src/embeddings/utils.ts
@@ -16,7 +16,7 @@ export const EMBEDDING_DIMENSIONS = 1536;
  * a way that requires re-embedding. Folded into `index_key` together with the
  * provider id, so stale rows re-embed in place.
  */
-export const EMBEDDING_INDEX_VERSION = "2026-08-11.2";
+export const EMBEDDING_INDEX_VERSION = "2026-08-16.1";
 
 /**
  * Normalizes a search query for cache identity: collapse whitespace and

--- a/packages/ai/src/embeddings/utils.ts
+++ b/packages/ai/src/embeddings/utils.ts
@@ -1,4 +1,4 @@
-import { buildHeadingOutline } from "./markdown.ts";
+import { buildHeadingOutline, stripMdx } from "./markdown.ts";
 
 /**
  * Vector dimension used everywhere.
@@ -16,7 +16,7 @@ export const EMBEDDING_DIMENSIONS = 1536;
  * a way that requires re-embedding. Folded into `index_key` together with the
  * provider id, so stale rows re-embed in place.
  */
-export const EMBEDDING_INDEX_VERSION = "2026-08-16.2";
+export const EMBEDDING_INDEX_VERSION = "2026-08-16.3";
 
 /**
  * Asymmetric embedding task type. Models like nomic-embed-text require
@@ -125,24 +125,6 @@ export const truncateForEmbedding = (
 };
 
 /**
- * Strips MDX/Markdown noise (imports, JSX tags, code blocks, md syntax) so
- * the embedding captures the article topic instead of markup.
- */
-export const stripMdx = (source: string): string => {
-  return source
-    .replace(/```[\s\S]*?(```|$)/g, " ") // fenced code blocks
-    .replace(/^(?:import|export)\s[^\n]*$/gm, " ") // ESM statements
-    .replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1") // images -> alt text
-    .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1") // links -> label
-    .replace(/<\/?[A-Za-z][^>\n]*>/g, " ") // JSX / HTML tags
-    .replace(/`([^`]*)`/g, "$1") // inline code
-    .replace(/^[#>\-*+\s]+/gm, "") // headings, quotes, list markers
-    .replace(/[*_~]{1,3}([^*_~\n]+)[*_~]{1,3}/g, "$1") // emphasis
-    .replace(/\s+/g, " ")
-    .trim();
-};
-
-/**
  * Tokens of stripped body text used when a translation has no summary at all.
  * Small on purpose — the card is meant to be a topic summary, and a body
  * excerpt is a poor stand-in, not a replacement.
@@ -170,19 +152,24 @@ export interface DocumentCardInput {
  * The body excerpt only appears when there is no summary/description/excerpt
  * to work with; see `CARD_BODY_FALLBACK_TOKENS`.
  */
-export const buildEmbeddingInput = (input: DocumentCardInput): string => {
+export const buildEmbeddingInput = async (
+  input: DocumentCardInput
+): Promise<string> => {
   const summary = [input.summary, input.description, input.excerpt]
     .map((value) => value?.trim())
     .find((value): value is string => !!value);
 
   const tags = input.tags?.filter((tag) => !!tag.trim()) ?? [];
-  const outline = input.content ? buildHeadingOutline(input.content) : "";
+  const outline = input.content ? await buildHeadingOutline(input.content) : "";
 
   // no summary and no structure to describe the post — fall back to a bounded
   // slice of the body so the vector is not just the title
   const bodyFallback =
     !summary && !outline && input.content
-      ? truncateForEmbedding(stripMdx(input.content), CARD_BODY_FALLBACK_TOKENS)
+      ? truncateForEmbedding(
+          await stripMdx(input.content),
+          CARD_BODY_FALLBACK_TOKENS
+        )
       : null;
 
   return [

--- a/packages/api/feeds/search.ts
+++ b/packages/api/feeds/search.ts
@@ -39,7 +39,6 @@ interface SearchFeedsServiceParams {
   model: SearchFeedsProvider;
   locale: Locale | undefined;
   limit?: number;
-  kv?: Keyv;
 }
 
 /** Feed-scoped view of resource search. */

--- a/packages/api/resources/feed-translation.resource.ts
+++ b/packages/api/resources/feed-translation.resource.ts
@@ -67,7 +67,7 @@ const buildChunkSet = async (
 ): Promise<ResourceChunkSet> => {
   const chunks: ResourceChunkInput[] = [];
 
-  const card = buildEmbeddingInput({
+  const card = await buildEmbeddingInput({
     title: source.title,
     description: source.description,
     summary: source.summary,

--- a/packages/api/resources/search.ts
+++ b/packages/api/resources/search.ts
@@ -27,7 +27,10 @@ const embedQuery = async (query: string): Promise<number[]> => {
   if (!query.trim()) {
     return [];
   }
-  const [embedding] = await resolveEmbeddingProvider().embed([query]);
+  const [embedding] = await resolveEmbeddingProvider().embed(
+    [query],
+    "search_query"
+  );
   return embedding ?? [];
 };
 

--- a/packages/db/__tests__/resources-chunk-plan.spec.ts
+++ b/packages/db/__tests__/resources-chunk-plan.spec.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+
+import { planChunkReplacement } from "../src/libs/resources/chunk.ts";
+import type {
+  ExistingChunkRow,
+  ResourceChunkInput,
+} from "../src/libs/resources/chunk.ts";
+
+let nextId = 1;
+const row = (
+  kind: string,
+  chunkIndex: number,
+  contentHash: string
+): ExistingChunkRow => ({ id: nextId++, kind, chunkIndex, contentHash });
+
+const input = (
+  kind: string,
+  chunkIndex: number,
+  contentHash: string
+): ResourceChunkInput => ({
+  kind: kind as ResourceChunkInput["kind"],
+  chunkIndex,
+  content: `content-${contentHash}`,
+  contentHash,
+});
+
+describe("planChunkReplacement", () => {
+  it("keeps an identical chunk set fully unchanged", () => {
+    const existing = [
+      row("card", 0, "c"),
+      row("section", 0, "a"),
+      row("section", 1, "b"),
+    ];
+    const incoming = [
+      input("card", 0, "c"),
+      input("section", 0, "a"),
+      input("section", 1, "b"),
+    ];
+
+    const plan = planChunkReplacement(existing, incoming);
+    expect(plan.unchanged).toHaveLength(3);
+    expect(plan.moved).toHaveLength(0);
+    expect(plan.rewritten).toHaveLength(0);
+    expect(plan.inserted).toHaveLength(0);
+    expect(plan.removed).toHaveLength(0);
+  });
+
+  it("recognises an inserted paragraph as one insert plus moves, not a tail rewrite", () => {
+    // a new section appears at index 1; every later section shifts by one —
+    // under (kind, index) identity the whole tail would have re-embedded
+    const existing = [
+      row("section", 0, "a"),
+      row("section", 1, "b"),
+      row("section", 2, "c"),
+    ];
+    const incoming = [
+      input("section", 0, "a"),
+      input("section", 1, "new"),
+      input("section", 2, "b"),
+      input("section", 3, "c"),
+    ];
+
+    const plan = planChunkReplacement(existing, incoming);
+    expect(plan.unchanged).toHaveLength(1); // "a" stays at 0
+    expect(plan.moved.map((m) => m.chunk.contentHash)).toEqual(["b", "c"]);
+    expect(plan.inserted.map((c) => c.contentHash)).toEqual(["new"]);
+    expect(plan.rewritten).toHaveLength(0);
+    expect(plan.removed).toHaveLength(0);
+  });
+
+  it("rewrites in place when content changes at a position", () => {
+    const existing = [row("section", 0, "a"), row("section", 1, "b")];
+    const incoming = [input("section", 0, "a"), input("section", 1, "b2")];
+
+    const plan = planChunkReplacement(existing, incoming);
+    expect(plan.unchanged).toHaveLength(1);
+    expect(plan.rewritten.map((r) => r.chunk.contentHash)).toEqual(["b2"]);
+    expect(plan.moved).toHaveLength(0);
+    expect(plan.inserted).toHaveLength(0);
+  });
+
+  it("removes rows for a shrunken document and moves the survivors", () => {
+    const existing = [
+      row("section", 0, "a"),
+      row("section", 1, "b"),
+      row("section", 2, "c"),
+    ];
+    const incoming = [input("section", 0, "c")];
+
+    const plan = planChunkReplacement(existing, incoming);
+    expect(plan.moved.map((m) => m.chunk.contentHash)).toEqual(["c"]);
+    expect(plan.removed).toHaveLength(2);
+    expect(plan.unchanged).toHaveLength(0);
+  });
+
+  it("claims duplicate hashes one row at a time", () => {
+    // the same content appears twice; each incoming duplicate must claim a
+    // distinct row, and a third occurrence is an insert
+    const existing = [row("section", 0, "dup"), row("section", 1, "dup")];
+    const incoming = [
+      input("section", 0, "dup"),
+      input("section", 1, "dup"),
+      input("section", 2, "dup"),
+    ];
+
+    const plan = planChunkReplacement(existing, incoming);
+    expect(plan.unchanged).toHaveLength(2);
+    expect(plan.inserted).toHaveLength(1);
+    expect(plan.removed).toHaveLength(0);
+  });
+
+  it("does not cross kinds: a card never claims a section's row", () => {
+    const existing = [row("section", 0, "same")];
+    const incoming = [input("card", 0, "same")];
+
+    const plan = planChunkReplacement(existing, incoming);
+    expect(plan.inserted).toHaveLength(1);
+    expect(plan.removed).toHaveLength(1);
+  });
+});

--- a/packages/db/__tests__/resources-search.spec.ts
+++ b/packages/db/__tests__/resources-search.spec.ts
@@ -14,6 +14,7 @@ const hit = (
   kind: "section",
   chunkIndex: 0,
   headingPath: null,
+  content: "",
   snippet: null,
   score,
   lexicalRank: null,

--- a/packages/db/__tests__/resources-search.spec.ts
+++ b/packages/db/__tests__/resources-search.spec.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import { aggregateChunkHits } from "../src/libs/resources/search.ts";
+import type { ChunkHit } from "../src/libs/resources/search.ts";
+
+const hit = (
+  sourceId: number,
+  score: number,
+  overrides: Partial<ChunkHit> = {}
+): ChunkHit => ({
+  chunkId: sourceId * 100 + Math.round(score * 1000),
+  sourceType: "feed_translation",
+  sourceId,
+  kind: "section",
+  chunkIndex: 0,
+  headingPath: null,
+  snippet: null,
+  score,
+  lexicalRank: null,
+  semanticRank: null,
+  ...overrides,
+});
+
+describe("aggregateChunkHits", () => {
+  it("rewards breadth: several relevant chunks outrank one equal best chunk", () => {
+    // both resources share the same best chunk score; resource 2 has two more
+    // relevant chunks — under a top-N mean it would have lost or tied
+    const hits = [hit(1, 0.9), hit(2, 0.9), hit(2, 0.5), hit(2, 0.4)].sort(
+      (a, b) => b.score - a.score
+    );
+
+    const [first, second] = aggregateChunkHits(hits, 10);
+    expect(first?.sourceId).toBe(2);
+    expect(second?.sourceId).toBe(1);
+  });
+
+  it("caps the score at top-N chunks so length alone cannot win", () => {
+    const many = Array.from({ length: 10 }, () => hit(1, 0.2));
+    const focused = [hit(2, 0.9), hit(2, 0.9)];
+    const hits = [...focused, ...many];
+
+    const [first] = aggregateChunkHits(hits, 10);
+    // 0.2 × (1 + ¼ + ¹⁄₁₆) < 0.9 × (1 + ¼) — chunks beyond the top N
+    // contribute nothing, and decayed later ranks cannot pile up past a
+    // dominant best chunk
+    expect(first?.sourceId).toBe(2);
+  });
+
+  it("keeps the best-scoring chunk as the citation chunk", () => {
+    const hits = [
+      hit(1, 0.9, { headingPath: "A > B" }),
+      hit(1, 0.5, { headingPath: "C" }),
+    ];
+
+    const [first] = aggregateChunkHits(hits, 10);
+    expect(first?.bestChunk.headingPath).toBe("A > B");
+    expect(first?.matchedChunks).toBe(2);
+  });
+
+  it("slices to the limit after sorting", () => {
+    const hits = [hit(1, 0.9), hit(2, 0.8), hit(3, 0.7)];
+    const results = aggregateChunkHits(hits, 2);
+    expect(results.map((result) => result.sourceId)).toEqual([1, 2]);
+  });
+});

--- a/packages/db/src/libs/resources/chunk.ts
+++ b/packages/db/src/libs/resources/chunk.ts
@@ -46,12 +46,112 @@ const sourceColumns = (ref: ResourceRef) => {
 const sourceFilter = (ref: ResourceRef) =>
   and(eq(chunks.sourceType, ref.sourceType), eq(chunks.sourceId, ref.sourceId));
 
+export interface ExistingChunkRow {
+  id: number;
+  kind: string;
+  chunkIndex: number;
+  contentHash: string;
+}
+
+export interface ChunkReplacementPlan {
+  /** same kind, index and hash — only the mirrored visibility is refreshed */
+  unchanged: number[];
+  /** same content at a new position — the row moves and its vectors survive */
+  moved: { id: number; chunk: ResourceChunkInput }[];
+  /** new content at an existing position — rewritten in place, vectors dropped */
+  rewritten: { id: number; chunk: ResourceChunkInput }[];
+  inserted: ResourceChunkInput[];
+  removed: number[];
+}
+
 /**
- * Replaces a resource's chunks in one transaction.
+ * Matches incoming chunks to existing rows by *content*, not position.
  *
- * Rows whose `content_hash` is unchanged are left alone, so their vectors
- * survive; only edited or new chunks are rewritten (which cascades their
- * vectors away) and stale positions are removed.
+ * Identity used to be `(kind, chunk_index)`: inserting one paragraph shifted
+ * every later chunk's index, so each compared against the wrong predecessor
+ * and the whole tail re-embedded. Matching by hash first means an edit costs
+ * what actually changed — shifted chunks are recognised as moves and keep
+ * their vectors.
+ *
+ * Matching order: exact `(kind, index, hash)` first (stable rows), then
+ * `(kind, hash)` in document order (moves), then `(kind, index)` (in-place
+ * rewrites), and whatever remains is an insert or a removal. Duplicate hashes
+ * are claimed row-by-row, so repeated content cannot double-match.
+ */
+export const planChunkReplacement = (
+  existing: ExistingChunkRow[],
+  incoming: ResourceChunkInput[]
+): ChunkReplacementPlan => {
+  const claimedRows = new Set<number>();
+  const matched = new Map<ResourceChunkInput, ExistingChunkRow>();
+
+  const claimWith = (
+    keyOf: (entry: {
+      kind: string;
+      chunkIndex: number;
+      contentHash: string;
+    }) => string
+  ) => {
+    const pool = new Map<string, ExistingChunkRow[]>();
+    for (const row of existing) {
+      if (claimedRows.has(row.id)) {
+        continue;
+      }
+      const key = keyOf(row);
+      pool.set(key, [...(pool.get(key) ?? []), row]);
+    }
+    for (const chunk of incoming) {
+      if (matched.has(chunk)) {
+        continue;
+      }
+      const row = pool.get(keyOf(chunk))?.shift();
+      if (row) {
+        claimedRows.add(row.id);
+        matched.set(chunk, row);
+      }
+    }
+  };
+
+  claimWith(
+    (entry) => `${entry.kind}:${entry.chunkIndex}:${entry.contentHash}`
+  );
+  claimWith((entry) => `${entry.kind}:${entry.contentHash}`);
+  claimWith((entry) => `${entry.kind}:${entry.chunkIndex}`);
+
+  const plan: ChunkReplacementPlan = {
+    unchanged: [],
+    moved: [],
+    rewritten: [],
+    inserted: [],
+    removed: existing
+      .filter((row) => !claimedRows.has(row.id))
+      .map((row) => row.id),
+  };
+
+  for (const chunk of incoming) {
+    const row = matched.get(chunk);
+    if (!row) {
+      plan.inserted.push(chunk);
+    } else if (row.contentHash !== chunk.contentHash) {
+      plan.rewritten.push({ id: row.id, chunk });
+    } else if (row.chunkIndex !== chunk.chunkIndex) {
+      plan.moved.push({ id: row.id, chunk });
+    } else {
+      plan.unchanged.push(row.id);
+    }
+  }
+
+  return plan;
+};
+
+/**
+ * Replaces a resource's chunks in one transaction, per `planChunkReplacement`.
+ *
+ * Moves land in two phases because of the unique `(source, kind, chunk_index)`
+ * index: a moved row's target position may still be held by another row that
+ * has not moved yet, so every moved row first parks on a negative index (real
+ * indexes are ≥ 0, and final indexes are unique, so `-(index + 1)` cannot
+ * collide) and takes its final position after inserts.
  */
 export const replaceResourceChunks = withDTO(
   async (
@@ -73,72 +173,80 @@ export const replaceResourceChunks = withDTO(
         .from(chunks)
         .where(sourceFilter(dto.ref));
 
-      const key = (kind: string, index: number) => `${kind}:${index}`;
-      const existingByKey = new Map(
-        existing.map((row) => [key(row.kind, row.chunkIndex), row])
-      );
+      const plan = planChunkReplacement(existing, dto.chunks);
 
-      let written = 0;
-      let unchanged = 0;
+      const visibility = {
+        locale: dto.visibility.locale ?? null,
+        published: dto.visibility.published,
+        deleted: dto.visibility.deleted,
+      };
+      const fieldsOf = (chunk: ResourceChunkInput) => ({
+        chunkIndex: chunk.chunkIndex,
+        headingPath: chunk.headingPath ?? null,
+        tokenCount: chunk.tokenCount ?? null,
+        metadata: chunk.metadata ?? null,
+        ...visibility,
+        updatedAt: new Date(),
+      });
 
-      for (const chunk of dto.chunks) {
-        const previous = existingByKey.get(key(chunk.kind, chunk.chunkIndex));
-
-        if (previous?.contentHash === chunk.contentHash) {
-          // text is identical; refresh only the mirrored visibility
-          await trx
-            .update(chunks)
-            .set({
-              locale: dto.visibility.locale ?? null,
-              published: dto.visibility.published,
-              deleted: dto.visibility.deleted,
-            })
-            .where(eq(chunks.id, previous.id));
-          unchanged++;
-          continue;
-        }
-
-        const values = {
-          ...sourceColumns(dto.ref),
-          kind: chunk.kind,
-          chunkIndex: chunk.chunkIndex,
-          content: chunk.content,
-          headingPath: chunk.headingPath ?? null,
-          tokenCount: chunk.tokenCount ?? null,
-          metadata: chunk.metadata ?? null,
-          contentHash: chunk.contentHash,
-          locale: dto.visibility.locale ?? null,
-          published: dto.visibility.published,
-          deleted: dto.visibility.deleted,
-        };
-
-        if (previous) {
-          // content changed — the update cascades the old vector away
-          await trx
-            .update(chunks)
-            .set({ ...values, updatedAt: new Date() })
-            .where(eq(chunks.id, previous.id));
-          await trx
-            .delete(embeddings)
-            .where(eq(embeddings.chunkId, previous.id));
-        } else {
-          await trx.insert(chunks).values(values);
-        }
-        written++;
+      if (plan.removed.length > 0) {
+        await trx.delete(chunks).where(inArray(chunks.id, plan.removed));
       }
 
-      const keptKeys = dto.chunks.map((chunk) =>
-        key(chunk.kind, chunk.chunkIndex)
-      );
-      const orphans = existing
-        .filter((row) => !keptKeys.includes(key(row.kind, row.chunkIndex)))
-        .map((row) => row.id);
-
-      if (orphans.length > 0) {
-        await trx.delete(chunks).where(inArray(chunks.id, orphans));
+      if (plan.unchanged.length > 0) {
+        await trx
+          .update(chunks)
+          .set(visibility)
+          .where(inArray(chunks.id, plan.unchanged));
       }
 
-      return { written, unchanged, removed: orphans.length };
+      // phase one: park every moved row off the index space
+      for (const move of plan.moved) {
+        await trx
+          .update(chunks)
+          .set({ chunkIndex: -(move.chunk.chunkIndex + 1) })
+          .where(eq(chunks.id, move.id));
+      }
+
+      for (const rewrite of plan.rewritten) {
+        await trx
+          .update(chunks)
+          .set({
+            ...fieldsOf(rewrite.chunk),
+            content: rewrite.chunk.content,
+            contentHash: rewrite.chunk.contentHash,
+          })
+          .where(eq(chunks.id, rewrite.id));
+        // content changed — the stored vector no longer describes it
+        await trx.delete(embeddings).where(eq(embeddings.chunkId, rewrite.id));
+      }
+
+      if (plan.inserted.length > 0) {
+        await trx.insert(chunks).values(
+          plan.inserted.map((chunk) => ({
+            ...sourceColumns(dto.ref),
+            kind: chunk.kind,
+            content: chunk.content,
+            contentHash: chunk.contentHash,
+            ...fieldsOf(chunk),
+          }))
+        );
+      }
+
+      // phase two: land the moved rows on their final indexes, vectors intact
+      for (const move of plan.moved) {
+        await trx
+          .update(chunks)
+          .set(fieldsOf(move.chunk))
+          .where(eq(chunks.id, move.id));
+      }
+
+      return {
+        written: plan.rewritten.length + plan.inserted.length,
+        unchanged: plan.unchanged.length,
+        moved: plan.moved.length,
+        removed: plan.removed.length,
+      };
     });
   }
 );

--- a/packages/db/src/libs/resources/search.ts
+++ b/packages/db/src/libs/resources/search.ts
@@ -35,6 +35,12 @@ export interface ChunkHit {
   kind: ResourceChunkKind;
   chunkIndex: number;
   headingPath: string | null;
+  /**
+   * The chunk's stored text. Hybrid and semantic hits have no highlighted
+   * snippet (ParadeDB rejects `pdb.snippet()` beside a window function), so
+   * this is what shows why a chunk matched.
+   */
+  content: string;
   /** `<b>`-highlighted fragment, when the lexical path produced one */
   snippet: string | null;
   /** comparable only within one result set */
@@ -89,6 +95,7 @@ const chunkColumns = {
   kind: chunks.kind,
   chunkIndex: chunks.chunkIndex,
   headingPath: chunks.headingPath,
+  content: chunks.content,
 };
 
 /**

--- a/packages/db/src/libs/resources/search.ts
+++ b/packages/db/src/libs/resources/search.ts
@@ -15,6 +15,19 @@ const RRF_K = 60;
 /** How many of a resource's best chunks contribute to its score. */
 const RESOURCE_SCORE_TOP_N = 3;
 
+/**
+ * Weight multiplier per rank inside a resource's top-N (1, ¼, ¹⁄₁₆).
+ *
+ * A plain sum broke on RRF scores, which are nearly flat (rank 1 ≈ 0.016,
+ * rank 30 ≈ 0.011): three mediocre chunks of a long article out-summed the
+ * single top-ranked chunk of a short one, so one-section articles lost to
+ * length. The decay keeps the best chunk dominant while additional relevant
+ * chunks still add — breadth is rewarded, piling up is not. 0.25 measured
+ * better than 0.5 on the hybrid path, which is what the API and the agent
+ * actually serve; see `toolings/scripts/rag-eval`.
+ */
+const RESOURCE_SCORE_DECAY = 0.25;
+
 export interface ChunkHit {
   chunkId: number;
   sourceType: string;
@@ -33,7 +46,7 @@ export interface ChunkHit {
 export interface ResourceHit {
   sourceType: string;
   sourceId: number;
-  /** mean of the resource's top chunk scores */
+  /** decayed sum of the resource's top chunk scores */
   score: number;
   matchedChunks: number;
   /** best-scoring chunk, for citation and preview */
@@ -196,12 +209,17 @@ export const searchChunksHybrid = withDTO(
       db
         .select({
           id: chunks.id,
-          rank: sql<number>`row_number() over (order by ${distance})`.as("rank"),
+          rank: sql<number>`row_number() over (order by ${distance})`.as(
+            "rank"
+          ),
         })
         .from(chunks)
         .innerJoin(
           embeddings,
-          and(eq(embeddings.chunkId, chunks.id), eq(embeddings.model, dto.model))
+          and(
+            eq(embeddings.chunkId, chunks.id),
+            eq(embeddings.model, dto.model)
+          )
         )
         .where(scope)
         .orderBy(distance)
@@ -213,7 +231,9 @@ export const searchChunksHybrid = withDTO(
         .select({
           id: sql<number>`coalesce(${lexical.id}, ${semantic.id})`.as("id"),
           lexicalRank: sql<number | null>`${lexical.rank}`.as("lexical_rank"),
-          semanticRank: sql<number | null>`${semantic.rank}`.as("semantic_rank"),
+          semanticRank: sql<number | null>`${semantic.rank}`.as(
+            "semantic_rank"
+          ),
           score: sql<number>`
             coalesce(1.0 / (${RRF_K} + ${lexical.rank}), 0)
             + coalesce(1.0 / (${RRF_K} + ${semantic.rank}), 0)
@@ -243,10 +263,13 @@ export const searchChunksHybrid = withDTO(
 /**
  * Collapses chunk hits into one hit per resource.
  *
- * Scored on the mean of a resource's top-N chunks rather than its single best:
- * one coincidentally-worded passage should not outrank a resource that is
- * relevant throughout. Resources with fewer than N chunks average over what
- * they have.
+ * Scored on the decayed sum of a resource's top-N chunk scores
+ * (`RESOURCE_SCORE_DECAY`): a resource that is relevant throughout should
+ * outrank one with a single coincidentally-worded passage — under a mean a
+ * second relevant chunk could only drag the score down, so breadth was never
+ * rewarded — but the best chunk stays dominant so a short focused article
+ * still beats a long tangential one. Comparable only within one result set,
+ * like the chunk scores it sums.
  */
 export const aggregateChunkHits = (
   hits: ChunkHit[],
@@ -266,7 +289,10 @@ export const aggregateChunkHits = (
     .map((bucket) => {
       // hits arrive in score order, so the head is already the best
       const top = bucket.slice(0, topN);
-      const score = top.reduce((sum, hit) => sum + hit.score, 0) / top.length;
+      const score = top.reduce(
+        (sum, hit, index) => sum + hit.score * RESOURCE_SCORE_DECAY ** index,
+        0
+      );
       const best = bucket[0]!;
       return {
         sourceType: best.sourceType,
@@ -304,7 +330,10 @@ export const findSimilarResources = withDTO(
         .from(chunks)
         .innerJoin(
           embeddings,
-          and(eq(embeddings.chunkId, chunks.id), eq(embeddings.model, dto.model))
+          and(
+            eq(embeddings.chunkId, chunks.id),
+            eq(embeddings.model, dto.model)
+          )
         )
         .where(
           and(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1806,6 +1806,30 @@ importers:
 
   toolings/scripts/hash: {}
 
+  toolings/scripts/rag-eval:
+    devDependencies:
+      '@chia/ai':
+        specifier: workspace:*
+        version: link:../../../packages/ai
+      '@chia/api':
+        specifier: workspace:*
+        version: link:../../../packages/api
+      '@chia/db':
+        specifier: workspace:*
+        version: link:../../../packages/db
+      '@chiastack/tsconfig':
+        specifier: catalog:chiastack
+        version: 2.1.2
+      '@types/node':
+        specifier: 'catalog:'
+        version: 26.2.0
+      drizzle-orm:
+        specifier: catalog:drizzle
+        version: 1.0.0-rc.4(@opentelemetry/api@1.9.1)(@sinclair/typebox@0.34.52)(@types/pg@8.21.0)(@upstash/redis@1.38.2)(bun-types@1.3.14)(pg@8.22.0)(sqlite3@5.1.7)(typebox@1.3.11)(zod@4.4.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+
   toolings/scripts/seed:
     dependencies:
       drizzle-orm:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1831,14 +1831,7 @@ importers:
         version: 7.0.2
 
   toolings/scripts/seed:
-    dependencies:
-      drizzle-orm:
-        specifier: catalog:drizzle
-        version: 1.0.0-rc.4(@opentelemetry/api@1.9.1)(@sinclair/typebox@0.34.52)(@types/pg@8.21.0)(@upstash/redis@1.38.2)(bun-types@1.3.14)(pg@8.22.0)(sqlite3@5.1.7)(typebox@1.3.11)(zod@4.4.3)
     devDependencies:
-      '@chia/ai':
-        specifier: workspace:*
-        version: link:../../../packages/ai
       '@chia/db':
         specifier: workspace:*
         version: link:../../../packages/db

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,9 @@ catalogs:
     '@types/lodash':
       specifier: ^4.17.25
       version: 4.17.25
+    '@types/mdast':
+      specifier: ^4.0.4
+      version: 4.0.4
     '@types/node':
       specifier: 26.2.0
       version: 26.2.0
@@ -107,6 +110,18 @@ catalogs:
     lodash:
       specifier: ^4.18.1
       version: 4.18.1
+    mdast-util-to-string:
+      specifier: ^4.0.0
+      version: 4.0.0
+    remark-gfm:
+      specifier: ^4.0.1
+      version: 4.0.1
+    remark-mdx:
+      specifier: ^3.1.1
+      version: 3.1.1
+    remark-parse:
+      specifier: ^11.0.0
+      version: 11.0.0
     server-only:
       specifier: ^0.0.1
       version: 0.0.1
@@ -119,6 +134,12 @@ catalogs:
     typescript:
       specifier: 7.0.2
       version: 7.0.2
+    unified:
+      specifier: ^11.0.5
+      version: 11.0.5
+    unist-util-visit:
+      specifier: ^5.1.0
+      version: 5.1.0
     zod:
       specifier: 4.4.3
       version: 4.4.3
@@ -1136,6 +1157,9 @@ importers:
       js-tiktoken:
         specifier: ^1.0.21
         version: 1.0.21
+      mdast-util-to-string:
+        specifier: 'catalog:'
+        version: 4.0.0
       next:
         specifier: catalog:next
         version: 16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.2.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -1145,6 +1169,21 @@ importers:
       openai:
         specifier: catalog:ai
         version: 7.4.0(@aws-sdk/credential-provider-node@3.972.78)(@smithy/signature-v4@5.6.12)(ws@8.21.3)(zod@4.4.3)
+      remark-gfm:
+        specifier: 'catalog:'
+        version: 4.0.1
+      remark-mdx:
+        specifier: 'catalog:'
+        version: 3.1.1
+      remark-parse:
+        specifier: 'catalog:'
+        version: 11.0.0
+      unified:
+        specifier: 'catalog:'
+        version: 11.0.5
+      unist-util-visit:
+        specifier: 'catalog:'
+        version: 5.1.0
       zod:
         specifier: 'catalog:'
         version: 4.4.3
@@ -1152,6 +1191,9 @@ importers:
       '@chiastack/tsconfig':
         specifier: catalog:chiastack
         version: 2.1.2
+      '@types/mdast':
+        specifier: 'catalog:'
+        version: 4.0.4
       '@types/node':
         specifier: 'catalog:'
         version: 26.2.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -33,6 +33,13 @@ catalog:
   graphql-request: ^7.4.0
   ky: ^2.0.2
   lodash: ^4.18.1
+  "@types/mdast": ^4.0.4
+  mdast-util-to-string: ^4.0.0
+  remark-gfm: ^4.0.1
+  remark-mdx: ^3.1.1
+  remark-parse: ^11.0.0
+  unified: ^11.0.5
+  unist-util-visit: ^5.1.0
   server-only: ^0.0.1
   superjson: 2.2.6
   tsdown: 0.22.14

--- a/toolings/scripts/rag-eval/.gitignore
+++ b/toolings/scripts/rag-eval/.gitignore
@@ -1,0 +1,1 @@
+reports/

--- a/toolings/scripts/rag-eval/README.md
+++ b/toolings/scripts/rag-eval/README.md
@@ -1,0 +1,56 @@
+# RAG retrieval eval
+
+Retrieval-quality benchmark for the search stack described in
+[`docs/rag-architecture.md`](../../../docs/rag-architecture.md). It runs a
+fixed set of golden queries through `searchFeedsService` — the same code path
+the API serves — and reports Recall@K and MRR per mode (`bm25`, `semantic`,
+`hybrid`).
+
+Run it **before and after** any change that affects ranking (chunking,
+`EMBEDDING_INDEX_VERSION` bumps, RRF constants, chunk-hit aggregation) and
+compare the two reports; without the before-run there is no way to tell an
+improvement from a regression.
+
+## Usage
+
+Needs a database holding the real corpus with current embeddings and, for
+`semantic` / `hybrid`, `OPENAI_API_KEY` in `.env.global`.
+
+```bash
+pnpm --filter rag-eval eval                    # all modes, all queries
+pnpm --filter rag-eval eval mode=bm25          # one mode
+pnpm --filter rag-eval eval kind=heading       # one query group
+pnpm --filter rag-eval eval id=zh-csrf         # one query
+pnpm --filter rag-eval eval out=baseline.json  # persist the full report
+pnpm --filter rag-eval eval db-url=…           # explicit connection string
+```
+
+Without `db-url` it connects like the apps do (`LOCAL_DATABASE_URL`). The
+usual local database is dev scratch data, so evaluate against a restored copy
+of the production corpus instead — that same copy is where chunking changes
+get reindexed and re-measured without touching production:
+
+```bash
+toolings/scripts/dump-chia-local.sh /tmp                 # dumps $DATABASE_URL
+psql "<local-admin-url>" -c 'CREATE DATABASE "chia-eval"'
+DATABASE_URL="<local…/chia-eval>" \
+  toolings/scripts/restore-chia-local-paradedb.sh /tmp/chia-local-*.sql
+pnpm --filter rag-eval eval "db-url=<local…/chia-eval>" out=reports/baseline.json
+```
+
+## Reading the report
+
+- The per-query table shows the rank of the first expected slug per mode
+  (`-` = not in the top 10).
+- `R@K` is averaged over the query set; with single-expected queries it is the
+  fraction of queries whose answer appears in the top K.
+- `R@5 by kind` is the actionable slice: `paraphrase` measures the semantic
+  path, `term` the lexical path, and `heading` the known weak case where the
+  answer sits under a heading whose words the section body does not repeat.
+
+## Maintaining the golden set
+
+Queries live in [`golden-queries.ts`](golden-queries.ts). Every expected slug
+must exist as a feed — the runner fails fast on unknown slugs so a renamed or
+deleted post breaks the eval loudly instead of silently deflating recall. When
+publishing a post that is an obvious retrieval target, add a query for it.

--- a/toolings/scripts/rag-eval/README.md
+++ b/toolings/scripts/rag-eval/README.md
@@ -38,6 +38,13 @@ DATABASE_URL="<local…/chia-eval>" \
 pnpm --filter rag-eval eval "db-url=<local…/chia-eval>" out=reports/baseline.json
 ```
 
+After a chunking or index-version change, rebuild the copy and measure again:
+
+```bash
+pnpm --filter rag-eval reindex "db-url=<local…/chia-eval>"
+pnpm --filter rag-eval eval "db-url=<local…/chia-eval>" out=reports/after.json
+```
+
 ## Reading the report
 
 - The per-query table shows the rank of the first expected slug per mode

--- a/toolings/scripts/rag-eval/golden-queries.ts
+++ b/toolings/scripts/rag-eval/golden-queries.ts
@@ -1,0 +1,314 @@
+import type { Locale } from "@chia/db/types";
+
+/**
+ * `kind` groups queries by which retrieval path they stress, so a regression
+ * shows *where* quality moved, not just that it moved:
+ *
+ * - `paraphrase` — describes the topic without the article's own words; the
+ *   semantic path has to carry it.
+ * - `term`       — an exact identifier / error message; the lexical path has
+ *   to carry it.
+ * - `heading`    — the answer lives under a heading whose words do not repeat
+ *   in the section body. Currently the weakest case: heading text is not part
+ *   of chunk content.
+ */
+export type GoldenQueryKind = "paraphrase" | "term" | "heading";
+
+export interface GoldenQuery {
+  /** stable id, used to reference a query in reports and diffs */
+  id: string;
+  query: string;
+  /** omit to exercise the no-locale (cross-locale dedupe) path */
+  locale?: Locale;
+  /** feed slugs that count as relevant; usually exactly one */
+  expected: string[];
+  /**
+   * Case-insensitive substring the hit's best-chunk `headingPath` must
+   * contain, for queries whose answer lives in one specific section. Measures
+   * citation quality: the document can rank #1 while the chunk shown as the
+   * match is the wrong one (typically the card, when the heading words are
+   * absent from the section body).
+   */
+  expectedHeading?: string;
+  kind: GoldenQueryKind;
+}
+
+/**
+ * Golden retrieval queries against the real corpus.
+ *
+ * Maintenance: every slug here must exist as a published feed — the runner
+ * fails fast on a slug it cannot resolve, so a renamed or deleted post breaks
+ * the eval loudly instead of silently deflating recall. When writing a new
+ * post that is an obvious retrieval target, add a query for it.
+ */
+export const GOLDEN_QUERIES: GoldenQuery[] = [
+  // ── zh-TW · paraphrase ────────────────────────────────────────────────
+  {
+    id: "zh-pg-semantic-search",
+    query: "如何用 Postgres 實作語意搜尋",
+    locale: "zh-TW",
+    expected: ["vector-search-embedding-postgres-implementation"],
+    kind: "paraphrase",
+  },
+  {
+    id: "zh-cors-blocked",
+    query: "API 被 CORS 擋住該怎麼辦",
+    locale: "zh-TW",
+    expected: ["how-to-solve-cors-issues"],
+    kind: "paraphrase",
+  },
+  {
+    id: "zh-chat-streaming",
+    query: "AI 聊天室要即時串流回覆該用什麼技術",
+    locale: "zh-TW",
+    expected: ["simple-ai-chat-bot-sse-vs-websocket"],
+    kind: "paraphrase",
+  },
+  {
+    id: "zh-agent-sandbox",
+    query: "讓 coding agent 在隔離的環境裡執行",
+    locale: "zh-TW",
+    expected: ["docker-sandboxes-agent-isolation"],
+    kind: "paraphrase",
+  },
+  {
+    id: "zh-wallet-login",
+    query: "用錢包簽名登入 Ethereum",
+    locale: "zh-TW",
+    expected: ["web3-wallet-login"],
+    kind: "paraphrase",
+  },
+  {
+    id: "zh-site-under-attack",
+    query: "網站被惡意流量攻擊怎麼用 Cloudflare 擋",
+    locale: "zh-TW",
+    expected: ["website-attack-cloudflare-protection"],
+    kind: "paraphrase",
+  },
+  {
+    id: "zh-gitignore-ignored",
+    query: "gitignore 加了檔案還是被 git 追蹤",
+    locale: "zh-TW",
+    expected: ["git-file-update-tracking-issue"],
+    kind: "paraphrase",
+  },
+  {
+    id: "zh-mac-port-usage",
+    query: "Mac 上查哪個程式佔用 port",
+    locale: "zh-TW",
+    expected: ["how-to-check-used-ports-on-mac"],
+    kind: "paraphrase",
+  },
+  {
+    id: "zh-rsc-vs-ssr",
+    query: "React Server Component 跟 SSR 是什麼關係",
+    locale: "zh-TW",
+    expected: ["what-is-rsc-and-its-relationship-with-ssr"],
+    kind: "paraphrase",
+  },
+  {
+    id: "zh-rsc-client-state",
+    query: "從 client 端更新 server component 的狀態",
+    locale: "zh-TW",
+    expected: ["update-rsc-state-from-client"],
+    kind: "paraphrase",
+  },
+  {
+    id: "zh-jwt-vs-session",
+    query: "JWT 跟 session cookie 登入方式的差別",
+    locale: "zh-TW",
+    expected: ["jwt-vs-session-cookie-authentication-differences"],
+    kind: "paraphrase",
+  },
+  {
+    id: "zh-storage-difference",
+    query: "localStorage 和 cookie 差在哪",
+    locale: "zh-TW",
+    expected: ["localstorage-sessionstorage-cookie-difference"],
+    kind: "paraphrase",
+  },
+  {
+    id: "zh-hydration-error",
+    query: "hydration error 發生原因跟解法",
+    locale: "zh-TW",
+    expected: ["nextjs-hydration-errors-explained-solutions"],
+    kind: "paraphrase",
+  },
+
+  // ── zh-TW · term ──────────────────────────────────────────────────────
+  {
+    id: "zh-feturbulence",
+    query: "feTurbulence 做雜訊背景",
+    locale: "zh-TW",
+    expected: ["svg-noise-background-with-feturbulence-"],
+    kind: "term",
+  },
+  {
+    id: "zh-exec-format-error",
+    query: "exec format error 部署失敗",
+    locale: "zh-TW",
+    expected: ["zeabur-bun-compile-binary-pitfalls"],
+    kind: "term",
+  },
+  {
+    id: "zh-forwardref-generic",
+    query: "forwardRef 泛型型別安全",
+    locale: "zh-TW",
+    expected: ["react-forwardref-generic-type-safety"],
+    kind: "term",
+  },
+  {
+    id: "zh-pnpm-catalog",
+    query: "pnpm workspace catalog 管理套件版本",
+    locale: "zh-TW",
+    expected: ["tips-for-managing-node-and-bun-projects-with-pnpm"],
+    kind: "term",
+  },
+  {
+    id: "zh-turborepo-trpc",
+    query: "用 Turborepo 和 tRPC 重構網站",
+    locale: "zh-TW",
+    expected: ["tech-stack-restructure-2024"],
+    kind: "term",
+  },
+
+  // ── zh-TW · heading ───────────────────────────────────────────────────
+  // The relevant content sits under a heading; the section body largely does
+  // not repeat the heading's words.
+  {
+    id: "zh-csrf",
+    query: "CSRF 跨站請求偽造是什麼",
+    locale: "zh-TW",
+    expected: ["localstorage-sessionstorage-cookie-difference"],
+    expectedHeading: "CSRF",
+    kind: "heading",
+  },
+  {
+    id: "zh-csp",
+    query: "CSP 能防止哪些攻擊",
+    locale: "zh-TW",
+    expected: ["localstorage-sessionstorage-cookie-difference"],
+    expectedHeading: "CSP",
+    kind: "heading",
+  },
+  {
+    id: "zh-t3-env",
+    query: "T3 Env 環境變數驗證在做什麼",
+    locale: "zh-TW",
+    expected: ["2026-full-stack-web-development-tech-stack-overview"],
+    expectedHeading: "T3 Env",
+    kind: "heading",
+  },
+  {
+    id: "zh-hydrate-root",
+    query: "hydrateRoot 怎麼用",
+    locale: "zh-TW",
+    expected: ["nextjs-hydration-errors-explained-solutions"],
+    expectedHeading: "hydrateRoot",
+    kind: "heading",
+  },
+  {
+    id: "zh-eventsource",
+    query: "用原生 EventSource 接 SSE",
+    locale: "zh-TW",
+    expected: ["simple-ai-chat-bot-sse-vs-websocket"],
+    expectedHeading: "EventSource",
+    kind: "heading",
+  },
+  {
+    id: "zh-sandbox-kernel",
+    query: "Docker sandbox 的 kernel 隔離差異",
+    locale: "zh-TW",
+    expected: ["docker-sandboxes-agent-isolation"],
+    expectedHeading: "Kernel",
+    kind: "heading",
+  },
+
+  // ── hard paraphrases — no content words shared with the article ───────
+  {
+    id: "zh-hard-flicker",
+    query: "頁面載入時內容閃一下就跳掉",
+    locale: "zh-TW",
+    expected: ["nextjs-hydration-errors-explained-solutions"],
+    kind: "paraphrase",
+  },
+  {
+    id: "zh-hard-token-storage",
+    query: "登入 token 放在哪裡比較安全",
+    locale: "zh-TW",
+    expected: ["localstorage-sessionstorage-cookie-difference"],
+    kind: "paraphrase",
+  },
+  {
+    id: "zh-hard-monorepo-share",
+    query: "很多專案要共用同一份程式碼怎麼管理",
+    locale: "zh-TW",
+    expected: ["tips-for-managing-node-and-bun-projects-with-pnpm"],
+    kind: "paraphrase",
+  },
+  {
+    id: "en-hard-server-push",
+    query: "push updates from the server to the browser without websockets",
+    locale: "en",
+    expected: ["simple-ai-chat-bot-sse-vs-websocket"],
+    kind: "paraphrase",
+  },
+
+  // ── en ────────────────────────────────────────────────────────────────
+  {
+    id: "en-jwt-vs-session",
+    query: "difference between JWT and session cookie authentication",
+    locale: "en",
+    expected: ["jwt-vs-session-cookie-authentication-differences"],
+    kind: "paraphrase",
+  },
+  {
+    id: "en-pgvector",
+    query: "implement semantic search with pgvector",
+    locale: "en",
+    expected: ["vector-search-embedding-postgres-implementation"],
+    kind: "paraphrase",
+  },
+  {
+    id: "en-hydration-why",
+    query: "why do hydration mismatches happen in Next.js",
+    locale: "en",
+    expected: ["nextjs-hydration-errors-explained-solutions"],
+    kind: "paraphrase",
+  },
+  {
+    id: "en-agent-sandbox",
+    query: "run Claude Code safely in an isolated sandbox",
+    locale: "en",
+    expected: ["docker-sandboxes-agent-isolation"],
+    kind: "paraphrase",
+  },
+  {
+    id: "en-rsc-share-function",
+    query: "share a function between client and server components",
+    locale: "en",
+    expected: ["react-server-module-conventions"],
+    kind: "paraphrase",
+  },
+  {
+    id: "en-cloudflare",
+    query: "protect a website from attacks with Cloudflare",
+    locale: "en",
+    expected: ["website-attack-cloudflare-protection"],
+    kind: "paraphrase",
+  },
+
+  // ── no locale (cross-locale dedupe path) ──────────────────────────────
+  {
+    id: "any-zeabur-bun",
+    query: "zeabur bun compile binary",
+    expected: ["zeabur-bun-compile-binary-pitfalls"],
+    kind: "term",
+  },
+  {
+    id: "any-pnpm-workspace",
+    query: "pnpm workspace",
+    expected: ["tips-for-managing-node-and-bun-projects-with-pnpm"],
+    kind: "term",
+  },
+];

--- a/toolings/scripts/rag-eval/index.ts
+++ b/toolings/scripts/rag-eval/index.ts
@@ -1,0 +1,379 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+import { inArray } from "drizzle-orm";
+
+import { resolveEmbeddingProvider } from "@chia/ai/embeddings/provider";
+import { EMBEDDING_INDEX_VERSION } from "@chia/ai/embeddings/utils";
+import { searchFeedsService } from "@chia/api/feeds/search";
+import type { SearchFeedsProvider } from "@chia/api/feeds/search";
+import { schema } from "@chia/db";
+import { connectDatabase, getConnection } from "@chia/db/client";
+
+import { GOLDEN_QUERIES } from "./golden-queries.ts";
+import type { GoldenQuery, GoldenQueryKind } from "./golden-queries.ts";
+
+/**
+ * Retrieval-quality benchmark: runs the golden queries through the real search
+ * stack (same code path the API serves) and reports Recall@K / MRR per mode.
+ *
+ * Run it before and after any change that affects ranking — chunking, index
+ * version bumps, fusion constants, aggregation — and compare the reports.
+ *
+ *   pnpm --filter rag-eval eval
+ *   pnpm --filter rag-eval eval mode=bm25 kind=heading
+ *   pnpm --filter rag-eval eval out=baseline.json
+ */
+
+const MODES: SearchFeedsProvider[] = ["bm25", "semantic", "hybrid"];
+/** Ranks past this count as a miss. */
+const MAX_K = 10;
+const RECALL_KS = [1, 3, 5, 10] as const;
+
+interface CLIOptions {
+  /** `all` (default) or one of `bm25 | semantic | hybrid` */
+  mode?: string;
+  /** run only queries with this kind */
+  kind?: string;
+  /** run only the query with this id */
+  id?: string;
+  /** write the full report as JSON to this path */
+  out?: string;
+  /** database env for `connectDatabase`; defaults to `local` */
+  env?: string;
+  /** explicit connection string; takes precedence over `env` */
+  "db-url"?: string;
+}
+
+const getCLIOptions = (): CLIOptions => {
+  const options: Record<string, string> = {};
+  for (const arg of process.argv.slice(2)) {
+    const [key, value] = arg.split("=");
+    if (key && value) {
+      options[key] = value;
+    }
+  }
+  return options;
+};
+
+interface QueryResult {
+  id: string;
+  kind: GoldenQueryKind;
+  query: string;
+  locale: string | null;
+  expected: string[];
+  /** slugs in rank order, length ≤ MAX_K */
+  returned: string[];
+  /** 1-based rank of the first expected slug, null on a miss */
+  firstHitRank: number | null;
+  recall: Record<number, number>;
+  /** best chunk of the first expected hit — what a citation would point at */
+  bestChunk: { kind: string; headingPath: string | null } | null;
+  /**
+   * Whether that chunk is a section under the expected heading. Only set for
+   * queries with `expectedHeading`; a ranked miss counts as a citation miss.
+   */
+  citationHit: boolean | null;
+  durationMs: number;
+  error?: string;
+}
+
+interface ModeReport {
+  mode: SearchFeedsProvider;
+  results: QueryResult[];
+  recall: Record<number, number>;
+  recallByKind: Record<GoldenQueryKind, number>;
+  mrr: number;
+  /** share of `expectedHeading` queries whose best chunk is the right section */
+  citationAccuracy: number | null;
+  avgDurationMs: number;
+  errors: number;
+}
+
+const mean = (values: number[]): number =>
+  values.length === 0
+    ? 0
+    : values.reduce((sum, value) => sum + value, 0) / values.length;
+
+const recallAt = (expected: string[], returned: string[], k: number): number =>
+  expected.filter((slug) => returned.slice(0, k).includes(slug)).length /
+  expected.length;
+
+const runQuery = async (
+  db: Awaited<ReturnType<typeof connectDatabase>>,
+  mode: SearchFeedsProvider,
+  golden: GoldenQuery
+): Promise<QueryResult> => {
+  const base = {
+    id: golden.id,
+    kind: golden.kind,
+    query: golden.query,
+    locale: golden.locale ?? null,
+    expected: golden.expected,
+  };
+
+  const startedAt = performance.now();
+  try {
+    const { items } = await searchFeedsService({
+      db,
+      keyword: golden.query,
+      model: mode,
+      locale: golden.locale,
+      limit: MAX_K,
+    });
+    const returned = items.map((item) => item.slug);
+    const firstHit = returned.findIndex((slug) =>
+      golden.expected.includes(slug)
+    );
+    const hitItem = firstHit === -1 ? null : items[firstHit]!;
+    const bestChunk = hitItem
+      ? {
+          kind: hitItem.bestChunk.kind,
+          headingPath: hitItem.bestChunk.headingPath,
+        }
+      : null;
+
+    return {
+      ...base,
+      returned,
+      firstHitRank: firstHit === -1 ? null : firstHit + 1,
+      recall: Object.fromEntries(
+        RECALL_KS.map((k) => [k, recallAt(golden.expected, returned, k)])
+      ),
+      bestChunk,
+      citationHit: golden.expectedHeading
+        ? bestChunk?.kind === "section" &&
+          (bestChunk.headingPath ?? "")
+            .toLowerCase()
+            .includes(golden.expectedHeading.toLowerCase())
+        : null,
+      durationMs: performance.now() - startedAt,
+    };
+  } catch (error) {
+    return {
+      ...base,
+      returned: [],
+      firstHitRank: null,
+      recall: Object.fromEntries(RECALL_KS.map((k) => [k, 0])),
+      bestChunk: null,
+      citationHit: golden.expectedHeading ? false : null,
+      durationMs: performance.now() - startedAt,
+      error: String(error),
+    };
+  }
+};
+
+const buildModeReport = (
+  mode: SearchFeedsProvider,
+  results: QueryResult[]
+): ModeReport => {
+  const kinds = [...new Set(results.map((result) => result.kind))];
+  return {
+    mode,
+    results,
+    recall: Object.fromEntries(
+      RECALL_KS.map((k) => [
+        k,
+        mean(results.map((result) => result.recall[k]!)),
+      ])
+    ),
+    recallByKind: Object.fromEntries(
+      kinds.map((kind) => [
+        kind,
+        mean(
+          results
+            .filter((result) => result.kind === kind)
+            .map((result) => result.recall[5]!)
+        ),
+      ])
+    ) as Record<GoldenQueryKind, number>,
+    mrr: mean(
+      results.map((result) =>
+        result.firstHitRank === null ? 0 : 1 / result.firstHitRank
+      )
+    ),
+    citationAccuracy: (() => {
+      const cited = results.filter((result) => result.citationHit !== null);
+      return cited.length === 0
+        ? null
+        : mean(cited.map((result) => (result.citationHit ? 1 : 0)));
+    })(),
+    avgDurationMs: mean(results.map((result) => result.durationMs)),
+    errors: results.filter((result) => result.error).length,
+  };
+};
+
+/**
+ * A fixture slug that no longer resolves must fail the run: it would otherwise
+ * deflate recall forever and read as a quality regression.
+ */
+const assertFixtureSlugs = async (
+  db: Awaited<ReturnType<typeof connectDatabase>>,
+  queries: GoldenQuery[]
+): Promise<void> => {
+  const slugs = [...new Set(queries.flatMap((query) => query.expected))];
+  const rows = await db
+    .select({ slug: schema.feeds.slug })
+    .from(schema.feeds)
+    .where(inArray(schema.feeds.slug, slugs));
+  const known = new Set(rows.map((row) => row.slug));
+  const missing = slugs.filter((slug) => !known.has(slug));
+  if (missing.length > 0) {
+    throw new Error(
+      `Golden queries reference slugs that do not exist: ${missing.join(", ")}. ` +
+        `Fix golden-queries.ts (or restore the local database).`
+    );
+  }
+};
+
+/** `1✓` — rank, plus the citation verdict when the query checks one. */
+const formatRank = (result: QueryResult): string => {
+  if (result.error) {
+    return "err";
+  }
+  const rank = result.firstHitRank?.toString() ?? "-";
+  return result.citationHit === null
+    ? rank
+    : `${rank}${result.citationHit ? "✓" : "✗"}`;
+};
+
+const pad = (value: string, width: number): string => value.padEnd(width);
+const num = (value: number): string => value.toFixed(2);
+
+const printReport = (queries: GoldenQuery[], reports: ModeReport[]): void => {
+  const idWidth = Math.max(...queries.map((query) => query.id.length)) + 2;
+  const kindWidth = 12;
+  const colWidth = 10;
+
+  console.log(
+    `\n${pad("query", idWidth)}${pad("kind", kindWidth)}` +
+      reports.map((report) => pad(report.mode, colWidth)).join("")
+  );
+  for (const query of queries) {
+    const cells = reports.map((report) => {
+      const result = report.results.find((entry) => entry.id === query.id)!;
+      return pad(formatRank(result), colWidth);
+    });
+    console.log(
+      `${pad(query.id, idWidth)}${pad(query.kind, kindWidth)}${cells.join("")}`
+    );
+  }
+
+  console.log(
+    `\n${pad("mode", 10)}R@1     R@3     R@5     R@10    MRR@10  cite    avg ms`
+  );
+  for (const report of reports) {
+    console.log(
+      pad(report.mode, 10) +
+        RECALL_KS.map((k) => pad(num(report.recall[k]!), 8)).join("") +
+        pad(num(report.mrr), 8) +
+        pad(
+          report.citationAccuracy === null ? "-" : num(report.citationAccuracy),
+          8
+        ) +
+        Math.round(report.avgDurationMs).toString()
+    );
+  }
+
+  const kinds = [...new Set(queries.map((query) => query.kind))];
+  console.log(`\nR@5 by kind`);
+  console.log(
+    `${pad("mode", 10)}` + kinds.map((kind) => pad(kind, kindWidth)).join("")
+  );
+  for (const report of reports) {
+    console.log(
+      pad(report.mode, 10) +
+        kinds
+          .map((kind) => pad(num(report.recallByKind[kind] ?? 0), kindWidth))
+          .join("")
+    );
+  }
+
+  for (const report of reports) {
+    if (report.errors > 0) {
+      const first = report.results.find((result) => result.error);
+      console.error(
+        `\n${report.errors} ${report.mode} queries failed; first error (${first?.id}): ${first?.error}`
+      );
+    }
+  }
+};
+
+const main = async (): Promise<void> => {
+  const options = getCLIOptions();
+
+  const modes =
+    options.mode && options.mode !== "all"
+      ? MODES.filter((mode) => mode === options.mode)
+      : MODES;
+  if (modes.length === 0) {
+    throw new Error(
+      `Unknown mode "${options.mode}". Use ${MODES.join(" | ")} | all.`
+    );
+  }
+
+  let queries = GOLDEN_QUERIES;
+  if (options.kind) {
+    queries = queries.filter((query) => query.kind === options.kind);
+  }
+  if (options.id) {
+    queries = queries.filter((query) => query.id === options.id);
+  }
+  if (queries.length === 0) {
+    throw new Error("No golden queries match the given filters.");
+  }
+
+  // `withCache: false` — a cached read would let one mode serve another's rows
+  // and corrupt the latency numbers
+  const db = options["db-url"]
+    ? await getConnection(options["db-url"], { withCache: false })
+    : await connectDatabase(options.env ?? "local", { withCache: false });
+  await assertFixtureSlugs(db, queries);
+
+  const indexKey = {
+    model: resolveEmbeddingProvider().id,
+    indexVersion: EMBEDDING_INDEX_VERSION,
+  };
+  console.log(
+    `RAG retrieval eval — ${queries.length} queries · model ${indexKey.model} · index ${indexKey.indexVersion}`
+  );
+
+  // Serial on purpose: concurrent queries would contend for the pool and the
+  // embedding API, turning avg ms into noise.
+  const reports: ModeReport[] = [];
+  for (const mode of modes) {
+    const results: QueryResult[] = [];
+    for (const query of queries) {
+      results.push(await runQuery(db, mode, query));
+    }
+    reports.push(buildModeReport(mode, results));
+  }
+
+  printReport(queries, reports);
+
+  if (options.out) {
+    mkdirSync(dirname(options.out), { recursive: true });
+    writeFileSync(
+      options.out,
+      `${JSON.stringify(
+        {
+          generatedAt: new Date().toISOString(),
+          ...indexKey,
+          maxK: MAX_K,
+          queryCount: queries.length,
+          modes: reports,
+        },
+        null,
+        2
+      )}\n`
+    );
+    console.log(`\nreport written to ${options.out}`);
+  }
+};
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/toolings/scripts/rag-eval/package.json
+++ b/toolings/scripts/rag-eval/package.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json.schemastore.org/package",
+  "name": "rag-eval",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "lint": "oxlint",
+    "lint:fix": "oxlint --fix",
+    "clean": "git clean -xdf .turbo node_modules .cache",
+    "eval": "tsx --env-file=../../../.env.global index.ts"
+  },
+  "devDependencies": {
+    "@chia/ai": "workspace:*",
+    "@chia/api": "workspace:*",
+    "@chia/db": "workspace:*",
+    "@chiastack/tsconfig": "catalog:chiastack",
+    "@types/node": "catalog:",
+    "drizzle-orm": "catalog:drizzle",
+    "typescript": "catalog:"
+  }
+}

--- a/toolings/scripts/rag-eval/package.json
+++ b/toolings/scripts/rag-eval/package.json
@@ -8,7 +8,8 @@
     "lint": "oxlint",
     "lint:fix": "oxlint --fix",
     "clean": "git clean -xdf .turbo node_modules .cache",
-    "eval": "tsx --env-file=../../../.env.global index.ts"
+    "eval": "tsx --env-file=../../../.env.global index.ts",
+    "reindex": "tsx --env-file=../../../.env.global reindex.ts"
   },
   "devDependencies": {
     "@chia/ai": "workspace:*",

--- a/toolings/scripts/rag-eval/reindex.ts
+++ b/toolings/scripts/rag-eval/reindex.ts
@@ -105,7 +105,10 @@ const main = async (): Promise<void> => {
     if (batch.length === 0) {
       break;
     }
-    const vectors = await provider.embed(batch.map((chunk) => chunk.content));
+    const vectors = await provider.embed(
+      batch.map((chunk) => chunk.content),
+      "search_document"
+    );
     if (vectors.length !== batch.length) {
       throw new Error(
         `Expected ${batch.length} embeddings, received ${vectors.length}`

--- a/toolings/scripts/rag-eval/reindex.ts
+++ b/toolings/scripts/rag-eval/reindex.ts
@@ -1,0 +1,143 @@
+import { resolveEmbeddingProvider } from "@chia/ai/embeddings/provider";
+import { EMBEDDING_INDEX_VERSION } from "@chia/ai/embeddings/utils";
+import {
+  FEED_TRANSLATION_SOURCE_TYPE,
+  getResourceAdapter,
+} from "@chia/api/resources/registry";
+import { getConnection } from "@chia/db/client";
+import { listFeedTranslationIds } from "@chia/db/repos/feeds";
+import {
+  deleteResourceChunks,
+  listChunksNeedingEmbedding,
+  replaceResourceChunks,
+  saveChunkEmbeddings,
+} from "@chia/db/repos/resources/chunk";
+
+/**
+ * Full reindex of an evaluation copy of the corpus, without the workflow
+ * runtime: rebuild every resource's chunks through the adapter, then embed
+ * whatever lacks a vector for the current `(model, index_version)`.
+ *
+ * Same repositories the real indexing steps use, so what the eval measures is
+ * what production would serve after its own reindex. Kept out of the eval
+ * runner on purpose — measuring must never mutate.
+ *
+ *   pnpm --filter rag-eval reindex db-url=postgresql://…/chia-eval
+ *
+ * `db-url` is required, and a non-localhost target additionally needs
+ * `allow-remote=true` — production reindexes go through the dashboard's
+ * `reindex:all`, which records a run; this script records nothing.
+ */
+
+const EMBED_BATCH_SIZE = 32;
+
+const options: Record<string, string> = {};
+for (const arg of process.argv.slice(2)) {
+  const [key, value] = arg.split("=");
+  if (key && value) {
+    options[key] = value;
+  }
+}
+
+const main = async (): Promise<void> => {
+  const url = options["db-url"];
+  if (!url) {
+    throw new Error(
+      "db-url is required — this script refuses implicit targets."
+    );
+  }
+  const host = new URL(url).hostname;
+  if (
+    host !== "localhost" &&
+    host !== "127.0.0.1" &&
+    options["allow-remote"] !== "true"
+  ) {
+    throw new Error(
+      `Target host "${host}" is not local. Pass allow-remote=true if you really mean it.`
+    );
+  }
+
+  const db = await getConnection(url, { withCache: false });
+  const provider = resolveEmbeddingProvider();
+  console.log(
+    `Reindexing ${host} — model ${provider.id} · index ${EMBEDDING_INDEX_VERSION}`
+  );
+
+  const ids = await listFeedTranslationIds(db, {});
+  const adapter = getResourceAdapter(FEED_TRANSLATION_SOURCE_TYPE);
+
+  let written = 0;
+  let unchanged = 0;
+  const failed: number[] = [];
+  for (const sourceId of ids) {
+    const ref = { sourceType: FEED_TRANSLATION_SOURCE_TYPE, sourceId };
+    try {
+      const chunkSet = await adapter.buildChunks(db, sourceId);
+      if (!chunkSet || chunkSet.chunks.length === 0) {
+        await deleteResourceChunks(db, { ref });
+        continue;
+      }
+      const result = await replaceResourceChunks(db, {
+        ref,
+        visibility: chunkSet.visibility,
+        chunks: chunkSet.chunks,
+      });
+      written += result.written;
+      unchanged += result.unchanged;
+    } catch (error) {
+      failed.push(sourceId);
+      console.error(`chunking failed for translation ${sourceId}:`, error);
+    }
+  }
+  console.log(
+    `chunks: ${written} written, ${unchanged} unchanged, ${failed.length} failed of ${ids.length} translations`
+  );
+
+  let embedded = 0;
+  // re-query instead of paging one snapshot — every persisted batch shrinks
+  // the backlog, so the loop terminates (same invariant as the real step)
+  while (true) {
+    const batch = await listChunksNeedingEmbedding(db, {
+      model: provider.id,
+      indexVersion: EMBEDDING_INDEX_VERSION,
+      limit: EMBED_BATCH_SIZE,
+    });
+    if (batch.length === 0) {
+      break;
+    }
+    const vectors = await provider.embed(batch.map((chunk) => chunk.content));
+    if (vectors.length !== batch.length) {
+      throw new Error(
+        `Expected ${batch.length} embeddings, received ${vectors.length}`
+      );
+    }
+    const { savedCount } = await saveChunkEmbeddings(db, {
+      model: provider.id,
+      indexVersion: EMBEDDING_INDEX_VERSION,
+      rows: batch.map((chunk, index) => ({
+        chunkId: chunk.id,
+        embedding: vectors[index]!,
+      })),
+    });
+    if (savedCount === 0) {
+      throw new Error(
+        `Persisted no embeddings for ${batch.length} pending chunks — aborting instead of spinning.`
+      );
+    }
+    embedded += savedCount;
+    console.log(`embedded ${embedded}…`);
+  }
+
+  console.log(`done: ${embedded} vectors embedded`);
+  if (failed.length > 0) {
+    console.error(`translations that failed chunking: ${failed.join(", ")}`);
+    process.exitCode = 1;
+  }
+};
+
+main()
+  .then(() => process.exit(process.exitCode ?? 0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/toolings/scripts/rag-eval/tsconfig.json
+++ b/toolings/scripts/rag-eval/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@chiastack/tsconfig/base.json",
+  "include": ["."],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "lib": ["ES2024"],
+    "allowImportingTsExtensions": true
+  }
+}

--- a/toolings/scripts/seed/README.md
+++ b/toolings/scripts/seed/README.md
@@ -1,13 +1,16 @@
 # Database seed script
 
 ```bash
-pnpm db:seed -- action=seedPost withEmbedding=true
+pnpm db:seed -- action=seedPost
 ```
 
 ## Options
 
-| Name          | Description                   | Required | Default |
-| ------------- | ----------------------------- | -------- | ------- |
-| env           | Environment                   | No       | local   |
-| action        | Action to run                 | Yes      | -       |
-| withEmbedding | Whether to generate embedding | No       | false   |
+| Name   | Description   | Required | Default |
+| ------ | ------------- | -------- | ------- |
+| env    | Environment   | No       | local   |
+| action | Action to run | Yes      | -       |
+
+Actions: `seedPost`, `seedNote`. Search chunks and vectors are not seeded —
+they come from the indexing workflow (`docs/rag-architecture.md`); trigger a
+reindex from the dashboard when the seeded rows should be searchable.

--- a/toolings/scripts/seed/index.ts
+++ b/toolings/scripts/seed/index.ts
@@ -1,11 +1,9 @@
 import { faker } from "@faker-js/faker";
 
-import { generateEmbedding } from "@chia/ai/embeddings/openai";
 import { schema } from "@chia/db";
 import type { DB } from "@chia/db";
 import { connectDatabase } from "@chia/db/client";
 import { getAdminId } from "@chia/utils/config";
-import { tryCatch } from "@chia/utils/error-helper";
 
 const withReplicas = (
   fun: (database: DB, adminId: string, env?: string) => Promise<void> | void,
@@ -75,94 +73,68 @@ console.log('Hello World');
 \`\`\`
 `;
 
-const seedPost = withReplicas(
-  async (db, adminId) => {
-    await db.transaction(async (trx) => {
-      let tags = await trx.select().from(schema.tags);
-      if (tags.length === 0) {
-        tags = await trx
-          .insert(schema.tags)
-          .values([
-            {
-              slug: "tag1",
-            },
-            {
-              slug: "tag2",
-            },
-          ])
-          .returning();
+/**
+ * One feed with a zh-TW translation and two tags.
+ *
+ * The body goes straight into `feed_translation.content` — there is no
+ * separate content table and no embedding column any more. Search vectors are
+ * the indexing workflow's job (`docs/rag-architecture.md`); seeded rows get
+ * them from a reindex, not from the seed.
+ */
+const seedFeed = (type: "post" | "note") =>
+  withReplicas(
+    async (db, adminId) => {
+      await db.transaction(async (trx) => {
+        let tags = await trx.select().from(schema.tags);
+        if (tags.length === 0) {
+          tags = await trx
+            .insert(schema.tags)
+            .values([{ slug: "tag1" }, { slug: "tag2" }])
+            .returning();
 
-        // Create tag translations
-        if (tags[0]?.id && tags[1]?.id) {
-          await trx.insert(schema.tagTranslations).values([
-            {
-              tagId: tags[0].id,
-              locale: "zh-TW",
-              name: "標籤 1",
-              description: "這是標籤 1 的描述",
-            },
-            {
-              tagId: tags[1].id,
-              locale: "zh-TW",
-              name: "標籤 2",
-              description: "這是標籤 2 的描述",
-            },
-          ]);
+          if (tags[0]?.id && tags[1]?.id) {
+            await trx.insert(schema.tagTranslations).values([
+              {
+                tagId: tags[0].id,
+                locale: "zh-TW",
+                name: "標籤 1",
+                description: "這是標籤 1 的描述",
+              },
+              {
+                tagId: tags[1].id,
+                locale: "zh-TW",
+                name: "標籤 2",
+                description: "這是標籤 2 的描述",
+              },
+            ]);
+          }
         }
-      }
 
-      // 1. Create feed (base info only)
-      const feed = await trx
-        .insert(schema.feeds)
-        .values({
-          slug: faker.lorem.slug(),
-          type: "post",
-          userId: adminId,
-          published: true,
-          defaultLocale: "zh-TW",
-          contentType: "mdx",
-        })
-        .returning({ feedId: schema.feeds.id });
+        const feed = await trx
+          .insert(schema.feeds)
+          .values({
+            slug: faker.lorem.slug(),
+            type,
+            userId: adminId,
+            published: true,
+            defaultLocale: "zh-TW",
+            contentType: "mdx",
+          })
+          .returning({ feedId: schema.feeds.id });
 
-      if (!feed[0]?.feedId) {
-        throw new Error("Feed ID not found");
-      }
+        if (!feed[0]?.feedId) {
+          throw new Error("Feed ID not found");
+        }
+        if (!tags[0]?.id || !tags[1]?.id) {
+          throw new Error("Tag ID not found");
+        }
 
-      if (!tags[0]?.id || !tags[1]?.id) {
-        throw new Error("Tag ID not found");
-      }
+        await trx.insert(schema.feedsToTags).values([
+          { feedId: feed[0].feedId, tagId: tags[0].id },
+          { feedId: feed[0].feedId, tagId: tags[1].id },
+        ]);
 
-      // 2. Create feed tags
-      await trx.insert(schema.feedsToTags).values([
-        {
-          feedId: feed[0].feedId,
-          tagId: tags[0].id,
-        },
-        {
-          feedId: feed[0].feedId,
-          tagId: tags[1].id,
-        },
-      ]);
-
-      // 3. Generate embedding if needed
-      const withEmbedding =
-        getCLIOptions().withEmbedding === "true" ||
-        getCLIOptions().withEmbedding === "1";
-
-      const { data: embeddingData, error: embeddingError } = await tryCatch(
-        withEmbedding
-          ? generateEmbedding(CONTENT)
-          : Promise.reject(new Error("disable embedding"))
-      );
-
-      if (embeddingError) {
-        console.info("Failed to generate embedding:", embeddingError);
-      }
-
-      // 4. Create feed translation (zh-TW)
-      const translation = await trx
-        .insert(schema.feedTranslations)
-        .values({
+        await trx.insert(schema.feedTranslations).values({
           feedId: feed[0].feedId,
           locale: "zh-TW",
           title: faker.lorem.sentence(),
@@ -170,152 +142,19 @@ const seedPost = withReplicas(
           description: faker.lorem.paragraph(),
           summary: faker.lorem.paragraph(),
           readTime: Math.floor(Math.random() * 10) + 1,
-          embedding: embeddingData ?? undefined,
-        })
-        .returning({ translationId: schema.feedTranslations.id });
-
-      if (!translation[0]?.translationId) {
-        throw new Error("Translation ID not found");
-      }
-
-      // 5. Create content
-      await trx.insert(schema.contents).values({
-        feedTranslationId: translation[0].translationId,
-        content: CONTENT,
-        source: CONTENT,
+          content: CONTENT,
+          source: CONTENT,
+        });
       });
-    });
-  },
-  {
-    env: getCLIOptions().env ?? "local",
-  }
-);
-
-const seedNote = withReplicas(
-  async (db, adminId) => {
-    await db.transaction(async (trx) => {
-      let tags = await trx.select().from(schema.tags);
-      if (tags.length === 0) {
-        tags = await trx
-          .insert(schema.tags)
-          .values([
-            {
-              slug: "tag1",
-            },
-            {
-              slug: "tag2",
-            },
-          ])
-          .returning();
-
-        // Create tag translations
-        if (tags[0]?.id && tags[1]?.id) {
-          await trx.insert(schema.tagTranslations).values([
-            {
-              tagId: tags[0].id,
-              locale: "zh-TW",
-              name: "標籤 1",
-              description: "這是標籤 1 的描述",
-            },
-            {
-              tagId: tags[1].id,
-              locale: "zh-TW",
-              name: "標籤 2",
-              description: "這是標籤 2 的描述",
-            },
-          ]);
-        }
-      }
-
-      // 1. Create feed (base info only)
-      const feed = await trx
-        .insert(schema.feeds)
-        .values({
-          slug: faker.lorem.slug(),
-          type: "note",
-          userId: adminId,
-          published: true,
-          defaultLocale: "zh-TW",
-          contentType: "mdx",
-        })
-        .returning({ feedId: schema.feeds.id });
-
-      if (!feed[0]?.feedId) {
-        throw new Error("Feed ID not found");
-      }
-
-      if (!tags[0]?.id || !tags[1]?.id) {
-        throw new Error("Tag ID not found");
-      }
-
-      // 2. Create feed tags
-      await trx.insert(schema.feedsToTags).values([
-        {
-          feedId: feed[0].feedId,
-          tagId: tags[0].id,
-        },
-        {
-          feedId: feed[0].feedId,
-          tagId: tags[1].id,
-        },
-      ]);
-
-      // 3. Generate embedding if needed
-      const withEmbedding =
-        getCLIOptions().withEmbedding === "true" ||
-        getCLIOptions().withEmbedding === "1";
-
-      const { data: embeddingData, error: embeddingError } = await tryCatch(
-        withEmbedding
-          ? generateEmbedding(CONTENT)
-          : Promise.reject(new Error("disable embedding"))
-      );
-
-      if (embeddingError) {
-        console.info("Failed to generate embedding:", embeddingError);
-      }
-
-      // 4. Create feed translation (zh-TW)
-      const translation = await trx
-        .insert(schema.feedTranslations)
-        .values({
-          feedId: feed[0].feedId,
-          locale: "zh-TW",
-          title: faker.lorem.sentence(),
-          excerpt: faker.lorem.paragraph(),
-          description: faker.lorem.paragraph(),
-          summary: faker.lorem.paragraph(),
-          readTime: Math.floor(Math.random() * 10) + 1,
-          embedding: embeddingData ?? undefined,
-        })
-        .returning({ translationId: schema.feedTranslations.id });
-
-      if (!translation[0]?.translationId) {
-        throw new Error("Translation ID not found");
-      }
-
-      // 5. Create content
-      await trx.insert(schema.contents).values({
-        feedTranslationId: translation[0].translationId,
-        content: CONTENT,
-        source: CONTENT,
-      });
-    });
-  },
-  {
-    env: getCLIOptions().env ?? "local",
-  }
-);
+    },
+    {
+      env: getCLIOptions().env ?? "local",
+    }
+  );
 
 const seedActions = [
-  {
-    name: "seedPost",
-    fn: seedPost,
-  },
-  {
-    name: "seedNote",
-    fn: seedNote,
-  },
+  { name: "seedPost", fn: seedFeed("post") },
+  { name: "seedNote", fn: seedFeed("note") },
 ];
 
 const seed = async () => {

--- a/toolings/scripts/seed/package.json
+++ b/toolings/scripts/seed/package.json
@@ -10,11 +10,7 @@
     "clean": "git clean -xdf .turbo node_modules .cache",
     "db:seed": "tsx --env-file=../../../.env.global index.ts"
   },
-  "dependencies": {
-    "drizzle-orm": "catalog:drizzle"
-  },
   "devDependencies": {
-    "@chia/ai": "workspace:*",
     "@chia/db": "workspace:*",
     "@chia/utils": "workspace:*",
     "@chiastack/tsconfig": "catalog:chiastack",


### PR DESCRIPTION
## Summary

Builds a retrieval-quality benchmark for the RAG stack, then uses it to land four measured retrieval fixes plus a parser migration and dead-code cleanup. Every ranking change in this PR was validated against a restored copy of the production corpus (`chia-eval`), before/after.

### 1. Eval harness (`toolings/scripts/rag-eval`) — 69ef9100
- 36 golden queries against the real corpus, run through `searchFeedsService` (the exact code path the API serves) per mode (`bm25` / `semantic` / `hybrid`)
- Reports Recall@K, MRR@10, and **citation accuracy** (whether a hit's best chunk is the section the query asked about), grouped by query kind (`paraphrase` / `term` / `heading`)
- `reindex` script rebuilds an eval copy without the workflow runtime; refuses non-local targets without `allow-remote=true`

### 2. Heading paths baked into section chunks + decay-sum aggregation — ae4a23c6
- Section chunk content now starts with its full heading path. Heading words are exactly what a body rarely repeats — BM25 citation accuracy went **0.33 → 0.83**. Also makes heading edits change the content hash, killing the stale-`heading_path` case.
- `aggregateChunkHits` scores a resource by the decayed sum (1, ¼, ¹⁄₁₆) of its top-3 chunks. A mean never rewards breadth; a plain sum (tried first, caught by the eval) let long articles out-pile short focused ones on RRF's nearly-flat scores. Decay 0.25 measured best on the hybrid path.

### 3. Content-identity chunks, task-aware embeddings, richer hits — 7babee7e
- **Chunk identity is content, not position** (`planChunkReplacement`): inserts/reorders become moves that keep their vectors instead of rewriting the whole tail. Moves land in two phases to satisfy the unique `(source, kind, chunk_index)` index. Packing no longer crosses H1/H2 boundaries, bounding edit cascades to one group — verified: a mid-document insert costs a handful of embeddings instead of the whole document.
- `EmbeddingProvider.embed()` takes a required `search_document` / `search_query` task — the Ollama path hardcoded the document prefix for queries, which silently degrades asymmetric models.
- `ChunkHit` carries the chunk's stored `content`, so hybrid/semantic hits (which cannot have a ParadeDB snippet) show why they matched; the agent's `get_post` accepts `focusHeadings` so matched sections survive budget degradation first.
- Cleanup: seed script rewritten against the current schema (it referenced the removed `contents` table and did not compile); dead `generateEmbedding` / `buildIndexKey` / `normalizeQueryForEmbedding` and unused `kv` plumbing removed.

### 4. Parse MDX with remark instead of regexes — 6298c51b
- `markdown.ts` rewritten on mdast (`remark-parse` + `gfm` + `mdx`), applying edits by node position over the original source so chunk text stays the author's text. Fixes the three regex failure modes: multi-line JSX opening tags, `{expressions}` leaking into chunks, and fences with meta strings never being condensed. Invalid MDX falls back to plain-markdown parsing instead of failing the run.
- Parser loads dynamically to stay off the service boot path; heading titles become the plain text the rendered page slugs.

## Eval results (baseline → final)

| mode | R@1 | MRR@10 | citation |
|---|---|---|---|
| bm25 | 0.92 → 0.92 | 0.95 → 0.94 | **0.33 → 0.67** |
| semantic | 0.89 → **0.92** | 0.93 → **0.95** | 0.83 |
| hybrid | 0.86 → **0.89** | 0.92 → **0.94** | 0.83 |

R@5 is 1.00 for every query group in every mode. bm25's MRR dip is confined to two hard-paraphrase queries the lexical path was never the serving mode for (hybrid/semantic rank them #1).

## Notes

- `EMBEDDING_INDEX_VERSION` → `2026-08-16.3`. **After deploy, run `reindex:all` from the dashboard** — old vectors keep serving until the rebuild completes, no downtime.
- `docs/rag-architecture.md` updated throughout (as-built).
- 345 tests pass; `type:check` / `lint` clean across the graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Markdown and MDX processing, including heading-aware chunking, cleaner excerpts, and code-block handling.
  * Search results now provide better snippets, heading context, and relevance ranking.
  * Document retrieval can prioritize sections matching the user’s requested headings.
  * Content updates preserve search embeddings when sections move without changing.
* **Bug Fixes**
  * Added fallback search snippets when highlighted text is unavailable.
  * Improved handling of oversized sections and grouped document content.
* **Documentation**
  * Added retrieval evaluation guidance, benchmarks, and updated indexing documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->