### PR TITLE
fix(agent): writing-agent harness friction and approval presentation

### DIFF
--- a/apps/dash/src/components/agent/agent-draft-preview.tsx
+++ b/apps/dash/src/components/agent/agent-draft-preview.tsx
@@ -13,6 +13,29 @@ interface AgentDraftPreviewProps {
 
 const jsonOf = <TValue,>(value: TValue) => JSON.stringify(value, null, 2);
 
+/** Per-locale fields `commit_draft` carries; shown even when empty so a gap is visible. */
+const TRANSLATION_FIELDS = ["excerpt", "description", "summary"] as const;
+
+const MetaField = ({
+  label,
+  value,
+}: {
+  label: string;
+  value?: string | null;
+}) => (
+  <div className="flex flex-col gap-1">
+    <div className="flex items-center gap-2">
+      <span className="text-muted text-xs font-medium uppercase">{label}</span>
+      {value ? null : (
+        <Chip color="warning" size="sm" variant="soft">
+          <Chip.Label>missing</Chip.Label>
+        </Chip>
+      )}
+    </div>
+    {value ? <p className="text-sm">{value}</p> : null}
+  </div>
+);
+
 export const AgentDraftPreview = ({ draft }: AgentDraftPreviewProps) => {
   if (!draft) {
     return (
@@ -60,14 +83,23 @@ export const AgentDraftPreview = ({ draft }: AgentDraftPreviewProps) => {
             <Card key={locale} variant="secondary">
               <Card.Header className="flex-row items-center gap-2">
                 <Card.Title>{translation.title || "Untitled"}</Card.Title>
+                {translation.title ? null : (
+                  <Chip color="warning" size="sm" variant="soft">
+                    <Chip.Label>missing title</Chip.Label>
+                  </Chip>
+                )}
                 <Chip className="ml-auto" size="sm" variant="soft">
                   <Chip.Label>{locale}</Chip.Label>
                 </Chip>
               </Card.Header>
               <Card.Content className="gap-4">
-                {translation.excerpt ? (
-                  <p className="text-muted text-sm">{translation.excerpt}</p>
-                ) : null}
+                {TRANSLATION_FIELDS.map((field) => (
+                  <MetaField
+                    key={field}
+                    label={field}
+                    value={translation[field]}
+                  />
+                ))}
                 <pre className="bg-surface max-h-120 overflow-auto rounded-xl p-4 text-sm leading-6 whitespace-pre-wrap">
                   {translation.content || "No content yet."}
                 </pre>

--- a/apps/service/src/services/writing-agent.service.ts
+++ b/apps/service/src/services/writing-agent.service.ts
@@ -337,28 +337,20 @@ const undecidedApprovals = async (
 };
 
 /**
- * The branch up to the leaf the running turn started from, plus that turn's own leading user
- * messages: the live replay carries no user text (the client already has what it sent), so the
- * prompt the turn is answering has to come from here for a rejoining client to see it.
+ * The branch up to the leaf the running turn started from. Everything after it — the turn's own
+ * user message included — is replayed by `attach` from the run's stream, which starts at the
+ * marker's `streamIndex`, before the turn announces `user`. Taking the user message from both
+ * sources showed it twice to a client that rejoined mid-turn.
  */
 const entriesBeforeTurn = (
   entries: SessionTreeEntry[],
   turn: AgentTurnMarker
 ): SessionTreeEntry[] => {
-  const leafIndex =
-    turn.leafEntryId === null
-      ? -1
-      : entries.findIndex((entry) => entry.id === turn.leafEntryId);
+  if (turn.leafEntryId === null) return [];
+  const leafIndex = entries.findIndex((entry) => entry.id === turn.leafEntryId);
   // A marker that is not on this branch cannot cut it; show everything rather than guess.
-  if (turn.leafEntryId !== null && leafIndex === -1) return entries;
-
-  let end = leafIndex + 1;
-  while (end < entries.length) {
-    const entry = entries[end];
-    if (entry?.type !== "message" || entry.message.role !== "user") break;
-    end += 1;
-  }
-  return entries.slice(0, end);
+  if (leafIndex === -1) return entries;
+  return entries.slice(0, leafIndex + 1);
 };
 
 const detailFor = async (caller: AgentServiceCaller, sessionId: string) => {
@@ -410,14 +402,15 @@ const detailFor = async (caller: AgentServiceCaller, sessionId: string) => {
   }
   const events = entriesToWireEvents(transcriptEntries, replayOptions);
 
-  // Surface approvals still waiting on a decision, so a reload restores the prompt.
-  const pendingApprovals = approvals
-    .filter((approval) => approval.status === "pending")
-    .map((approval) => ({
-      toolCallId: approval.toolCallId,
-      toolName: approval.toolName,
-      args: approval.args ?? undefined,
-    }));
+  // Approval events are never replayed from the transcript; the rows are. A pending row restores
+  // the prompt on reload, a decided one closes its card the way the live stream did.
+  const approvalRows = approvals.map((approval) => ({
+    toolCallId: approval.toolCallId,
+    toolName: approval.toolName,
+    args: approval.args ?? undefined,
+    status: approval.status,
+    comment: approval.comment ?? undefined,
+  }));
 
   return {
     session: summaryOf(row),
@@ -428,7 +421,7 @@ const detailFor = async (caller: AgentServiceCaller, sessionId: string) => {
       /* SAFETY: The producer contract guarantees this value satisfies never. */ draftState as never,
     run,
     events,
-    pendingApprovals,
+    approvals: approvalRows,
     stats: {
       messageCount: stats.messageCount,
       totalTokens: stats.totalTokens,

--- a/apps/service/src/steps/agent-turn.step.ts
+++ b/apps/service/src/steps/agent-turn.step.ts
@@ -7,6 +7,7 @@ import type {
   ThinkingLevel,
   ToolTier,
 } from "@chia/agent-runtime/types";
+import type { OperatorDecision } from "@chia/agent-runtime/wire/operator-decision";
 import type { AgentWireEvent } from "@chia/agent-runtime/wire/schema";
 import type { DB } from "@chia/db/client";
 import { connectDatabase } from "@chia/db/client";
@@ -98,6 +99,8 @@ export interface AgentTurnRequest {
   abortController: AgentAbortControllerRef;
   text: string;
   template?: { name: string; args?: string[] };
+  /** Set when this turn relays an operator's decision on a gated call; see `AgentTurnMessage`. */
+  decision?: OperatorDecision;
   preAuthorizeToolNames?: string[];
   /**
    * The operator's own provider keys, still encrypted — see `services/agent-credentials.ts`.
@@ -294,6 +297,7 @@ async function runWritingAgentTurn(
     message: {
       text: request.text,
       template: request.template,
+      decision: request.decision,
     },
     toApproval: (approval): AgentApprovalRequestSnapshot => ({
       toolCallId: approval.toolCallId,

--- a/apps/service/src/workflows/agent-session.workflow.ts
+++ b/apps/service/src/workflows/agent-session.workflow.ts
@@ -1,5 +1,8 @@
 import * as z from "zod";
 
+import { formatOperatorDecision } from "@chia/agent-runtime/wire/operator-decision";
+import type { OperatorDecision } from "@chia/agent-runtime/wire/operator-decision";
+
 import {
   closeAgentStreamsStep,
   completeAgentRunStep,
@@ -132,6 +135,13 @@ export const agentSessionWorkflow = async (request: Request) => {
       });
       credentials = decision.credentials;
 
+      const relayed: OperatorDecision = {
+        toolCallId: gated.toolCallId,
+        toolName: gated.toolName,
+        approved: decision.approved,
+        comment: decision.comment,
+      };
+
       if (!decision.approved) {
         turns += 1;
         // Rejected: tell the agent why and let it respond, rather than silently stopping.
@@ -142,10 +152,8 @@ export const agentSessionWorkflow = async (request: Request) => {
           sessionId,
           userId,
           abortController,
-          text:
-            `The operator declined \`${gated.toolName}\`.` +
-            (decision.comment ? ` They said: ${decision.comment}` : "") +
-            " Do not retry it. Acknowledge and wait for further instructions.",
+          text: formatOperatorDecision(relayed),
+          decision: relayed,
           credentials,
         });
         continue;
@@ -156,10 +164,8 @@ export const agentSessionWorkflow = async (request: Request) => {
         sessionId,
         userId,
         abortController,
-        text:
-          `The operator approved \`${gated.toolName}\`.` +
-          (decision.comment ? ` They said: ${decision.comment}` : "") +
-          " Run it now.",
+        text: formatOperatorDecision(relayed),
+        decision: relayed,
         // The approval is already persisted, so the gate lets this call through.
         preAuthorizeToolNames: [gated.toolName],
         credentials,

--- a/docs/agent-architecture.md
+++ b/docs/agent-architecture.md
@@ -367,7 +367,15 @@ published-only for every caller. The writing agent's port is `author`; a public 
 
 `buildSystemPrompt` is the stable system prompt; `buildTurnContext` is the volatile block with the
 draft state and current time (see §4). Skills and prompt templates live under
-`packages/agent-writing/src/prompts/`.
+`packages/agent-writing/src/prompts/`. The system prompt carries only the skills _index_ (name
+and description); the model loads a skill's full text with the `read_skill` tool (tier `read`).
+That tool is the only read path — Pi's own convention of reading `SKILL.md` from disk has no file
+tool behind it here — and it leaves a tool call in the thread, so the operator can see which rules
+were consulted.
+
+The draft store's merge semantics (`undefined` leaves a field alone, `null` clears it) live once in
+`draft/operations.ts`; both `PgDraftStore` and `InMemoryDraftStore` go through it, so the store the
+tests run against cannot diverge from the one production uses.
 
 There is no in-process conversational state. The process-level kind-to-service map contains only
 implementations; all mutable state is durable:

--- a/docs/agent-architecture.md
+++ b/docs/agent-architecture.md
@@ -248,8 +248,9 @@ acknowledge the operator's comment.
 the approval card while the model is still writing its hand-back. Persistence still waits for the
 provider turn to succeed and writes the whole batch atomically, so a provider or persistence failure
 returns an `error` turn with no undecided approval rows and the workflow never waits for a hook it
-cannot resume; the client retracts announced-but-unpersisted cards on any `run:end` other than
-`awaiting_approval`.
+cannot resume. The client keeps the card locked until `run:end{awaiting_approval}` (or a reloaded
+pending row) — a decision sent before the row exists would have nothing to land on — and retracts
+announced-but-unpersisted cards on any other `run:end`.
 
 The relay turn is a real user message to the model — that is what makes it act — but the operator
 did not type it. `AgentTurnMessage.decision` marks it: the turn emits `approval:resolved` before

--- a/docs/agent-architecture.md
+++ b/docs/agent-architecture.md
@@ -226,14 +226,15 @@ sequenceDiagram
     participant DB as agent_tool_approval
 
     M->>G: commit tool call
+    G-->>R: emit approval:request at once
     G-->>M: blocked; stop and await approval
-    G-->>R: collect request
-    R->>DB: atomically persist collected requests
-    R-->>WF: emit approval:request after persistence
+    R->>DB: atomically persist collected requests at turn end
+    R-->>WF: run:end{awaiting_approval}
     WF->>WF: park on approval hook
     OP->>DB: persist decision
     OP->>WF: resume hook
-    WF->>M: acknowledgement/execution turn
+    WF->>R: relay turn (text from formatOperatorDecision, plus the decision)
+    R-->>OP: approval:resolved, then user{origin: operator-decision}
     M->>G: re-issued call
     G-->>M: allowed when pre-authorized
 ```
@@ -243,9 +244,19 @@ was durably approved, or its tool name is pre-authorized for this turn. The deci
 before the workflow is resumed. Rejections also receive a follow-up turn so the agent can
 acknowledge the operator's comment.
 
-Approval requests are published only after the provider turn succeeds and the whole request batch
-has been persisted. A provider or persistence failure therefore returns an `error` turn with no
-undecided approval rows, so the workflow never waits for a hook that it cannot resume.
+`approval:request` is announced the moment the gate refuses, so the client swaps the tool card for
+the approval card while the model is still writing its hand-back. Persistence still waits for the
+provider turn to succeed and writes the whole batch atomically, so a provider or persistence failure
+returns an `error` turn with no undecided approval rows and the workflow never waits for a hook it
+cannot resume; the client retracts announced-but-unpersisted cards on any `run:end` other than
+`awaiting_approval`.
+
+The relay turn is a real user message to the model — that is what makes it act — but the operator
+did not type it. `AgentTurnMessage.decision` marks it: the turn emits `approval:resolved` before
+`user`, and the `user` event carries `origin: "operator-decision"` so the client renders a notice
+rather than a user bubble. Replay cannot see the marker, so the text itself is recognisable
+(`wire/operator-decision.ts`), and the session detail lists every approval row — pending rows
+restore the prompt on reload, decided rows close their card the way the live stream did.
 
 ## 6. Wire events and streaming
 

--- a/packages/agent-content/src/tools/read.tool.ts
+++ b/packages/agent-content/src/tools/read.tool.ts
@@ -101,8 +101,9 @@ export const getPostTool = defineTool({
     focusHeadings: Type.Optional(
       Type.Array(Type.String(), {
         description:
-          "Heading paths (from search results' `headingPath`) to keep first when the post is too " +
-          "long to return in full.",
+          "Heading paths to keep first when the post is too long to return in full. Pass each " +
+          "search hit's `headingPath` string unchanged, e.g. " +
+          '`["Setup > Install", "Caveats"]`.',
       })
     ),
   }),

--- a/packages/agent-elements/__tests__/store.test.ts
+++ b/packages/agent-elements/__tests__/store.test.ts
@@ -30,7 +30,7 @@ const detailOf = (
   },
   run: null,
   events: [],
-  pendingApprovals: [],
+  approvals: [],
   stats: { messageCount: 0, totalTokens: 0, costTotal: 0 },
   ...overrides,
 });
@@ -164,8 +164,13 @@ describe("foldDetail", () => {
             summary: "blocked",
           },
         ],
-        pendingApprovals: [
-          { toolCallId: "t1", toolName: "commit_post", args: { slug: "x" } },
+        approvals: [
+          {
+            toolCallId: "t1",
+            toolName: "commit_post",
+            args: { slug: "x" },
+            status: "pending",
+          },
         ],
       })
     );
@@ -175,6 +180,47 @@ describe("foldDetail", () => {
     const tool = view.items.find((item) => item.kind === "tool");
     expect(tool).toMatchObject({ status: "awaiting_approval", tier: "commit" });
     expect(view.runStatus).toBe("awaiting_approval");
+  });
+
+  it("closes a decided approval's card on reload the way the live stream did", () => {
+    const view = foldDetail(
+      detailOf({
+        events: [
+          { type: "user", messageId: "u1", text: "publish" },
+          {
+            type: "tool:start",
+            toolCallId: "t1",
+            toolName: "commit_post",
+            label: "Commit post",
+            tier: "commit",
+            args: { slug: "x" },
+          },
+          {
+            type: "tool:end",
+            toolCallId: "t1",
+            toolName: "commit_post",
+            isError: true,
+            summary: "blocked",
+          },
+        ],
+        approvals: [
+          {
+            toolCallId: "t1",
+            toolName: "commit_post",
+            args: { slug: "x" },
+            status: "approved",
+            comment: "ship it",
+          },
+        ],
+      })
+    );
+    expect(view.pendingApprovals).toEqual([]);
+    const tool = view.items.find((item) => item.kind === "tool");
+    expect(tool).toMatchObject({
+      status: "ok",
+      approval: { approved: true, comment: "ship it" },
+    });
+    expect(view.runStatus).toBe("idle");
   });
 
   it("derives the run status from the server run, not the last replayed event", () => {

--- a/packages/agent-elements/src/approval-card.tsx
+++ b/packages/agent-elements/src/approval-card.tsx
@@ -30,8 +30,9 @@ export interface ApprovalCardProps {
 }
 
 /**
- * The approval handshake, in place in the transcript. Deciding starts the follow-up turn through
- * the store, so both buttons lock the moment one is pressed. A note travels with the decision as
+ * The approval handshake, in place in the transcript. The buttons unlock when the turn has handed
+ * back and lock again the moment one is pressed — deciding starts the follow-up turn through the
+ * store. A note travels with the decision as
  * its comment; "always allow" adds the tool's tier to the session's auto-approve list first, so
  * the same tier never asks again this session.
  */
@@ -43,8 +44,11 @@ export const ApprovalCard = ({ className, tool }: ApprovalCardProps) => {
   const sessionId = useAgentSession((state) => state.sessionId);
   const kind = useAgentSession((state) => state.kind);
   const autoApprove = useSessionDetail().data?.settings?.autoApprove;
-  const streaming = useAgentSession(
-    (state) => state.connection === "streaming"
+  // Decidable only once the turn has handed back: the request is announced while the model is
+  // still writing and before the server has persisted it, and a decision sent in that window
+  // has no row to land on. `run:end{awaiting_approval}` and a reloaded pending row both set this.
+  const decidable = useAgentSession(
+    (state) => state.view.runStatus === "awaiting_approval"
   );
   const [deciding, setDeciding] = useState<boolean | null>(null);
   const [noteOpen, setNoteOpen] = useState(false);
@@ -78,7 +82,7 @@ export const ApprovalCard = ({ className, tool }: ApprovalCardProps) => {
   };
 
   const pending = tool.approval === undefined;
-  const locked = streaming || deciding !== null;
+  const locked = !decidable || deciding !== null;
   const args = jsonOf(tool.args);
 
   return (

--- a/packages/agent-elements/src/notice.tsx
+++ b/packages/agent-elements/src/notice.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Alert } from "@heroui/react";
-import { Archive, CircleAlert } from "lucide-react";
+import { Archive, CircleAlert, ShieldCheck } from "lucide-react";
 
 import type { NoticeView } from "@chia/agent-runtime/wire/fold";
 import { cn } from "@chia/ui/utils/cn.util";
@@ -13,9 +13,23 @@ export interface NoticeProps {
   className?: string;
 }
 
-/** Compaction and agent-side errors, inline where they happened in the transcript. */
+/**
+ * Compaction, relayed approval decisions and agent-side errors, inline where they happened in the
+ * transcript.
+ */
 export const Notice = ({ className, notice }: NoticeProps) => {
   const labels = useAgentLabels();
+
+  if (notice.variant === "decision") {
+    return (
+      <div
+        className={cn("text-muted flex items-center gap-2 text-xs", className)}>
+        <ShieldCheck className="size-3.5" />
+        <span className="font-medium">{labels.decisionRelayed}</span>
+        <span className="truncate">{notice.text}</span>
+      </div>
+    );
+  }
 
   if (notice.variant === "compacted") {
     return (

--- a/packages/agent-elements/src/store.ts
+++ b/packages/agent-elements/src/store.ts
@@ -80,28 +80,30 @@ const messageOf = (cause: unknown): string =>
   cause instanceof Error ? cause.message : String(cause);
 
 /**
- * The persisted transcript never replays approval events, so the server lists undecided
- * approvals separately; they are re-applied here so a reload restores the prompt in place.
+ * The persisted transcript never replays approval events, so the server lists the approval rows
+ * separately; they are re-applied here so a reload shows each card as the live stream left it.
  */
 export const foldDetail = (detail: AgentSessionDetail): AgentViewState => {
   let view = foldEvents(detail.events);
-  for (const approval of detail.pendingApprovals) {
-    if (
-      view.pendingApprovals.some(
-        (pending) => pending.toolCallId === approval.toolCallId
-      )
-    ) {
-      continue;
-    }
+  for (const approval of detail.approvals) {
     const tool = view.items.find(
       (item) => item.kind === "tool" && item.toolCallId === approval.toolCallId
     );
+    // A row for a call that is not on this branch (a rewound session) has nothing to attach to.
+    if (tool?.kind !== "tool") continue;
     view = applyEvent(view, {
       type: "approval:request",
       toolCallId: approval.toolCallId,
       toolName: approval.toolName,
-      tier: tool?.kind === "tool" ? tool.tier : "",
-      args: approval.args ?? (tool?.kind === "tool" ? tool.args : undefined),
+      tier: tool.tier,
+      args: approval.args ?? tool.args,
+    });
+    if (approval.status === "pending") continue;
+    view = applyEvent(view, {
+      type: "approval:resolved",
+      toolCallId: approval.toolCallId,
+      approved: approval.status === "approved",
+      comment: approval.comment,
     });
   }
   // Replay carries no run boundaries, so the reducer's status reflects the last event, not the run.

--- a/packages/agent-runtime/__tests__/fold.test.ts
+++ b/packages/agent-runtime/__tests__/fold.test.ts
@@ -48,6 +48,18 @@ describe("approval fold", () => {
     expect(view.runStatus).toBe("awaiting_approval");
   });
 
+  it("does not make the request decidable before the turn has handed back", () => {
+    const { view, tool } = toolOf([
+      { type: "run:start", sessionId: "s" },
+      toolStart,
+      request,
+      refusal,
+    ]);
+    // Announced and visible, but the row is not persisted yet — the card must stay locked.
+    expect(tool.status).toBe("awaiting_approval");
+    expect(view.runStatus).toBe("running");
+  });
+
   it("closes the card on the relayed decision and renders the relay as a notice", () => {
     const { view, tool } = toolOf([
       toolStart,

--- a/packages/agent-runtime/__tests__/fold.test.ts
+++ b/packages/agent-runtime/__tests__/fold.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+
+import { foldEvents } from "../src/wire/fold.ts";
+import type { AgentWireEvent } from "../src/wire/schema.ts";
+
+const toolStart: AgentWireEvent = {
+  type: "tool:start",
+  toolCallId: "call-1",
+  toolName: "commit_draft",
+  label: "Commit draft",
+  tier: "commit",
+  args: {},
+};
+const request: AgentWireEvent = {
+  type: "approval:request",
+  toolCallId: "call-1",
+  toolName: "commit_draft",
+  tier: "commit",
+  args: {},
+};
+const refusal: AgentWireEvent = {
+  type: "tool:end",
+  toolCallId: "call-1",
+  toolName: "commit_draft",
+  isError: true,
+  summary: "needs approval",
+};
+
+const toolOf = (events: AgentWireEvent[]) => {
+  const view = foldEvents(events);
+  const tool = view.items.find((item) => item.kind === "tool");
+  if (tool?.kind !== "tool") throw new Error("no tool item");
+  return { view, tool };
+};
+
+describe("approval fold", () => {
+  it("keeps the card awaiting when the gate's refusal lands after the announcement", () => {
+    const { view, tool } = toolOf([
+      toolStart,
+      request,
+      refusal,
+      { type: "run:end", reason: "awaiting_approval" },
+    ]);
+    expect(tool.status).toBe("awaiting_approval");
+    expect(view.pendingApprovals.map((pending) => pending.toolCallId)).toEqual([
+      "call-1",
+    ]);
+    expect(view.runStatus).toBe("awaiting_approval");
+  });
+
+  it("closes the card on the relayed decision and renders the relay as a notice", () => {
+    const { view, tool } = toolOf([
+      toolStart,
+      request,
+      refusal,
+      { type: "run:end", reason: "awaiting_approval" },
+      { type: "run:start", sessionId: "s" },
+      {
+        type: "approval:resolved",
+        toolCallId: "call-1",
+        approved: true,
+        comment: "go",
+      },
+      {
+        type: "user",
+        messageId: "u:2",
+        text: "Operator decision: approved `commit_draft`. Run it now.",
+        origin: "operator-decision",
+      },
+    ]);
+    expect(tool.status).toBe("ok");
+    expect(tool.approval).toEqual({ approved: true, comment: "go" });
+    expect(view.pendingApprovals).toEqual([]);
+    expect(view.items.at(-1)).toMatchObject({
+      kind: "notice",
+      variant: "decision",
+    });
+    expect(view.items.some((item) => item.kind === "user")).toBe(false);
+  });
+
+  it("retracts an announced request when the turn ends any other way", () => {
+    const { view, tool } = toolOf([
+      toolStart,
+      request,
+      refusal,
+      { type: "error", kind: "internal", message: "db down" },
+      { type: "run:end", reason: "error" },
+    ]);
+    expect(tool.status).toBe("error");
+    expect(view.pendingApprovals).toEqual([]);
+    expect(view.runStatus).toBe("error");
+  });
+});

--- a/packages/agent-runtime/__tests__/runtime.test.ts
+++ b/packages/agent-runtime/__tests__/runtime.test.ts
@@ -38,6 +38,7 @@ vi.mock("@earendil-works/pi-agent-core", async (importOriginal) => {
 });
 
 import { runPiTurn } from "../src/pi/turn.ts";
+import { formatOperatorDecision } from "../src/wire/operator-decision.ts";
 
 /** Pi resolves a turn with the final assistant message; these are the shapes runPiTurn reads. */
 const reply = (
@@ -139,12 +140,14 @@ describe("runPiTurn", () => {
     expect(flushEvents).toHaveBeenCalledOnce();
   });
 
-  it("atomically persists approval requests before publishing them", async () => {
+  it("announces approval requests as they are refused and persists them atomically at the end", async () => {
     const options = createOptions();
     options.persistApprovals.mockImplementation(async () => {
+      // The client has already been told, so the card can replace the tool while the model is
+      // still writing; the durable request is the one thing that waits for the turn to succeed.
       expect(
-        options.events.some((event) => event.type === "approval:request")
-      ).toBe(false);
+        options.events.filter((event) => event.type === "approval:request")
+      ).toHaveLength(2);
     });
     pi.harness.prompt.mockImplementation(async () => {
       const handler = pi.handlers.get("tool_call");
@@ -177,6 +180,44 @@ describe("runPiTurn", () => {
         .filter((event) => event.type === "approval:request")
         .map((event) => event.toolCallId)
     ).toEqual(["call-1", "call-2"]);
+  });
+
+  it("relays an operator decision before the model runs and marks its own message as synthesised", async () => {
+    const options = createOptions();
+    const text = formatOperatorDecision({
+      toolName: "publish",
+      approved: true,
+      comment: "go",
+    });
+
+    await runPiTurn({
+      ...options,
+      message: {
+        text,
+        decision: {
+          toolCallId: "call-1",
+          toolName: "publish",
+          approved: true,
+          comment: "go",
+        },
+      },
+    });
+
+    expect(pi.harness.prompt).toHaveBeenCalledWith(text);
+    expect(options.events.slice(0, 3)).toEqual([
+      { type: "run:start", sessionId: "session-1" },
+      {
+        type: "approval:resolved",
+        toolCallId: "call-1",
+        approved: true,
+        comment: "go",
+      },
+      expect.objectContaining({
+        type: "user",
+        text,
+        origin: "operator-decision",
+      }),
+    ]);
   });
 
   it("dispatches templates and turns provider failures into terminal events", async () => {
@@ -350,9 +391,17 @@ describe("runPiTurn", () => {
     });
     expect(options.persistApprovals).not.toHaveBeenCalled();
     expect(pi.harness.compact).not.toHaveBeenCalled();
-    expect(options.events).not.toContainEqual(
-      expect.objectContaining({ type: "approval:request" })
+    // Announced live when refused; the client retracts it on `run:end{aborted}`.
+    expect(options.events).toContainEqual(
+      expect.objectContaining({
+        type: "approval:request",
+        toolCallId: "call-1",
+      })
     );
+    expect(options.events.at(-1)).toEqual({
+      type: "run:end",
+      reason: "aborted",
+    });
   });
 
   it("stops listening once the turn is over", async () => {
@@ -454,8 +503,11 @@ describe("runPiTurn", () => {
       approvals: [],
       error: { kind: "internal", message: "database unavailable" },
     });
-    expect(options.events).not.toContainEqual(
-      expect.objectContaining({ type: "approval:request" })
+    expect(options.events).toContainEqual(
+      expect.objectContaining({
+        type: "approval:request",
+        toolCallId: "call-1",
+      })
     );
     expect(options.events.slice(-2)).toEqual([
       { type: "error", kind: "internal", message: "database unavailable" },
@@ -487,9 +539,14 @@ describe("runPiTurn", () => {
       error: { kind: "internal", message: "provider failed" },
     });
     expect(options.persistApprovals).not.toHaveBeenCalled();
-    expect(options.events).not.toContainEqual(
-      expect.objectContaining({ type: "approval:request" })
+    // Announced live when refused; `run:end{error}` is what retracts it on the client.
+    expect(options.events).toContainEqual(
+      expect.objectContaining({
+        type: "approval:request",
+        toolCallId: "call-1",
+      })
     );
+    expect(options.events.at(-1)).toEqual({ type: "run:end", reason: "error" });
   });
 
   it("does not compact a successful turn that requests approval", async () => {

--- a/packages/agent-runtime/package.json
+++ b/packages/agent-runtime/package.json
@@ -17,6 +17,10 @@
       "types": "./src/tools.ts",
       "default": "./src/tools.ts"
     },
+    "./wire/operator-decision": {
+      "types": "./src/wire/operator-decision.ts",
+      "default": "./src/wire/operator-decision.ts"
+    },
     "./wire/schema": {
       "types": "./src/wire/schema.ts",
       "default": "./src/wire/schema.ts"

--- a/packages/agent-runtime/src/pi/tool-gate.ts
+++ b/packages/agent-runtime/src/pi/tool-gate.ts
@@ -40,6 +40,12 @@ export interface PiToolCallGateOptions {
    * common path avoid burning a turn on the refusal handshake.
    */
   preAuthorizedToolNames?: ReadonlySet<string>;
+  /**
+   * Called the moment a call is refused, before the model has even seen the refusal. Lets the
+   * host announce the request while the turn is still streaming; persistence still waits for the
+   * turn to finish, so a turn that fails afterwards leaves no durable request behind.
+   */
+  onRequest?: (request: ApprovalRequest) => void;
 }
 
 export interface PiToolCallGate {
@@ -78,6 +84,7 @@ export const createPiToolCallGate = (
         args: event.input,
       };
       requests.push(request);
+      options.onRequest?.(request);
 
       return {
         block: true,

--- a/packages/agent-runtime/src/pi/turn.ts
+++ b/packages/agent-runtime/src/pi/turn.ts
@@ -124,6 +124,16 @@ export const runPiTurn = async <TContext extends object, TApproval>({
       autoApprove: settings.autoApprove,
       approvedToolCallIds,
       preAuthorizedToolNames,
+      // Announced at once so the approval card replaces the tool card while the model is still
+      // writing its hand-back, instead of appearing only after the turn has ended.
+      onRequest: (request) =>
+        onEvent({
+          type: "approval:request",
+          toolCallId: request.toolCallId,
+          toolName: request.toolName,
+          tier: request.tier,
+          args: request.args,
+        }),
     });
     unsubscribers.push(
       turnHarness.on("tool_call", (event) => gate.handle(event))
@@ -207,11 +217,22 @@ export const runPiTurn = async <TContext extends object, TApproval>({
     }
 
     onEvent({ type: "run:start", sessionId: agentSessionId });
+    if (message.decision) {
+      // The decision was persisted by the host before this turn was woken, so announcing it
+      // here is a replay of fact, not a new state; it closes the approval card on the live view.
+      onEvent({
+        type: "approval:resolved",
+        toolCallId: message.decision.toolCallId,
+        approved: message.decision.approved,
+        comment: message.decision.comment,
+      });
+    }
     onEvent({
       type: "user",
       messageId: `u:${turnId}`,
       text: message.text,
       at: Date.now(),
+      origin: message.decision ? "operator-decision" : undefined,
     });
 
     let failure: AgentTurnError | undefined;
@@ -247,18 +268,6 @@ export const runPiTurn = async <TContext extends object, TApproval>({
         approvals = pending;
       } catch (error) {
         failure = errorOfThrown(error);
-      }
-    }
-
-    if (!failure && !aborted) {
-      for (const request of gate.requests) {
-        onEvent({
-          type: "approval:request",
-          toolCallId: request.toolCallId,
-          toolName: request.toolName,
-          tier: request.tier,
-          args: request.args,
-        });
       }
     }
 

--- a/packages/agent-runtime/src/types.ts
+++ b/packages/agent-runtime/src/types.ts
@@ -5,6 +5,8 @@ import type {
   ThinkingLevel,
 } from "@earendil-works/pi-agent-core";
 
+import type { OperatorDecision } from "./wire/operator-decision.ts";
+
 export type { PromptTemplate, Skill, ThinkingLevel };
 
 export type ToolTier = string;
@@ -69,6 +71,12 @@ export interface AgentNavigationResult {
 export interface AgentTurnMessage {
   text: string;
   template?: { name: string; args?: string[] };
+  /**
+   * The operator decision this turn relays, when the workflow synthesised it after an approval.
+   * The turn then announces the decision on the wire before the model runs and marks its own
+   * user message as not operator-typed.
+   */
+  decision?: OperatorDecision;
 }
 
 /**

--- a/packages/agent-runtime/src/wire/fold.ts
+++ b/packages/agent-runtime/src/wire/fold.ts
@@ -32,7 +32,7 @@ export interface TextMessageView {
 
 export interface NoticeView {
   kind: "notice";
-  variant: "compacted" | "error";
+  variant: "compacted" | "error" | "decision";
   text: string;
   /** Set on `error` notices. */
   code?: AgentErrorKind;
@@ -91,6 +91,11 @@ export const applyEvent = (
       return { ...state, items, runStatus: "running" };
 
     case "user":
+      if (event.origin === "operator-decision") {
+        // Synthesised by the workflow to relay the operator's decision, not typed by them.
+        items.push({ kind: "notice", variant: "decision", text: event.text });
+        return { ...state, items, runStatus: "running" };
+      }
       items.push({
         kind: "user",
         messageId: event.messageId,
@@ -246,8 +251,18 @@ export const applyEvent = (
       const index = findTool(event.toolCallId);
       if (index !== -1) {
         // SAFETY: approval events can only target tool items created by tool:start.
+        const existing = items[index] as ToolCallView;
         items[index] = {
-          ...(items[index] as ToolCallView),
+          ...existing,
+          // The gated call itself never ran — a decision closes the card, and the re-issued call
+          // arrives as its own tool item. Leave `awaiting_approval` or a later `tool:end` would
+          // read as the gate still holding it.
+          status:
+            existing.status === "awaiting_approval"
+              ? event.approved
+                ? "ok"
+                : "error"
+              : existing.status,
           approval: { approved: event.approved, comment: event.comment },
         };
       }
@@ -282,15 +297,21 @@ export const applyEvent = (
       return { ...state, items, runStatus: "error" };
 
     case "run:end":
+      if (event.reason === "awaiting_approval") {
+        return { ...state, items, runStatus: "awaiting_approval" };
+      }
+      // `approval:request` is announced as soon as the gate refuses, before the turn has proven it
+      // can persist the request. A turn that then ends any other way has nothing for the operator
+      // to decide — drop the prompts rather than leave cards nobody can act on.
       return {
         ...state,
-        items,
-        runStatus:
-          event.reason === "awaiting_approval"
-            ? "awaiting_approval"
-            : event.reason === "error"
-              ? "error"
-              : "idle",
+        items: items.map((item) =>
+          item.kind === "tool" && item.status === "awaiting_approval"
+            ? { ...item, status: "error" }
+            : item
+        ),
+        pendingApprovals: [],
+        runStatus: event.reason === "error" ? "error" : "idle",
       };
   }
 };

--- a/packages/agent-runtime/src/wire/fold.ts
+++ b/packages/agent-runtime/src/wire/fold.ts
@@ -239,11 +239,13 @@ export const applyEvent = (
       };
       if (index === -1) items.push(view);
       else items[index] = view;
+      // The request is announced while the turn is still running and before it is persisted;
+      // only `run:end{awaiting_approval}` (or a reloaded pending row) makes it decidable, so the
+      // run status is left to that event and the card stays locked until then.
       return {
         ...state,
         items,
         pendingApprovals: [...state.pendingApprovals, view],
-        runStatus: "awaiting_approval",
       };
     }
 

--- a/packages/agent-runtime/src/wire/operator-decision.ts
+++ b/packages/agent-runtime/src/wire/operator-decision.ts
@@ -1,0 +1,27 @@
+/**
+ * The message a session's workflow sends the model after the operator decides on a gated tool
+ * call. It is a real user turn in the transcript — that is what makes the model act on it — but
+ * it is not something the operator typed, so the client renders it as a notice. The live turn
+ * knows its origin structurally; a replayed transcript only has the text, hence the fixed prefix.
+ */
+
+export interface OperatorDecision {
+  toolCallId: string;
+  toolName: string;
+  approved: boolean;
+  comment?: string;
+}
+
+const PREFIX = "Operator decision:";
+
+export const formatOperatorDecision = (
+  decision: Pick<OperatorDecision, "toolName" | "approved" | "comment">
+): string => {
+  const said = decision.comment ? ` They said: ${decision.comment}` : "";
+  return decision.approved
+    ? `${PREFIX} approved \`${decision.toolName}\`.${said} Run it now.`
+    : `${PREFIX} declined \`${decision.toolName}\`.${said} Do not retry it. Acknowledge and wait for further instructions.`;
+};
+
+export const isOperatorDecisionText = (text: string): boolean =>
+  text.startsWith(PREFIX);

--- a/packages/agent-runtime/src/wire/replay.ts
+++ b/packages/agent-runtime/src/wire/replay.ts
@@ -5,6 +5,7 @@ import { errorOfAssistantMessage } from "../pi/errors.ts";
 import type { AgentEventPresentation } from "../types.ts";
 
 import { clipDetails } from "./clip.ts";
+import { isOperatorDecisionText } from "./operator-decision.ts";
 import type { AgentWireEvent } from "./schema.ts";
 
 // ============================================
@@ -35,11 +36,13 @@ export const entriesToWireEvents = (
     const message = entry.message;
 
     if (message.role === "user") {
+      const text = contentToText(message.content);
       events.push({
         type: "user",
         messageId: entry.id,
-        text: contentToText(message.content),
+        text,
         at: message.timestamp,
+        origin: isOperatorDecisionText(text) ? "operator-decision" : undefined,
       });
       continue;
     }

--- a/packages/agent-runtime/src/wire/schema.ts
+++ b/packages/agent-runtime/src/wire/schema.ts
@@ -32,6 +32,11 @@ export const agentWireEventSchema = z.discriminatedUnion("type", [
     text: z.string(),
     /** Epoch ms. Optional only so streams written before it existed still parse. */
     at: z.number().optional(),
+    /**
+     * Set when the turn was synthesised by the session's workflow rather than typed by the
+     * operator — today only the relayed approval decision. Clients render these as notices.
+     */
+    origin: z.enum(["operator-decision"]).optional(),
   }),
   z.object({ type: z.literal("assistant:start"), messageId: z.string() }),
   z.object({

--- a/packages/agent-writing/__tests__/pg-draft-store.test.ts
+++ b/packages/agent-writing/__tests__/pg-draft-store.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { DB } from "@chia/db/client";
+import type { JsonObject } from "@chia/db/json";
+import type { Locale } from "@chia/db/types";
+
+/**
+ * Fakes the repo layer with the same persistence semantics as the real tables: `meta` jsonb is
+ * replaced wholesale on upsert, `content` is a column that an `undefined` leaves untouched.
+ * The bug this guards against lived entirely above that layer — a store-level merge that let
+ * an omitted field overwrite a stored one.
+ */
+interface FakeSession {
+  feedMeta: JsonObject;
+  targetFeedId: number | null;
+}
+interface FakeDraftRow {
+  meta: JsonObject;
+  content: string | null;
+}
+interface FakeState {
+  session: FakeSession;
+  drafts: Map<Locale, FakeDraftRow>;
+}
+const state: FakeState = {
+  session: { feedMeta: {}, targetFeedId: null },
+  drafts: new Map(),
+};
+
+vi.mock("@chia/db/repos/agent", () => ({
+  getWritingAgentSession: vi.fn(async () => ({ ...state.session })),
+  getWritingAgentDrafts: vi.fn(async () =>
+    [...state.drafts.entries()].map(([locale, row]) => ({
+      locale,
+      meta: row.meta,
+      content: row.content,
+    }))
+  ),
+  updateWritingAgentSession: vi.fn(
+    async (
+      _db: DB,
+      _sessionId: string,
+      patch: { feedMeta?: JsonObject; targetFeedId?: number | null }
+    ) => {
+      if (patch.feedMeta !== undefined) state.session.feedMeta = patch.feedMeta;
+      if (patch.targetFeedId !== undefined)
+        state.session.targetFeedId = patch.targetFeedId;
+    }
+  ),
+  upsertWritingAgentDraft: vi.fn(
+    async (
+      _db: DB,
+      input: { locale: Locale; meta: JsonObject; content?: string | null }
+    ) => {
+      const existing = state.drafts.get(input.locale);
+      state.drafts.set(input.locale, {
+        meta: input.meta,
+        content:
+          input.content === undefined
+            ? (existing?.content ?? null)
+            : input.content,
+      });
+    }
+  ),
+  deleteWritingAgentDrafts: vi.fn(async () => {
+    state.drafts.clear();
+  }),
+}));
+
+const { PgDraftStore } = await import("../src/draft/pg-draft-store.ts");
+
+// SAFETY: every repo function is mocked above and never touches the handle.
+const db = {} as DB;
+const sessionId = "session-1";
+
+describe("PgDraftStore", () => {
+  beforeEach(() => {
+    state.session = { feedMeta: {}, targetFeedId: null };
+    state.drafts.clear();
+  });
+
+  it("leaves omitted per-locale fields alone when the patch carries explicit undefined keys", async () => {
+    const store = new PgDraftStore(db);
+    await store.patchTranslation(sessionId, "en", {
+      title: "Title",
+      excerpt: "Excerpt",
+      description: "Description",
+      summary: "Summary",
+    });
+
+    // Exactly what `patch_draft_meta` sends: every per-locale key present, most undefined.
+    const next = await store.patchTranslation(sessionId, "en", {
+      title: "New title",
+      excerpt: undefined,
+      description: undefined,
+      summary: undefined,
+    });
+
+    expect(next.translations.en).toMatchObject({
+      title: "New title",
+      excerpt: "Excerpt",
+      description: "Description",
+      summary: "Summary",
+    });
+    expect((await store.get(sessionId)).translations.en).toMatchObject({
+      title: "New title",
+      excerpt: "Excerpt",
+      description: "Description",
+      summary: "Summary",
+    });
+  });
+
+  it("clears a field on null and keeps the body across metadata patches", async () => {
+    const store = new PgDraftStore(db);
+    await store.setContent(sessionId, "en", "## Body");
+    await store.patchTranslation(sessionId, "en", { title: "T", excerpt: "E" });
+    const next = await store.patchTranslation(sessionId, "en", {
+      excerpt: null,
+    });
+
+    expect(next.translations.en?.excerpt).toBeNull();
+    expect(next.translations.en?.title).toBe("T");
+    expect(next.translations.en?.content).toBe("## Body");
+    expect(state.drafts.get("en")?.content).toBe("## Body");
+  });
+
+  it("merges feed-level metadata the same way", async () => {
+    const store = new PgDraftStore(db);
+    await store.patchFeedMeta(sessionId, { slug: "a-slug", type: "post" });
+    const next = await store.patchFeedMeta(sessionId, {
+      slug: undefined,
+      type: undefined,
+      defaultLocale: "en",
+    });
+
+    expect(next.feedMeta).toEqual({
+      slug: "a-slug",
+      type: "post",
+      defaultLocale: "en",
+    });
+    expect(state.session.feedMeta).toEqual({
+      slug: "a-slug",
+      type: "post",
+      defaultLocale: "en",
+    });
+  });
+});

--- a/packages/agent-writing/package.json
+++ b/packages/agent-writing/package.json
@@ -61,6 +61,10 @@
       "types": "./src/tools/summarize.ts",
       "default": "./src/tools/summarize.ts"
     },
+    "./tools/skill.tool": {
+      "types": "./src/tools/skill.tool.ts",
+      "default": "./src/tools/skill.tool.ts"
+    },
     "./tools/retrieval.tool": {
       "types": "./src/tools/retrieval.tool.ts",
       "default": "./src/tools/retrieval.tool.ts"

--- a/packages/agent-writing/src/draft/pg-draft-store.ts
+++ b/packages/agent-writing/src/draft/pg-draft-store.ts
@@ -12,7 +12,11 @@ import type { Locale } from "@chia/db/types";
 import type { DraftStore } from "../ports.ts";
 import type { DraftFeedMeta, DraftTranslation, FeedDraft } from "../types.ts";
 
-import { emptyDraft } from "./operations.ts";
+import {
+  emptyDraft,
+  patchFeedMeta as mergeFeedMeta,
+  patchTranslation as mergeTranslation,
+} from "./operations.ts";
 
 /**
  * {@link DraftStore} over `writing_agent_draft` (per-locale) +
@@ -53,10 +57,13 @@ export class PgDraftStore implements DraftStore {
     sessionId: string,
     patch: DraftFeedMeta
   ): Promise<FeedDraft> {
-    const current = await this.get(sessionId);
-    const feedMeta = stripUndefined({ ...current.feedMeta, ...patch });
-    await updateWritingAgentSession(this.db, sessionId, { feedMeta });
-    return { ...current, feedMeta };
+    // Merge semantics live in `operations.ts` so this store and the in-memory one cannot drift:
+    // an omitted field arrives as an explicit `undefined` key and a plain spread would wipe it.
+    const next = mergeFeedMeta(await this.get(sessionId), patch);
+    await updateWritingAgentSession(this.db, sessionId, {
+      feedMeta: stripUndefined(next.feedMeta),
+    });
+    return next;
   }
 
   async patchTranslation(
@@ -64,25 +71,18 @@ export class PgDraftStore implements DraftStore {
     locale: Locale,
     patch: DraftTranslation
   ): Promise<FeedDraft> {
-    const current = await this.get(sessionId);
-    const merged = stripUndefined({
-      ...(current.translations[locale] ?? {}),
-      ...patch,
-    });
+    const next = mergeTranslation(await this.get(sessionId), locale, patch);
 
     // `content` has its own column; everything else goes to the jsonb blob.
-    const { content, ...meta } = merged;
+    const { content, ...meta } = next.translations[locale] ?? {};
     await upsertWritingAgentDraft(this.db, {
       sessionId,
       locale,
-      meta,
+      meta: stripUndefined(meta),
       content,
     });
 
-    return {
-      ...current,
-      translations: { ...current.translations, [locale]: merged },
-    };
+    return next;
   }
 
   setContent(

--- a/packages/agent-writing/src/prompts/skills.ts
+++ b/packages/agent-writing/src/prompts/skills.ts
@@ -1,9 +1,10 @@
 import type { Skill } from "@earendil-works/pi-agent-core";
 
 /**
- * Skills, in pi's first-class sense: `formatSkillsForSystemPrompt` inserts the name and
- * description into the system prompt, and pi loads the full `content` through its skill resource
- * API when the model selects one.
+ * Skills, in pi's first-class sense. The system prompt carries only name and description
+ * (`formatSkillsIndex` in `system.ts`); the model loads `content` on demand through the
+ * `read_skill` tool, which is the only read path — pi's default convention of reading the skill
+ * file from disk has no tool to back it here.
  *
  * They live inline rather than as `SKILL.md` files on disk because this package is consumed
  * source-only (no build step) and is loaded inside a server bundle — a runtime `fs.readFile`
@@ -185,8 +186,8 @@ actually covers, not a hook.
 ## \`slug\`
 
 Lowercase, hyphenated, English even for zh-TW posts, and stable — changing it breaks inbound
-links. Call \`slugify\` to see the normalised form before setting it. Keep it short: 3–6 words.
-Omit stop words.
+links. \`patch_draft_meta\` normalises what you pass and echoes the result; \`slugify\` exists to
+compare candidates before you choose. Keep it short: 3–6 words. Omit stop words.
 `
 );
 

--- a/packages/agent-writing/src/prompts/system.ts
+++ b/packages/agent-writing/src/prompts/system.ts
@@ -1,4 +1,3 @@
-import { formatSkillsForSystemPrompt } from "@earendil-works/pi-agent-core";
 import type { Skill } from "@earendil-works/pi-agent-core";
 
 import type { ToolTier } from "@chia/agent-runtime/types";
@@ -42,12 +41,17 @@ initiative.
 You never edit the live blog directly. You edit a **staging draft** attached to this
 conversation, and the operator promotes it when they are satisfied:
 
-1. **Ground yourself.** \`search_posts\` before writing anything new — the worst outcome is a
+1. **Load the rules.** \`read_skill\` for every skill whose description matches the task —
+   \`mdx-authoring\` before any body, the locale's tone skill before any prose, \`seo-metadata\`
+   before any title/excerpt/description/summary. The skills index below lists what exists; it
+   is not the content.
+2. **Ground yourself.** \`search_posts\` before writing anything new — the worst outcome is a
    near-duplicate of an existing post. \`list_posts\` shows drafts in flight too. \`get_post\` to
    match established voice and structure; \`list_tags\` before proposing a new tag.
-2. **Draft.** \`write_draft_content\` for a first version, \`edit_draft_content\` for revisions.
-   Set metadata with \`patch_draft_meta\`.
-3. **Hand back.** Stop and summarise. \`commit_draft\` and \`set_published\` need the operator's
+3. **Draft.** \`write_draft_content\` for a first version, \`edit_draft_content\` for revisions.
+   Set metadata with \`patch_draft_meta\`; its result echoes the merged fields, so trust it
+   rather than re-reading.
+4. **Hand back.** Stop and summarise. \`commit_draft\` and \`set_published\` need the operator's
    explicit approval every time.
 
 # Rules
@@ -62,19 +66,22 @@ conversation, and the operator promotes it when they are satisfied:
   a turn and risks matching the wrong place.
 - **Prefer editing to rewriting.** Once the operator has reviewed prose, replacing the whole
   body throws that review away. Make targeted edits.
-- **Match the existing voice.** This is one person's blog with a consistent register. Read the
-  relevant tone skill before writing prose, and read a nearby existing post if unsure.
+- **Match the existing voice.** This is one person's blog with a consistent register.
+  \`read_skill\` the relevant tone skill before writing prose, and read a nearby existing post
+  if unsure.
 - **Ask when the brief is ambiguous.** Scope, audience and depth are the operator's call. One
   clarifying question beats three thousand words in the wrong direction.
 - **Report honestly.** If a claim would not check out, or you could not find a source — say so
-  plainly. Do not paper over it in a summary.
+  plainly. Do not paper over it in a summary. The same goes for anything you were told to use
+  and could not: if a skill, tool or page would not load, say that you skipped it instead of
+  silently substituting something else.
 `;
 
 export const buildSystemPrompt = (input: SystemPromptInput): string => {
   const sections = [CORE.trim()];
 
   if (input.skills.length > 0) {
-    sections.push(formatSkillsForSystemPrompt([...input.skills]));
+    sections.push(formatSkillsIndex(input.skills));
   }
 
   sections.push(formatApprovalPosture(input.autoApprove));
@@ -128,6 +135,32 @@ export const buildTurnContext = (input: TurnContextInput): string => {
     }
   }
 
+  return lines.join("\n");
+};
+
+/**
+ * Pi's own `formatSkillsForSystemPrompt` tells the model to read a skill *file* at its
+ * `filePath`, which presumes a file-reading tool. This agent loads skills through `read_skill`
+ * instead, so the index has to name that path or the model is left guessing at URLs.
+ */
+const formatSkillsIndex = (skills: readonly Skill[]): string => {
+  const lines = [
+    "# Skills",
+    "",
+    "Skills hold the detailed rules for specific parts of the job. This index is only names and",
+    "descriptions — call `read_skill` with the name to load the full instructions whenever a task",
+    "matches a description. Do not act on a skill you have not loaded in this session.",
+    "",
+    "<available_skills>",
+  ];
+  for (const skill of skills) {
+    if (skill.disableModelInvocation) continue;
+    lines.push("  <skill>");
+    lines.push(`    <name>${skill.name}</name>`);
+    lines.push(`    <description>${skill.description}</description>`);
+    lines.push("  </skill>");
+  }
+  lines.push("</available_skills>");
   return lines.join("\n");
 };
 

--- a/packages/agent-writing/src/prompts/templates.ts
+++ b/packages/agent-writing/src/prompts/templates.ts
@@ -23,9 +23,10 @@ Work in this order:
 
 1. \`search_posts\` for the topic. If something close already exists, stop and tell me — we
    should update that post instead of adding a near-duplicate.
-2. Read the \`mdx-authoring\` and \`seo-metadata\` skills.
+2. \`read_skill\` \`mdx-authoring\`, \`seo-metadata\` and the tone skill for the locale you
+   will write in.
 3. Decide the default locale (zh-TW unless the topic is clearly English-first) and set the
-   feed metadata: \`type\`, \`slug\` (run \`slugify\` first), \`defaultLocale\`.
+   feed metadata: \`type\`, \`slug\`, \`defaultLocale\`.
 4. Write the body for the default locale, then set its title, excerpt, description and summary.
 5. Stop and show me a summary. Do NOT commit — I will tell you when.
 `
@@ -37,7 +38,7 @@ export const translateTemplate = template(
   `
 Produce the $1 version of the current draft.
 
-Read the \`bilingual-parity\` skill first, then the tone skill for $1. This is a rewrite, not a
+\`read_skill\` \`bilingual-parity\` first, then the tone skill for $1. This is a rewrite, not a
 translation: same structure, same code, prose that reads as though written in $1 originally.
 
 Write real per-locale metadata — do not copy the other locale's.
@@ -50,7 +51,7 @@ export const seoPassTemplate = template(
   `
 Do a metadata pass over every locale of the current draft.
 
-Read the \`seo-metadata\` skill. For each locale: read the draft, then judge whether the title,
+\`read_skill\` \`seo-metadata\`. For each locale: read the draft, then judge whether the title,
 excerpt, description and summary each do their distinct job. Rewrite the ones that do not.
 Check the description length. Make sure the slug is short, stable and descriptive.
 

--- a/packages/agent-writing/src/prompts/templates.ts
+++ b/packages/agent-writing/src/prompts/templates.ts
@@ -23,9 +23,8 @@ Work in this order:
 
 1. \`search_posts\` for the topic. If something close already exists, stop and tell me — we
    should update that post instead of adding a near-duplicate.
-2. \`read_skill\` \`mdx-authoring\`, \`seo-metadata\` and the tone skill for the locale you
-   will write in.
-3. Decide the default locale (zh-TW unless the topic is clearly English-first) and set the
+2. Decide the default locale (zh-TW unless the topic is clearly English-first).
+3. \`read_skill\` \`mdx-authoring\`, \`seo-metadata\` and the tone skill for that locale. Set the
    feed metadata: \`type\`, \`slug\`, \`defaultLocale\`.
 4. Write the body for the default locale, then set its title, excerpt, description and summary.
 5. Stop and show me a summary. Do NOT commit — I will tell you when.

--- a/packages/agent-writing/src/tools/draft.tool.ts
+++ b/packages/agent-writing/src/tools/draft.tool.ts
@@ -5,7 +5,7 @@ import { ContentType, FeedType } from "@chia/db/types";
 import type { Locale } from "@chia/db/types";
 
 import { applyEdit, withLineNumbers } from "../draft/operations.ts";
-import type { WritingTool } from "../types.ts";
+import type { DraftFeedMeta, DraftTranslation, WritingTool } from "../types.ts";
 
 import { TOOL_NAMES, labelOf } from "./registry.ts";
 import {
@@ -37,6 +37,14 @@ const slugify = (text: string): string => new GithubSlugger().slug(text);
 
 /** SEO description cap enforced by the site's metadata layer. */
 const MAX_DESCRIPTION_CHARS = 160;
+
+/** What `patch_draft_meta` echoes back: the merged state, scoped to the locale it touched. */
+interface MetaReadback {
+  feedMeta: DraftFeedMeta;
+  locales: string[];
+  locale?: Locale;
+  translation?: Omit<DraftTranslation, "content">;
+}
 
 export const readDraftTool = defineTool({
   name: TOOL_NAMES.readDraft,
@@ -99,7 +107,7 @@ export const patchDraftMetaTool = defineTool({
   description:
     "Update draft metadata. Omitted fields are left alone; pass `null` to clear an optional field. " +
     "Feed-level fields (slug/type/tags) apply to the whole post; the rest are per-locale and " +
-    "require `locale`.",
+    "require `locale`. The result echoes the merged metadata, so no read-back call is needed.",
   parameters: Type.Object({
     locale: Type.Optional(
       LocaleSchema("Required when setting any per-locale field.")
@@ -123,7 +131,8 @@ export const patchDraftMetaTool = defineTool({
     slug: Type.Optional(
       Type.String({
         description:
-          "URL slug for the whole post. Will be normalised; call slugify first to see the result.",
+          "URL slug for the whole post. Normalised on write; the result echoes the final form. " +
+          "Use `slugify` only to compare candidates beforehand.",
       })
     ),
     type: Type.Optional(
@@ -193,13 +202,27 @@ export const patchDraftMetaTool = defineTool({
       );
     }
 
+    // Echo the merged per-locale fields so the model can confirm the patch from this result
+    // instead of spending a `read_draft` round-trip on it.
+    const readback: MetaReadback = {
+      feedMeta: draft.feedMeta,
+      locales: Object.keys(draft.translations),
+    };
+    if (locale) {
+      const translation = draft.translations[locale];
+      readback.locale = locale;
+      readback.translation = {
+        title: translation?.title,
+        excerpt: translation?.excerpt,
+        description: translation?.description,
+        summary: translation?.summary,
+      };
+    }
+
     return textResult(
       `Draft metadata updated.${warnings.length > 0 ? `\n\nWarnings:\n- ${warnings.join("\n- ")}` : ""}\n\n` +
-        jsonBlock({
-          feedMeta: draft.feedMeta,
-          locales: Object.keys(draft.translations),
-        }),
-      { feedMeta: draft.feedMeta, warnings }
+        jsonBlock(readback),
+      { ...readback, warnings }
     );
   },
 });

--- a/packages/agent-writing/src/tools/registry.ts
+++ b/packages/agent-writing/src/tools/registry.ts
@@ -15,6 +15,7 @@ import type { ToolTier } from "@chia/agent-runtime/types";
 
 export const TOOL_NAMES = {
   // read
+  readSkill: "read_skill",
   ...CONTENT_TOOL_NAMES,
   webSearch: "web_search",
   fetchUrl: "fetch_url",
@@ -32,6 +33,7 @@ export const TOOL_NAMES = {
 export type ToolName = (typeof TOOL_NAMES)[keyof typeof TOOL_NAMES];
 
 export const TOOL_TIER_BY_NAME = {
+  [TOOL_NAMES.readSkill]: "read",
   [TOOL_NAMES.searchPosts]: "read",
   [TOOL_NAMES.getPost]: "read",
   [TOOL_NAMES.listPosts]: "read",
@@ -50,6 +52,7 @@ export const TOOL_TIER_BY_NAME = {
 } satisfies Record<ToolName, ToolTier>;
 
 export const TOOL_LABEL_BY_NAME = {
+  [TOOL_NAMES.readSkill]: "Read skill",
   ...CONTENT_TOOL_LABEL_BY_NAME,
   [TOOL_NAMES.webSearch]: "Search web",
   [TOOL_NAMES.fetchUrl]: "Fetch page",

--- a/packages/agent-writing/src/tools/skill.tool.ts
+++ b/packages/agent-writing/src/tools/skill.tool.ts
@@ -1,0 +1,47 @@
+import { formatSkillInvocation } from "@earendil-works/pi-agent-core";
+import { StringEnum } from "@earendil-works/pi-ai";
+
+import { writingSkills } from "../prompts/skills.ts";
+import type { WritingTool } from "../types.ts";
+
+import { TOOL_NAMES, labelOf } from "./registry.ts";
+import { Type, defineTool, textResult } from "./schema.ts";
+
+/**
+ * The only path from the skills index in the system prompt to a skill's full text.
+ *
+ * Pi's own skill convention assumes a file-reading tool, which this agent does not have; without
+ * this tool the index advertises rules the model can never load. Going through a tool rather than
+ * inlining every skill also leaves a visible record in the thread of which rules were consulted
+ * before a body was written.
+ */
+export const readSkillTool = defineTool({
+  name: TOOL_NAMES.readSkill,
+  label: labelOf(TOOL_NAMES.readSkill),
+  description:
+    "Load the full instructions of a skill listed in the system prompt. Read the matching skills " +
+    "before writing a body or metadata — `mdx-authoring` for any body, the locale's tone skill " +
+    "for prose, `seo-metadata` for title/excerpt/description/summary. Cheap and side-effect free.",
+  parameters: Type.Object({
+    name: StringEnum(
+      writingSkills.map((skill) => skill.name),
+      { description: "Skill name exactly as listed in the system prompt." }
+    ),
+  }),
+  executionMode: "parallel",
+  execute(_toolCallId, params) {
+    const skill = writingSkills.find(
+      (candidate) => candidate.name === params.name
+    );
+    if (!skill) {
+      throw new Error(
+        `Unknown skill "${params.name}". Available: ${writingSkills.map((candidate) => candidate.name).join(", ")}.`
+      );
+    }
+    return Promise.resolve(
+      textResult(formatSkillInvocation(skill), { name: skill.name })
+    );
+  },
+});
+
+export const skillTools: WritingTool[] = [readSkillTool];

--- a/packages/agent-writing/src/tools/summarize.ts
+++ b/packages/agent-writing/src/tools/summarize.ts
@@ -33,6 +33,10 @@ export const summarizeToolResult = <TResult>(
   if (!details) return "Done.";
 
   switch (toolName) {
+    case TOOL_NAMES.readSkill: {
+      const name = asString(details.name);
+      return name ? `Read skill \`${name}\`.` : "Read skill.";
+    }
     case TOOL_NAMES.webSearch: {
       const query = asString(details.query);
       const count = asNumber(details.count);
@@ -54,9 +58,11 @@ export const summarizeToolResult = <TResult>(
     }
     case TOOL_NAMES.patchDraftMeta: {
       const warnings = asArray(details.warnings);
+      const locale = asString(details.locale);
+      const scope = locale ? `${locale} metadata` : "Metadata";
       return warnings && warnings.length > 0
-        ? `Metadata updated with ${warnings.length} warning(s).`
-        : "Metadata updated.";
+        ? `${scope} updated with ${warnings.length} warning(s).`
+        : `${scope} updated.`;
     }
     case TOOL_NAMES.writeDraftContent: {
       const locale = asString(details.locale);

--- a/packages/agent-writing/src/tools/tool-set.ts
+++ b/packages/agent-writing/src/tools/tool-set.ts
@@ -3,14 +3,16 @@ import type { WritingTool } from "../types.ts";
 import { commitTools } from "./commit.tool.ts";
 import { draftTools } from "./draft.tool.ts";
 import { retrievalTools } from "./retrieval.tool.ts";
+import { skillTools } from "./skill.tool.ts";
 
 /**
  * The writing agent's full tool set.
  *
  * Ordering is intentional — it is the order pi lists tools to the model, which nudges the
- * natural workflow: ground yourself, draft, then commit.
+ * natural workflow: load the rules, ground yourself, draft, then commit.
  */
 export const createWritingTools = (): WritingTool[] => [
+  ...skillTools,
   ...retrievalTools,
   ...draftTools,
   ...commitTools,
@@ -21,4 +23,4 @@ export const createWritingTools = (): WritingTool[] => [
  * (e.g. a read-only review session).
  */
 export const readOnlyToolNames = (): string[] =>
-  [...retrievalTools, ...draftTools].map((tool) => tool.name);
+  [...skillTools, ...retrievalTools, ...draftTools].map((tool) => tool.name);

--- a/packages/api/orpc/contracts/agent.contract.ts
+++ b/packages/api/orpc/contracts/agent.contract.ts
@@ -118,11 +118,17 @@ export const agentSessionDetailSchema = z.object({
    * `{ type: "attach" }` replays the running turn from its start and tails it live.
    */
   events: z.array(agentWireEventSchema),
-  pendingApprovals: z.array(
+  /**
+   * Every approval row of the session. The transcript never replays approval events, so the client
+   * re-applies these: a pending row restores the prompt, a decided row closes its card.
+   */
+  approvals: z.array(
     z.object({
       toolCallId: z.string(),
       toolName: z.string(),
       args: z.unknown().optional(),
+      status: z.enum(["pending", "approved", "rejected"]),
+      comment: z.string().optional(),
     })
   ),
   stats: z.object({

--- a/packages/i18n/agent-elements/en-US.json
+++ b/packages/i18n/agent-elements/en-US.json
@@ -31,6 +31,7 @@
   "notePlaceholder": "Tell the agent why, or what to do instead…",
   "alwaysAllow": "Allow all {tier} tools for the rest of this session",
   "compacted": "Conversation compacted",
+  "decisionRelayed": "Decision relayed to the agent",
   "modelPicker": "Model",
   "thinkingLevel": "Thinking",
   "thinkingLevelNames": {

--- a/packages/i18n/agent-elements/zh-TW.json
+++ b/packages/i18n/agent-elements/zh-TW.json
@@ -31,6 +31,7 @@
   "notePlaceholder": "告訴 agent 原因，或改怎麼做…",
   "alwaysAllow": "本次對話接下來都允許 {tier} 類工具",
   "compacted": "對話已壓縮",
+  "decisionRelayed": "決定已轉達給 agent",
   "modelPicker": "模型",
   "thinkingLevel": "思考程度",
   "thinkingLevelNames": {


### PR DESCRIPTION
## Summary

Two commits addressing friction reported by the writing agent itself, plus the approval-flow presentation issues seen in dash.

### `71d508d9` — skills loadable, `patch_draft_meta` no longer drops fields
- **Bug:** `PgDraftStore` merged patches with a spread, so the explicit `undefined` keys `patch_draft_meta` sends for omitted fields overwrote stored values before `stripUndefined` deleted them. The in-memory store used the correct `mergeDefined`, which is why tests passed while prod dropped `title`/`excerpt`/…. Both stores now go through the pure merge in `draft/operations.ts`; a `PgDraftStore` test over a mocked repo layer locks the semantics (fails on the old store, passes on the new one).
- `patch_draft_meta` echoes the merged per-locale fields so no `read_draft` round-trip is needed to confirm a patch.
- **Harness gap:** the skills index told the model to *read a skill file*, but the tool set has no file-reading tool. Added `read_skill` (tier `read`) as the load path, replaced pi's file-oriented index text with one naming the tool, pointed the system prompt and templates at it, and extended the honesty rule to resources that fail to load.
- Dash draft preview shows excerpt/description/summary with `missing` markers; `slugify` is optional; `focusHeadings` documents the `headingPath` format inline.

### `46384200` — approval announced as gated, decision relayed as a notice, cards close on reload
- `approval:request` is emitted the moment the gate refuses (`tool-gate` `onRequest`), so the approval card replaces the tool card while the model is still writing instead of after the turn ends. Persistence is unchanged (atomic, after the provider turn succeeds); the fold retracts announced-but-unpersisted cards on any `run:end` other than `awaiting_approval`.
- The workflow's post-decision turn was a user message the operator never typed, shown as a second user bubble. It now carries `AgentTurnMessage.decision`: the turn emits `approval:resolved` before the model runs and tags its `user` event with `origin: "operator-decision"`; replay recognises the text via `wire/operator-decision`; the fold renders both as a decision notice.
- `approval:resolved` was defined but never emitted — the old card stayed pending live and showed as a red error on reload. The fold now closes the card on resolution, and the session detail lists every approval row (`approvals`, replacing `pendingApprovals`) so a reload restores each card as the live stream left it.
- `entriesBeforeTurn` no longer includes the running turn's leading user messages — `attach` replays them from the stream, and taking both showed the prompt twice to a client that rejoined mid-turn.
- `docs/agent-architecture.md` §5 updated.

Not in scope: keeping the turn suspended in-process while awaiting approval (kept the refusal + hook mechanism as-is).

## Test plan
- [x] `@chia/agent-writing` vitest (incl. new `pg-draft-store.test.ts`) 
- [x] `@chia/agent-runtime` vitest (new `fold.test.ts`, updated runtime tests)
- [x] `@chia/agent-elements` store tests
- [x] `type:check` + `lint` on agent-runtime / agent-elements / agent-writing / agent-content / api / service / dash / www
- [ ] Manual: in dash, trigger `commit_draft` → approval card appears while the hand-back streams; approve → old card shows "Allowed", relay shows as a notice (not a user bubble), new tool card runs; reload → same picture
- [ ] Manual: `/new-post` → thread shows `Read skill \`mdx-authoring\`` tool calls before the body is written

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Approval requests now appear immediately during tool execution.
  * Approvals and rejections are relayed with clear decision notices, comments, and resolved tool statuses.
  * Approval states persist across reloads, including approved and rejected decisions.
  * Writing skills can be loaded on demand for more focused guidance.
* **Bug Fixes**
  * Prevented duplicate user messages when rejoining an active turn.
  * Draft metadata updates now preserve omitted fields and support clearing values.
  * Translation previews now show missing titles and metadata fields clearly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->