### PR TITLE
feat(contents): share table and emphasis elements between blog MDX and agent markdown

### DIFF
--- a/apps/www/.next/dev/types/link.d.ts
+++ b/apps/www/.next/dev/types/link.d.ts
@@ -42,7 +42,7 @@ declare namespace __next_route_internal_types__ {
     | `/${SafeSlug<T>}/${SafeSlug<T>}/${SafeSlug<T>}/og` // ../../../src/app/[locale]/(blog)/[type]/[slug]/og/route.ts
     | `/${SafeSlug<T>}/about` // /[locale]/about
     | `/${SafeSlug<T>}/contact` // ../../../src/app/[locale]/contact/page.tsx
-    | `/${SafeSlug<T>}/email` // ../../../src/app/[locale]/@modal/(.)email/page.tsx
+    | `/${SafeSlug<T>}/email` // ../../../src/app/[locale]/email/page.ts
     | `/${SafeSlug<T>}/note/${SafeSlug<T>}` // /[locale]/note/[slug]
     | `/${SafeSlug<T>}/post/${SafeSlug<T>}` // /[locale]/post/[slug]
     | `/${SafeSlug<T>}/projects` // ../../../src/app/[locale]/projects/page.tsx

--- a/apps/www/.next/dev/types/link.d.ts
+++ b/apps/www/.next/dev/types/link.d.ts
@@ -42,7 +42,7 @@ declare namespace __next_route_internal_types__ {
     | `/${SafeSlug<T>}/${SafeSlug<T>}/${SafeSlug<T>}/og` // ../../../src/app/[locale]/(blog)/[type]/[slug]/og/route.ts
     | `/${SafeSlug<T>}/about` // /[locale]/about
     | `/${SafeSlug<T>}/contact` // ../../../src/app/[locale]/contact/page.tsx
-    | `/${SafeSlug<T>}/email` // ../../../src/app/[locale]/email/page.ts
+    | `/${SafeSlug<T>}/email` // ../../../src/app/[locale]/@modal/(.)email/page.tsx
     | `/${SafeSlug<T>}/note/${SafeSlug<T>}` // /[locale]/note/[slug]
     | `/${SafeSlug<T>}/post/${SafeSlug<T>}` // /[locale]/post/[slug]
     | `/${SafeSlug<T>}/projects` // ../../../src/app/[locale]/projects/page.tsx

--- a/packages/agent-elements/package.json
+++ b/packages/agent-elements/package.json
@@ -110,6 +110,7 @@
     "@chia/agent-runtime": "workspace:*",
     "@chia/agent-writing": "workspace:*",
     "@chia/api": "workspace:*",
+    "@chia/contents": "workspace:*",
     "@chia/i18n": "workspace:*",
     "@chia/ui": "workspace:*",
     "@heroui/react": "catalog:heroui-v3",

--- a/packages/agent-elements/src/markdown.tsx
+++ b/packages/agent-elements/src/markdown.tsx
@@ -7,6 +7,7 @@ import { ExternalLink } from "lucide-react";
 import { Streamdown } from "streamdown";
 import type { Components, LinkSafetyModalProps } from "streamdown";
 
+import { markdownElements } from "@chia/contents/markdown-elements";
 import { CopyButton } from "@chia/ui/copy-button";
 import { cn } from "@chia/ui/utils/cn.util";
 
@@ -15,11 +16,13 @@ import { useAgentLabels } from "./provider.tsx";
 /**
  * Streamdown's defaults are styled with shadcn tokens (`bg-muted`, `text-muted-foreground`…).
  * HeroUI defines `muted` as a text colour, so those defaults come out as mid-grey slabs in both
- * schemes. These overrides restate the affected elements in HeroUI tokens; everything not listed
+ * schemes. Tables and emphasis come from the blog's shared elements so assistant prose reads like
+ * an article; the rest restates the affected elements in HeroUI tokens. Everything not listed
  * (headings, lists, code blocks) keeps Streamdown's rendering. A host can layer its own on top
  * through `components`.
  */
 export const markdownComponents: Components = {
+  ...markdownElements,
   inlineCode: ({ className, node: _node, ...props }) => (
     <code
       className={cn(
@@ -37,30 +40,6 @@ export const markdownComponents: Components = {
       )}
       {...props}
     />
-  ),
-  table: ({ className, node: _node, ...props }) => (
-    <table
-      className={cn("my-4 w-full border-collapse text-sm", className)}
-      {...props}
-    />
-  ),
-  thead: ({ className, node: _node, ...props }) => (
-    <thead className={cn("bg-surface-secondary", className)} {...props} />
-  ),
-  tr: ({ className, node: _node, ...props }) => (
-    <tr className={cn("border-border border-b", className)} {...props} />
-  ),
-  th: ({ className, node: _node, ...props }) => (
-    <th
-      className={cn(
-        "text-foreground px-3 py-2 text-left font-semibold",
-        className
-      )}
-      {...props}
-    />
-  ),
-  td: ({ className, node: _node, ...props }) => (
-    <td className={cn("px-3 py-2 align-top", className)} {...props} />
   ),
   hr: ({ className, node: _node, ...props }) => (
     <hr className={cn("border-border my-6", className)} {...props} />

--- a/packages/contents/package.json
+++ b/packages/contents/package.json
@@ -17,6 +17,10 @@
       "types": "./src/content.rsc.ts",
       "default": "./src/content.rsc.tsx"
     },
+    "./markdown-elements": {
+      "types": "./src/markdown-elements.tsx",
+      "default": "./src/markdown-elements.tsx"
+    },
     "./mdx-components": {
       "types": "./src/mdx-components.ts",
       "default": "./src/mdx-components.tsx"

--- a/packages/contents/src/markdown-elements.tsx
+++ b/packages/contents/src/markdown-elements.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import type { ComponentType, JSX } from "react";
 
 import { Alert, ScrollShadow } from "@heroui/react";

--- a/packages/contents/src/markdown-elements.tsx
+++ b/packages/contents/src/markdown-elements.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import type { ComponentType, JSX } from "react";
+
+import { Alert, ScrollShadow } from "@heroui/react";
+
+import { ErrorBoundary } from "@chia/ui/error-boundary";
+import { cn } from "@chia/ui/utils/cn.util";
+
+/**
+ * Both MDX and Streamdown hand element overrides their HTML props; Streamdown additionally passes
+ * the hast `node`, which must not reach the DOM.
+ */
+type ElementProps<T extends keyof JSX.IntrinsicElements> =
+  JSX.IntrinsicElements[T] & { node?: unknown };
+
+type Element<T extends keyof JSX.IntrinsicElements> = ComponentType<
+  ElementProps<T>
+>;
+
+const table: Element<"table"> = ({ className, node: _node, ...props }) => (
+  <ErrorBoundary
+    errorElement={
+      <Alert status="danger" className="not-prose my-2">
+        <Alert.Indicator />
+        <Alert.Content>
+          <Alert.Title>Error loading table</Alert.Title>
+          <Alert.Description>Please try again later.</Alert.Description>
+        </Alert.Content>
+      </Alert>
+    }>
+    <div className="my-6 w-full">
+      <ScrollShadow orientation="horizontal">
+        <table
+          className={cn(
+            "not-prose w-full min-w-[600px] border-collapse text-sm",
+            className
+          )}
+          {...props}
+        />
+      </ScrollShadow>
+    </div>
+  </ErrorBoundary>
+);
+
+const thead: Element<"thead"> = ({ className, node: _node, ...props }) => (
+  <thead className={cn("bg-surface-secondary", className)} {...props} />
+);
+
+const tbody: Element<"tbody"> = ({ node: _node, ...props }) => (
+  <tbody {...props} />
+);
+
+const tr: Element<"tr"> = ({ className, node: _node, ...props }) => (
+  <tr className={cn("border-border border-b", className)} {...props} />
+);
+
+const th: Element<"th"> = ({ className, node: _node, ...props }) => (
+  <th
+    className={cn(
+      "text-foreground min-w-40 px-3 py-2 text-left font-semibold",
+      className
+    )}
+    {...props}
+  />
+);
+
+const td: Element<"td"> = ({ className, node: _node, ...props }) => (
+  <td className={cn("px-3 py-2 align-top", className)} {...props} />
+);
+
+const strong: Element<"strong"> = ({ className, node: _node, ...props }) => (
+  <strong
+    className={cn("dark:c-text-bg-purple-half c-text-bg-pink-half", className)}
+    {...props}
+  />
+);
+
+/** Element overrides shared by blog MDX and the agent's markdown so prose reads the same in both. */
+export const markdownElements = {
+  table,
+  thead,
+  tbody,
+  tr,
+  th,
+  td,
+  strong,
+};

--- a/packages/contents/src/markdown-elements.tsx
+++ b/packages/contents/src/markdown-elements.tsx
@@ -29,13 +29,10 @@ const table: Element<"table"> = ({ className, node: _node, ...props }) => (
         </Alert.Content>
       </Alert>
     }>
-    <div className="my-6 w-full">
+    <div className="table-root table-root--primary my-6">
       <ScrollShadow orientation="horizontal">
         <table
-          className={cn(
-            "not-prose w-full min-w-[600px] border-collapse text-sm",
-            className
-          )}
+          className={cn("not-prose table__content min-w-[600px]", className)}
           {...props}
         />
       </ScrollShadow>
@@ -44,29 +41,21 @@ const table: Element<"table"> = ({ className, node: _node, ...props }) => (
 );
 
 const thead: Element<"thead"> = ({ className, node: _node, ...props }) => (
-  <thead className={cn("bg-surface-secondary", className)} {...props} />
+  <thead className={cn("table__header", className)} {...props} />
 );
 
-const tbody: Element<"tbody"> = ({ node: _node, ...props }) => (
-  <tbody {...props} />
+const tbody: Element<"tbody"> = ({ className, node: _node, ...props }) => (
+  <tbody className={cn("table__body", className)} {...props} />
 );
 
-const tr: Element<"tr"> = ({ className, node: _node, ...props }) => (
-  <tr className={cn("border-border border-b", className)} {...props} />
-);
+const tr: Element<"tr"> = ({ node: _node, ...props }) => <tr {...props} />;
 
 const th: Element<"th"> = ({ className, node: _node, ...props }) => (
-  <th
-    className={cn(
-      "text-foreground min-w-40 px-3 py-2 text-left font-semibold",
-      className
-    )}
-    {...props}
-  />
+  <th className={cn("table__column min-w-40", className)} {...props} />
 );
 
 const td: Element<"td"> = ({ className, node: _node, ...props }) => (
-  <td className={cn("px-3 py-2 align-top", className)} {...props} />
+  <td className={cn("table__cell", className)} {...props} />
 );
 
 const strong: Element<"strong"> = ({ className, node: _node, ...props }) => (

--- a/packages/contents/src/mdx-components.tsx
+++ b/packages/contents/src/mdx-components.tsx
@@ -3,7 +3,6 @@
 
 import Image from "next/image";
 
-import { Alert, ScrollShadow } from "@heroui/react";
 import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
 import { Banner } from "fumadocs-ui/components/banner";
 import { Callout } from "fumadocs-ui/components/callout";
@@ -15,11 +14,10 @@ import { TypeTable } from "fumadocs-ui/components/type-table";
 import defaultComponents from "fumadocs-ui/mdx";
 import type { MDXComponents } from "mdx/types";
 
-import { ErrorBoundary } from "@chia/ui/error-boundary";
 import ImageZoom from "@chia/ui/image-zoom";
-import { cn } from "@chia/ui/utils/cn.util";
 
 import { Mermaid } from "./components/mermaid";
+import { markdownElements } from "./markdown-elements";
 
 export const FumadocsComponents =
   /* SAFETY: The producer contract guarantees this value satisfies MDXComponents. */ {
@@ -95,41 +93,6 @@ export const V1MDXComponents: MDXComponents = {
   FlexCenter: (props: any) => (
     <div className="flex w-full justify-center">{props.children}</div>
   ),
-  table: (props: any) => (
-    <ErrorBoundary
-      errorElement={
-        <Alert status="danger" className="not-prose my-2">
-          <Alert.Indicator />
-          <Alert.Content>
-            <Alert.Title>Error loading table</Alert.Title>
-            <Alert.Description>Please try again later.</Alert.Description>
-          </Alert.Content>
-        </Alert>
-      }>
-      <div className="table-root table-root--primary my-6">
-        <ScrollShadow orientation="horizontal">
-          <table className="not-prose table__content min-w-[600px]">
-            {props.children}
-          </table>
-        </ScrollShadow>
-      </div>
-    </ErrorBoundary>
-  ),
-  thead: (props: any) => (
-    <thead className="table__header">{props.children}</thead>
-  ),
-  tbody: (props: any) => (
-    <tbody className="table__body">{props.children}</tbody>
-  ),
-  tr: (props: any) => <tr>{props.children}</tr>,
-  th: (props: any) => (
-    <th className={cn("table__column min-w-40")}>{props.children}</th>
-  ),
-  td: (props: any) => <td className="table__cell">{props.children}</td>,
-  strong: (props: any) => (
-    <strong className="dark:c-text-bg-purple-half c-text-bg-pink-half">
-      {props.children}
-    </strong>
-  ),
+  ...markdownElements,
   Mermaid,
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1125,6 +1125,9 @@ importers:
       '@chia/api':
         specifier: workspace:*
         version: link:../api
+      '@chia/contents':
+        specifier: workspace:*
+        version: link:../contents
       '@chia/i18n':
         specifier: workspace:*
         version: link:../i18n


### PR DESCRIPTION
## Summary
- Add `@chia/contents/markdown-elements`: renderer-agnostic overrides for `table/thead/tbody/tr/th/td/strong`, typed to accept both MDX props and Streamdown's extra `node` prop (stripped before reaching the DOM). No `next` / `fumadocs-ui` imports, so `@chia/agent-elements` does not inherit those dependencies.
- `V1MDXComponents` (blog) and `markdownComponents` (agent chat, Streamdown) both compose from it, so assistant prose tables and emphasis render with the same HeroUI table classes as posts.
- Overrides now spread props instead of forwarding only `children`, so `className` / `data-*` from the renderer (e.g. Streamdown's streaming attributes) are preserved.
- Headings and code blocks are intentionally left on each renderer's own implementation.

## Notes
- The module must stay without `"use client"`: `www` spreads `V1MDXComponents` on the RSC side, and a client-boundary object export becomes a reference proxy whose spread yields no overrides. The leaf components (`ErrorBoundary`, HeroUI `Alert` / `ScrollShadow`) already carry their own boundaries.

## Test plan
- [x] `pnpm turbo run lint type:check` for `@chia/contents`, `@chia/agent-elements`, `www`, `dash`
- [x] `/posts/test-table-100b4a31` on `www` renders the table with HeroUI table styles
- [ ] Agent chat on `dash`: a markdown table from the assistant picks up the same table styles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved Markdown and MDX rendering with consistent table formatting and responsive horizontal scrolling.
  * Added clearer handling for table rendering errors.
  * Standardized bold-text styling across supported content surfaces.
  * Consolidated shared Markdown display behavior so content appears more consistent throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->