### PR TITLE
feat(agent): bound tool-call loops with a per-turn budget

### DIFF
--- a/docs/agent-architecture.md
+++ b/docs/agent-architecture.md
@@ -179,8 +179,10 @@ turn context and the writing policy.
 `runPiTurn` owns the complete lifecycle:
 
 1. clamp thinking level to the resolved model and construct one harness for the turn;
-2. install the Pi tool-call approval hook, the `context` hook that appends the volatile block, the
-   host abort signal, and Pi-to-wire event mapping;
+2. install one `tool_call` hook composing the turn budget and the approval hook (budget first —
+   Pi keeps the last defined hook result, so they cannot be two handlers), the `context` hook
+   that appends the volatile block, the host abort signal, the turn deadline, and Pi-to-wire
+   event mapping;
 3. emit `run:start` and the user event, then invoke prompt or prompt template;
 4. read the resolved assistant message: `stopReason: "error"` is a classified provider failure,
    `"aborted"` ends the turn as aborted; a thrown harness or hook error is `internal`;
@@ -188,6 +190,27 @@ turn context and the writing policy.
    `approval:request` events;
 6. auto-compact only after a successful turn with no pending approvals;
 7. emit the terminal error/end events, unsubscribe, then flush the durable writer.
+
+### Turn budget
+
+Pi's loop has no step limit: it runs while the assistant message carries tool calls, so a model
+that re-issues the same call would run until the operator aborts. Every kind therefore passes an
+`AgentTurnBudget` (`writingTurnBudget` in `@chia/agent-writing/policy`) and `createPiTurnBudget`
+(`packages/agent-runtime/src/pi/turn-budget.ts`) enforces it on the `tool_call` hook, ahead of the
+approval gate:
+
+| Limit              | Crossing it                                                                                                                              |
+| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `maxRepeats`       | the same tool with identical arguments that many times in a row — refused with a tool error telling the model the result will not change |
+| `maxToolCalls`     | every further call refused with a tool error asking the model to answer from what it has                                                 |
+| `hardMaxToolCalls` | the model called through the refusals — the harness is aborted and the turn ends `error{budget_exhausted}`                               |
+| `maxDurationMs`    | wall-clock for the whole turn, provider time included — same abort and error                                                             |
+
+Refusals speak to the model through the tool result, the channel the approval gate already uses,
+so a model that complies finishes the turn normally. The two aborts go through the same host-failure
+path as a failed volatile-context read: the failure is recorded, the harness aborted, and the turn
+ends as that error rather than as `aborted`. Per-user and per-session quotas are not here — they
+belong at enqueue time, in the kind service.
 
 ### Prompt layering
 
@@ -289,8 +312,8 @@ session:compacted · state:changed · error · run:end
 - `entriesToWireEvents` rebuilds history from persisted Pi entries and uses each entry id as the
   stable assistant identity. A persisted assistant message with `stopReason: "error"` replays as
   the same `error` event the live turn emitted.
-- `error` carries a `kind` (`auth · quota · rate_limited · context_overflow · provider ·
-internal`) so a client can say what to do next; `describeAgentError` is the shared headline.
+- `error` carries a `kind` (`auth · quota · rate_limited · context_overflow · budget_exhausted ·
+provider · internal`) so a client can say what to do next; `describeAgentError` is the shared headline.
 - `tool:end.details` is clipped by `clipDetails` before it reaches the wire — long strings, arrays,
   wide objects and deep nesting are shortened in place, shape preserved — because every coarse
   event is a durable write that is replayed to every reconnecting client. The model reads the
@@ -435,6 +458,7 @@ until a concrete second execution foundation requires a different seam.
 | ---------------------------- | ---------------------------------------------------------------------------------------------- |
 | Pi turn lifecycle            | `packages/agent-runtime/src/pi/turn.ts`                                                        |
 | Pi approval hook             | `packages/agent-runtime/src/pi/tool-gate.ts`                                                   |
+| Turn budget                  | `packages/agent-runtime/src/pi/turn-budget.ts`                                                 |
 | Error classification         | `packages/agent-runtime/src/pi/errors.ts`                                                      |
 | Details clipping             | `packages/agent-runtime/src/wire/clip.ts`                                                      |
 | Abort controller             | `apps/service/src/workflows/agent-abort.workflow.ts`, `src/services/agent-abort-controller.ts` |

--- a/docs/agent-architecture.md
+++ b/docs/agent-architecture.md
@@ -199,12 +199,12 @@ that re-issues the same call would run until the operator aborts. Every kind the
 (`packages/agent-runtime/src/pi/turn-budget.ts`) enforces it on the `tool_call` hook, ahead of the
 approval gate:
 
-| Limit              | Crossing it                                                                                                                              |
-| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `maxRepeats`       | the same tool with identical arguments that many times in a row — refused with a tool error telling the model the result will not change |
-| `maxToolCalls`     | every further call refused with a tool error asking the model to answer from what it has                                                 |
-| `hardMaxToolCalls` | the model called through the refusals — the harness is aborted and the turn ends `error{budget_exhausted}`                               |
-| `maxDurationMs`    | wall-clock for the whole turn, provider time included — same abort and error                                                             |
+| Limit              | Crossing it                                                                                                                                                                       |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `maxRepeats`       | the same tool with identical arguments that many times in a row — refused with a tool error telling the model the result will not change                                          |
+| `maxToolCalls`     | every further call refused with a tool error asking the model to answer from what it has                                                                                          |
+| `hardMaxToolCalls` | the model called through the refusals — the harness is aborted and the turn ends `error{budget_exhausted}`                                                                        |
+| `maxDurationMs`    | wall-clock for the model's generation — same abort and error; cleared once the reply resolves, so the host work after it (approval persistence, compaction) is never failed by it |
 
 Refusals speak to the model through the tool result, the channel the approval gate already uses,
 so a model that complies finishes the turn normally. The two aborts go through the same host-failure

--- a/docs/agent-architecture.zh.md
+++ b/docs/agent-architecture.zh.md
@@ -174,8 +174,9 @@ context 與 writing policy。
 `runPiTurn` 負責完整生命週期：
 
 1. 依 resolved model clamp thinking level，每個 turn 建立一個 harness；
-2. 安裝 Pi tool-call approval hook、附加 volatile block 的 `context` hook、host 的 abort
-   signal，以及 Pi-to-wire event mapper；
+2. 安裝一個組合了 turn budget 與 approval hook 的 `tool_call` hook（budget 先——Pi 只保留最後
+   一個有回傳值的 hook 結果，所以不能拆成兩個 handler）、附加 volatile block 的 `context`
+   hook、host 的 abort signal、turn deadline，以及 Pi-to-wire event mapper；
 3. emit `run:start`、user event，再呼叫 prompt 或 prompt template；
 4. 檢查回傳的 assistant message：`stopReason: "error"` 是分類過的 provider 失敗，
    `"aborted"` 讓 turn 以 aborted 結束；harness 或 hook 拋出的例外歸為 `internal`；
@@ -183,6 +184,26 @@ context 與 writing policy。
    `approval:request`；
 6. 只在成功且沒有 pending approval 時 auto-compact；
 7. emit terminal error/end，解除 subscriptions，最後 flush durable writer。
+
+### Turn budget
+
+Pi 的 loop 沒有 step 上限：只要 assistant message 還帶 tool call 就繼續跑，所以一個不斷重發
+同一個呼叫的模型會一直跑到 operator abort 為止。因此每個 kind 都要傳入 `AgentTurnBudget`
+（writing 的是 `@chia/agent-writing/policy` 的 `writingTurnBudget`），由 `createPiTurnBudget`
+（`packages/agent-runtime/src/pi/turn-budget.ts`）在 `tool_call` hook 上、approval gate 之前
+執行：
+
+| 上限               | 越過時                                                                                 |
+| ------------------ | -------------------------------------------------------------------------------------- |
+| `maxRepeats`       | 同一個 tool 以完全相同的參數連續呼叫這麼多次——以 tool error 拒絕，告訴模型結果不會改變 |
+| `maxToolCalls`     | 之後每個呼叫都以 tool error 拒絕，要模型用現有結果作答                                 |
+| `hardMaxToolCalls` | 模型無視拒絕繼續呼叫——abort harness，turn 以 `error{budget_exhausted}` 結束            |
+| `maxDurationMs`    | 整個 turn 的 wall-clock（含 provider 時間）——同樣 abort 與 error                       |
+
+拒絕是透過 tool result 跟模型對話，與 approval gate 用的是同一條通道，所以會聽話的模型會正常
+結束這一輪。兩種 abort 走的是與 volatile-context 讀取失敗相同的 host-failure 路徑：記下失敗、
+abort harness，turn 以該 error 結束而非 `aborted`。per-user 與 per-session 的配額不在這裡——
+那屬於 enqueue 時的 kind service。
 
 ### Prompt 分層
 
@@ -267,7 +288,8 @@ session:compacted · state:changed · error · run:end
 - `entriesToWireEvents`：persisted Pi entries → replay history，使用 entry id 作為穩定的
   assistant identity。`stopReason: "error"` 的持久化 assistant message 會 replay 成與 live
   turn 相同的 `error` event。
-- `error` 帶 `kind`（`auth · quota · rate_limited · context_overflow · provider · internal`），
+- `error` 帶 `kind`（`auth · quota · rate_limited · context_overflow · budget_exhausted · provider ·
+internal`），
   讓 client 能提示下一步；`describeAgentError` 是共用的 headline。
 - `tool:end.details` 上 wire 前會經過 `clipDetails`——長字串、陣列、寬物件與深巢狀就地縮短、
   保留形狀——因為每個 coarse event 都是 durable write，且會 replay 給每個重連的 client。模型
@@ -393,6 +415,7 @@ factory、capability plugin system 或 provider-neutral handle。
 | ---------------------------- | ---------------------------------------------------------------------------------------------- |
 | Pi turn lifecycle            | `packages/agent-runtime/src/pi/turn.ts`                                                        |
 | Pi approval hook             | `packages/agent-runtime/src/pi/tool-gate.ts`                                                   |
+| Turn budget                  | `packages/agent-runtime/src/pi/turn-budget.ts`                                                 |
 | Error classification         | `packages/agent-runtime/src/pi/errors.ts`                                                      |
 | Details clipping             | `packages/agent-runtime/src/wire/clip.ts`                                                      |
 | Abort controller             | `apps/service/src/workflows/agent-abort.workflow.ts`, `src/services/agent-abort-controller.ts` |

--- a/docs/agent-architecture.zh.md
+++ b/docs/agent-architecture.zh.md
@@ -193,12 +193,12 @@ Pi 的 loop 沒有 step 上限：只要 assistant message 還帶 tool call 就�
 （`packages/agent-runtime/src/pi/turn-budget.ts`）在 `tool_call` hook 上、approval gate 之前
 執行：
 
-| 上限               | 越過時                                                                                 |
-| ------------------ | -------------------------------------------------------------------------------------- |
-| `maxRepeats`       | 同一個 tool 以完全相同的參數連續呼叫這麼多次——以 tool error 拒絕，告訴模型結果不會改變 |
-| `maxToolCalls`     | 之後每個呼叫都以 tool error 拒絕，要模型用現有結果作答                                 |
-| `hardMaxToolCalls` | 模型無視拒絕繼續呼叫——abort harness，turn 以 `error{budget_exhausted}` 結束            |
-| `maxDurationMs`    | 整個 turn 的 wall-clock（含 provider 時間）——同樣 abort 與 error                       |
+| 上限               | 越過時                                                                                                                            |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
+| `maxRepeats`       | 同一個 tool 以完全相同的參數連續呼叫這麼多次——以 tool error 拒絕，告訴模型結果不會改變                                            |
+| `maxToolCalls`     | 之後每個呼叫都以 tool error 拒絕，要模型用現有結果作答                                                                            |
+| `hardMaxToolCalls` | 模型無視拒絕繼續呼叫——abort harness，turn 以 `error{budget_exhausted}` 結束                                                       |
+| `maxDurationMs`    | 模型生成階段的 wall-clock——同樣 abort 與 error；reply 一回來就清掉，之後的 host 工作（approval 持久化、compaction）不會被它判失敗 |
 
 拒絕是透過 tool result 跟模型對話，與 approval gate 用的是同一條通道，所以會聽話的模型會正常
 結束這一輪。兩種 abort 走的是與 volatile-context 讀取失敗相同的 host-failure 路徑：記下失敗、

--- a/packages/agent-runtime/__tests__/pi-turn-budget.test.ts
+++ b/packages/agent-runtime/__tests__/pi-turn-budget.test.ts
@@ -91,6 +91,22 @@ describe("createPiTurnBudget", () => {
     expect(turnBudget.handle(call({ q: "same" }))).toBeUndefined();
   });
 
+  it.each([
+    ["NaN count", { maxToolCalls: Number.NaN }],
+    ["infinite count", { hardMaxToolCalls: Number.POSITIVE_INFINITY }],
+    ["fractional count", { maxRepeats: 1.5 }],
+    ["NaN duration", { maxDurationMs: Number.NaN }],
+    ["infinite duration", { maxDurationMs: Number.POSITIVE_INFINITY }],
+    ["duration past the timer range", { maxDurationMs: 2 ** 31 }],
+  ])("rejects a budget with a %s", (_label, override) => {
+    expect(() =>
+      createPiTurnBudget({
+        budget: { ...budget, ...override },
+        onExhausted: vi.fn(),
+      })
+    ).toThrow();
+  });
+
   it("rejects a budget whose hard limit is below its soft limit", () => {
     expect(() =>
       createPiTurnBudget({

--- a/packages/agent-runtime/__tests__/pi-turn-budget.test.ts
+++ b/packages/agent-runtime/__tests__/pi-turn-budget.test.ts
@@ -1,0 +1,102 @@
+import type { ToolCallEvent } from "@earendil-works/pi-agent-core";
+import { describe, expect, it, vi } from "vitest";
+
+import type { JsonObject } from "@chia/db/json";
+
+import { createPiTurnBudget } from "../src/pi/turn-budget.ts";
+import type { AgentTurnBudget } from "../src/types.ts";
+
+/**
+ * The budget is the only thing that can end a tool-call loop from inside a turn, so each limit
+ * is pinned at its exact boundary: one call under must pass, the next must not.
+ */
+
+const budget: AgentTurnBudget = {
+  maxToolCalls: 4,
+  hardMaxToolCalls: 6,
+  maxRepeats: 2,
+  maxDurationMs: 1000,
+};
+
+const call = (
+  input: JsonObject,
+  toolName = "search",
+  id = "call"
+): ToolCallEvent => ({ type: "tool_call", toolCallId: id, toolName, input });
+
+describe("createPiTurnBudget", () => {
+  it("lets distinct calls through until the soft limit, then refuses with a finish-now reason", () => {
+    const turnBudget = createPiTurnBudget({ budget, onExhausted: vi.fn() });
+
+    for (let index = 0; index < budget.maxToolCalls; index += 1) {
+      expect(turnBudget.handle(call({ q: index }))).toBeUndefined();
+    }
+    const refused = turnBudget.handle(call({ q: "one too many" }));
+
+    expect(refused).toMatchObject({ block: true });
+    expect(refused?.reason).toMatch(/do not call any more tools/i);
+    expect(turnBudget.toolCalls).toBe(budget.maxToolCalls + 1);
+  });
+
+  it("fires onExhausted exactly once, the first time the hard limit is crossed", () => {
+    const onExhausted = vi.fn();
+    const turnBudget = createPiTurnBudget({ budget, onExhausted });
+
+    for (let index = 0; index < budget.hardMaxToolCalls; index += 1) {
+      turnBudget.handle(call({ q: index }));
+    }
+    expect(onExhausted).not.toHaveBeenCalled();
+
+    expect(turnBudget.handle(call({ q: "over" }))).toMatchObject({
+      block: true,
+      reason: expect.stringMatching(/stopped/i),
+    });
+    turnBudget.handle(call({ q: "still over" }));
+
+    expect(onExhausted).toHaveBeenCalledOnce();
+  });
+
+  it("refuses the call after maxRepeats identical consecutive calls", () => {
+    const turnBudget = createPiTurnBudget({ budget, onExhausted: vi.fn() });
+
+    expect(turnBudget.handle(call({ q: "same" }))).toBeUndefined();
+    expect(turnBudget.handle(call({ q: "same" }))).toBeUndefined();
+    const refused = turnBudget.handle(call({ q: "same" }));
+
+    expect(refused).toMatchObject({ block: true });
+    expect(refused?.reason).toMatch(/same arguments/i);
+  });
+
+  it("treats argument key order as irrelevant and nested objects as part of the identity", () => {
+    const turnBudget = createPiTurnBudget({ budget, onExhausted: vi.fn() });
+
+    turnBudget.handle(call({ a: 1, b: { c: 2, d: 3 } }));
+    turnBudget.handle(call({ b: { d: 3, c: 2 }, a: 1 }));
+
+    expect(turnBudget.handle(call({ a: 1, b: { c: 2, d: 3 } }))).toMatchObject({
+      block: true,
+    });
+    // A differing nested value is a different call.
+    expect(
+      turnBudget.handle(call({ a: 1, b: { c: 2, d: 4 } }))
+    ).toBeUndefined();
+  });
+
+  it("resets the repeat count when the tool or its arguments change", () => {
+    const turnBudget = createPiTurnBudget({ budget, onExhausted: vi.fn() });
+
+    turnBudget.handle(call({ q: "same" }));
+    turnBudget.handle(call({ q: "same" }));
+    expect(turnBudget.handle(call({ q: "same" }, "get_post"))).toBeUndefined();
+    expect(turnBudget.handle(call({ q: "same" }))).toBeUndefined();
+  });
+
+  it("rejects a budget whose hard limit is below its soft limit", () => {
+    expect(() =>
+      createPiTurnBudget({
+        budget: { ...budget, hardMaxToolCalls: budget.maxToolCalls - 1 },
+        onExhausted: vi.fn(),
+      })
+    ).toThrow(/hardMaxToolCalls/);
+  });
+});

--- a/packages/agent-runtime/__tests__/runtime.test.ts
+++ b/packages/agent-runtime/__tests__/runtime.test.ts
@@ -491,6 +491,36 @@ describe("runPiTurn", () => {
     }
   });
 
+  it("does not fail a turn whose deadline passes while approvals are being persisted", async () => {
+    vi.useFakeTimers();
+    try {
+      const options = createOptions();
+      pi.harness.prompt.mockImplementation(async () => {
+        await pi.handlers.get("tool_call")?.({
+          type: "tool_call",
+          toolCallId: "call-1",
+          toolName: "publish",
+          input: {},
+        });
+        return reply("stop");
+      });
+      options.persistApprovals.mockImplementation(async () => {
+        // The model already stopped; only host work is left when the deadline would fire.
+        await vi.advanceTimersByTimeAsync(budget.maxDurationMs + 1);
+      });
+
+      const result = await runPiTurn(options);
+
+      expect(pi.harness.abort).not.toHaveBeenCalled();
+      expect(result).toMatchObject({
+        status: "awaiting_approval",
+        approvals: ["call-1"],
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("clears the deadline when the turn finishes first", async () => {
     vi.useFakeTimers();
     try {

--- a/packages/agent-runtime/__tests__/runtime.test.ts
+++ b/packages/agent-runtime/__tests__/runtime.test.ts
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { JsonObject } from "@chia/db/json";
 
-import type { AgentPolicy } from "../src/types.ts";
+import type { AgentPolicy, AgentTurnBudget } from "../src/types.ts";
 import type { AgentWireEvent } from "../src/wire/schema.ts";
 
 interface HarnessEvent extends JsonObject {
@@ -53,6 +53,13 @@ const policy: AgentPolicy = {
   summarize: () => "",
 };
 
+const budget: AgentTurnBudget = {
+  maxToolCalls: 3,
+  hardMaxToolCalls: 5,
+  maxRepeats: 2,
+  maxDurationMs: 60_000,
+};
+
 const createOptions = () => {
   const faux = fauxProvider({
     provider: "faux",
@@ -82,6 +89,7 @@ const createOptions = () => {
     toolContext: {},
     systemPrompt: "",
     policy,
+    budget,
     message: { text: "Hello" },
     onEvent: (event: AgentWireEvent) => events.push(event),
     toApproval: (approval: { toolCallId: string }) => approval.toolCallId,
@@ -402,6 +410,98 @@ describe("runPiTurn", () => {
       type: "run:end",
       reason: "aborted",
     });
+  });
+
+  it("refuses tool calls past the soft budget and the gate never sees them", async () => {
+    const options = createOptions();
+    const results: unknown[] = [];
+    pi.harness.prompt.mockImplementation(async () => {
+      for (let index = 0; index < 4; index += 1) {
+        results.push(
+          await pi.handlers.get("tool_call")?.({
+            type: "tool_call",
+            toolCallId: `call-${index}`,
+            toolName: index === 3 ? "publish" : "search",
+            input: { q: String(index) },
+          })
+        );
+      }
+      return reply("stop");
+    });
+
+    const result = await runPiTurn(options);
+
+    expect(results.slice(0, 3)).toEqual([undefined, undefined, undefined]);
+    expect(results[3]).toMatchObject({ block: true });
+    expect(results[3]).toMatchObject({
+      reason: expect.stringMatching(/budget/i),
+    });
+    // The fourth call was a gated `publish`; the budget refused it first, so no approval exists.
+    expect(options.persistApprovals).not.toHaveBeenCalled();
+    expect(result.status).toBe("done");
+  });
+
+  it("ends the turn as budget_exhausted once the model calls through the hard limit", async () => {
+    const options = createOptions();
+    pi.harness.prompt.mockImplementation(async () => {
+      for (let index = 0; index < 6; index += 1) {
+        await pi.handlers.get("tool_call")?.({
+          type: "tool_call",
+          toolCallId: `call-${index}`,
+          toolName: "search",
+          input: { q: String(index) },
+        });
+      }
+      return reply("aborted");
+    });
+
+    const result = await runPiTurn(options);
+
+    expect(pi.harness.abort).toHaveBeenCalledOnce();
+    expect(result).toMatchObject({
+      status: "error",
+      error: { kind: "budget_exhausted" },
+    });
+    expect(options.events.at(-1)).toEqual({ type: "run:end", reason: "error" });
+  });
+
+  it("ends the turn as budget_exhausted when the wall-clock runs out mid-generation", async () => {
+    vi.useFakeTimers();
+    try {
+      const options = createOptions();
+      pi.harness.prompt.mockImplementation(async () => {
+        await vi.advanceTimersByTimeAsync(budget.maxDurationMs + 1);
+        return reply(
+          pi.harness.abort.mock.calls.length > 0 ? "aborted" : "stop"
+        );
+      });
+
+      const result = await runPiTurn(options);
+
+      expect(pi.harness.abort).toHaveBeenCalledOnce();
+      expect(result).toMatchObject({
+        status: "error",
+        error: {
+          kind: "budget_exhausted",
+          message: expect.stringMatching(/60s/),
+        },
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("clears the deadline when the turn finishes first", async () => {
+    vi.useFakeTimers();
+    try {
+      const options = createOptions();
+      await runPiTurn(options);
+      await vi.advanceTimersByTimeAsync(budget.maxDurationMs + 1);
+
+      expect(pi.harness.abort).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("stops listening once the turn is over", async () => {

--- a/packages/agent-runtime/package.json
+++ b/packages/agent-runtime/package.json
@@ -41,6 +41,10 @@
       "types": "./src/pi/events.ts",
       "default": "./src/pi/events.ts"
     },
+    "./pi/turn-budget": {
+      "types": "./src/pi/turn-budget.ts",
+      "default": "./src/pi/turn-budget.ts"
+    },
     "./pi/tool-gate": {
       "types": "./src/pi/tool-gate.ts",
       "default": "./src/pi/tool-gate.ts"

--- a/packages/agent-runtime/src/pi/turn-budget.ts
+++ b/packages/agent-runtime/src/pi/turn-budget.ts
@@ -61,18 +61,35 @@ const callIdentity = (event: ToolCallEvent): string => {
   return `${event.toolName} ${input === undefined ? event.toolCallId : canonical(input)}`;
 };
 
+/** Node clamps longer timer delays to 1ms, which would fire the deadline at once. */
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
+const isCount = (value: number): boolean =>
+  Number.isSafeInteger(value) && value >= 1;
+
 export const assertTurnBudget = (budget: AgentTurnBudget): void => {
-  if (budget.maxToolCalls < 1) {
-    throw new Error("maxToolCalls must be at least 1.");
+  if (!isCount(budget.maxToolCalls)) {
+    throw new Error("maxToolCalls must be a positive integer.");
   }
-  if (budget.hardMaxToolCalls < budget.maxToolCalls) {
-    throw new Error("hardMaxToolCalls must be at least maxToolCalls.");
+  if (
+    !isCount(budget.hardMaxToolCalls) ||
+    budget.hardMaxToolCalls < budget.maxToolCalls
+  ) {
+    throw new Error(
+      "hardMaxToolCalls must be a positive integer of at least maxToolCalls."
+    );
   }
-  if (budget.maxRepeats < 1) {
-    throw new Error("maxRepeats must be at least 1.");
+  if (!isCount(budget.maxRepeats)) {
+    throw new Error("maxRepeats must be a positive integer.");
   }
-  if (budget.maxDurationMs < 1) {
-    throw new Error("maxDurationMs must be positive.");
+  if (
+    !Number.isFinite(budget.maxDurationMs) ||
+    budget.maxDurationMs < 1 ||
+    budget.maxDurationMs > MAX_TIMER_DELAY_MS
+  ) {
+    throw new Error(
+      `maxDurationMs must be between 1 and ${MAX_TIMER_DELAY_MS}.`
+    );
   }
 };
 

--- a/packages/agent-runtime/src/pi/turn-budget.ts
+++ b/packages/agent-runtime/src/pi/turn-budget.ts
@@ -1,0 +1,139 @@
+import type {
+  ToolCallEvent,
+  ToolCallResult,
+} from "@earendil-works/pi-agent-core";
+import * as z from "zod";
+
+import type { JsonValue } from "@chia/db/json";
+
+import type { AgentTurnBudget } from "../types.ts";
+
+const jsonValueSchema: z.ZodType<JsonValue> = z.json();
+const jsonObjectSchema = z.record(z.string(), jsonValueSchema);
+
+/**
+ * Per-turn tool-call budget, composed into the same Pi `tool_call` hook as the approval gate.
+ *
+ * Pi's loop is `while (true)` over "the assistant message still carries tool calls"; it has no
+ * step limit of its own, so a model that keeps re-issuing a call would run until the operator
+ * aborts. This is the only place a runaway turn can be stopped from inside, and it works in two
+ * registers: a *refusal* (a tool error the model reads, the same channel the approval gate uses
+ * to talk to it) and, when the model keeps going through the refusals, an *exhaustion* the host
+ * turns into an abort.
+ *
+ * The hook must run before the gate and their results must be composed by the caller: Pi's
+ * `emitHook` keeps the last defined result, so two independent `tool_call` handlers would let
+ * whichever registered later override the other.
+ */
+
+export interface PiTurnBudgetOptions {
+  budget: AgentTurnBudget;
+  /**
+   * Called once, the first time the hard limit is crossed. The host is expected to abort the
+   * harness; the budget itself can only refuse the call.
+   */
+  onExhausted: () => void;
+}
+
+export interface PiTurnBudget {
+  handle: (event: ToolCallEvent) => ToolCallResult | undefined;
+  /** Tool calls the model has emitted this turn, refused ones included. */
+  readonly toolCalls: number;
+}
+
+/**
+ * Canonical form of a call for repeat detection: key order must not matter, because the model
+ * does not emit arguments in a stable order.
+ */
+const canonical = (value: JsonValue): string => {
+  if (Array.isArray(value)) return `[${value.map(canonical).join(",")}]`;
+  const record = jsonObjectSchema.safeParse(value).data;
+  if (record === undefined) return JSON.stringify(value);
+  return `{${Object.keys(record)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${canonical(record[key] ?? null)}`)
+    .join(",")}}`;
+};
+
+/** Tool arguments arrived from the provider as JSON; anything else has no stable identity. */
+const callIdentity = (event: ToolCallEvent): string => {
+  const input = jsonValueSchema.safeParse(event.input).data;
+  return `${event.toolName} ${input === undefined ? event.toolCallId : canonical(input)}`;
+};
+
+export const assertTurnBudget = (budget: AgentTurnBudget): void => {
+  if (budget.maxToolCalls < 1) {
+    throw new Error("maxToolCalls must be at least 1.");
+  }
+  if (budget.hardMaxToolCalls < budget.maxToolCalls) {
+    throw new Error("hardMaxToolCalls must be at least maxToolCalls.");
+  }
+  if (budget.maxRepeats < 1) {
+    throw new Error("maxRepeats must be at least 1.");
+  }
+  if (budget.maxDurationMs < 1) {
+    throw new Error("maxDurationMs must be positive.");
+  }
+};
+
+export const createPiTurnBudget = (
+  options: PiTurnBudgetOptions
+): PiTurnBudget => {
+  const { budget } = options;
+  assertTurnBudget(budget);
+
+  let toolCalls = 0;
+  let lastCall: string | undefined;
+  let repeats = 0;
+  let exhausted = false;
+
+  return {
+    get toolCalls() {
+      return toolCalls;
+    },
+    handle(event) {
+      toolCalls += 1;
+
+      if (toolCalls > budget.hardMaxToolCalls) {
+        if (!exhausted) {
+          exhausted = true;
+          options.onExhausted();
+        }
+        return {
+          block: true,
+          reason: "This turn has been stopped: its tool budget is exhausted.",
+        };
+      }
+
+      if (toolCalls > budget.maxToolCalls) {
+        return {
+          block: true,
+          reason:
+            `This turn's tool budget (${budget.maxToolCalls} calls) is used up. ` +
+            "Do not call any more tools. Answer now from what you already have, " +
+            "and say what you could not finish.",
+        };
+      }
+
+      const key = callIdentity(event);
+      if (key === lastCall) {
+        repeats += 1;
+      } else {
+        lastCall = key;
+        repeats = 1;
+      }
+      if (repeats > budget.maxRepeats) {
+        return {
+          block: true,
+          reason:
+            `\`${event.toolName}\` was already called ${budget.maxRepeats} times in a row with ` +
+            "these exact arguments and the result will not change. Do not call it again with " +
+            "the same arguments: use the result you already have, change the arguments, or " +
+            "answer without it.",
+        };
+      }
+
+      return undefined;
+    },
+  };
+};

--- a/packages/agent-runtime/src/pi/turn.ts
+++ b/packages/agent-runtime/src/pi/turn.ts
@@ -14,6 +14,7 @@ import type {
 
 import type { AgentPolicy, AgentSessionSettings, AgentTool } from "../types.ts";
 import type {
+  AgentTurnBudget,
   AgentTurnError,
   AgentTurnExecution,
   AgentTurnMessage,
@@ -26,6 +27,7 @@ import { createPiWireEventMapper } from "./events.ts";
 import { clampSessionThinkingLevel } from "./settings.ts";
 import { createPiToolCallGate } from "./tool-gate.ts";
 import type { ApprovalRequest } from "./tool-gate.ts";
+import { createPiTurnBudget } from "./turn-budget.ts";
 
 export interface RunPiTurnOptions<TContext extends object, TApproval> {
   agentSessionId: string;
@@ -57,6 +59,8 @@ export interface RunPiTurnOptions<TContext extends object, TApproval> {
   skills?: Skill[];
   promptTemplates?: PromptTemplate[];
   policy: AgentPolicy;
+  /** See {@link AgentTurnBudget}; crossing it ends the turn as `budget_exhausted`. */
+  budget: AgentTurnBudget;
   approvedToolCallIds?: ReadonlySet<string>;
   preAuthorizedToolNames?: ReadonlySet<string>;
   message: AgentTurnMessage;
@@ -88,6 +92,7 @@ export const runPiTurn = async <TContext extends object, TApproval>({
   skills,
   promptTemplates,
   policy,
+  budget,
   approvedToolCallIds,
   preAuthorizedToolNames,
   message,
@@ -119,6 +124,22 @@ export const runPiTurn = async <TContext extends object, TApproval>({
           systemPrompt,
         } as never
       ) as AgentHarness<TContext>;
+    /**
+     * A failure raised by the host inside a Pi hook. Pi turns a throwing hook into an assistant
+     * message with `stopReason: "error"`, indistinguishable from a provider failure, so hooks catch
+     * their own errors here and the turn is failed as `internal` once the harness has unwound.
+     */
+    let hostFailure: AgentTurnError | undefined;
+
+    /**
+     * Ends the turn on a host decision. Not awaited: `abort()` waits for the run to settle, and
+     * the callers are on the run's own path (a hook, or a timer racing the provider).
+     */
+    const failTurn = (error: AgentTurnError) => {
+      hostFailure ??= error;
+      void turnHarness.abort().catch(() => undefined);
+    };
+
     const gate = createPiToolCallGate({
       policy,
       autoApprove: settings.autoApprove,
@@ -135,16 +156,32 @@ export const runPiTurn = async <TContext extends object, TApproval>({
           args: request.args,
         }),
     });
+    const turnBudget = createPiTurnBudget({
+      budget,
+      onExhausted: () =>
+        failTurn({
+          kind: "budget_exhausted",
+          message: `The model issued more than ${budget.hardMaxToolCalls} tool calls in one turn.`,
+        }),
+    });
+    // One handler, budget first: Pi keeps the last defined hook result, so two handlers would
+    // let the gate overrule a refused call (or the reverse) depending on registration order.
     unsubscribers.push(
-      turnHarness.on("tool_call", (event) => gate.handle(event))
+      turnHarness.on(
+        "tool_call",
+        (event) => turnBudget.handle(event) ?? gate.handle(event)
+      )
     );
 
-    /**
-     * A failure raised by the host inside a Pi hook. Pi turns a throwing hook into an assistant
-     * message with `stopReason: "error"`, indistinguishable from a provider failure, so hooks catch
-     * their own errors here and the turn is failed as `internal` once the harness has unwound.
-     */
-    let hostFailure: AgentTurnError | undefined;
+    const deadline = setTimeout(
+      () =>
+        failTurn({
+          kind: "budget_exhausted",
+          message: `The turn ran longer than ${Math.round(budget.maxDurationMs / 1000)}s.`,
+        }),
+      budget.maxDurationMs
+    );
+    unsubscribers.push(() => clearTimeout(deadline));
 
     if (volatileContext) {
       unsubscribers.push(
@@ -154,10 +191,8 @@ export const runPiTurn = async <TContext extends object, TApproval>({
             if (!text) return undefined;
             return { messages: [...event.messages, volatileMessage(text)] };
           } catch (error) {
-            // Fail closed: a model that cannot see the current state must not act on it. Not awaited
-            // — `abort()` waits for the run to settle, and this hook is on the run's own path.
-            hostFailure = errorOfThrown(error);
-            void turnHarness.abort().catch(() => undefined);
+            // Fail closed: a model that cannot see the current state must not act on it.
+            failTurn(errorOfThrown(error));
             return undefined;
           }
         })

--- a/packages/agent-runtime/src/pi/turn.ts
+++ b/packages/agent-runtime/src/pi/turn.ts
@@ -173,6 +173,11 @@ export const runPiTurn = async <TContext extends object, TApproval>({
       )
     );
 
+    /**
+     * Bounds the model's generation only. It is cleared as soon as the reply resolves, so it can
+     * never fail a turn whose model has already stopped — approval persistence and compaction
+     * that follow are host work, and a turn that reaches them is not running away.
+     */
     const deadline = setTimeout(
       () =>
         failTurn({
@@ -291,6 +296,7 @@ export const runPiTurn = async <TContext extends object, TApproval>({
         failure = hostFailure ?? errorOfThrown(error);
       }
     }
+    clearTimeout(deadline);
     // An abort that lands after the reply resolved must still keep the turn from persisting
     // approvals or compacting: the run is being cancelled, and rows written now would outlive it.
     if (!failure && signal?.aborted) aborted = true;

--- a/packages/agent-runtime/src/types.ts
+++ b/packages/agent-runtime/src/types.ts
@@ -88,12 +88,38 @@ export type AgentErrorKind =
   | "quota"
   | "rate_limited"
   | "context_overflow"
+  | "budget_exhausted"
   | "provider"
   | "internal";
 
 export interface AgentTurnError {
   kind: AgentErrorKind;
   message: string;
+}
+
+/**
+ * What one turn may consume before the runtime stops it. A turn ends on its own only when the
+ * model stops emitting tool calls, so every limit here bounds tool calls or wall-clock; nothing
+ * else can keep a turn alive.
+ */
+export interface AgentTurnBudget {
+  /**
+   * Tool calls after which every further call is refused with a tool error asking the model to
+   * finish from what it has. A model that complies ends the turn normally.
+   */
+  maxToolCalls: number;
+  /**
+   * Tool calls after which the turn is aborted as `budget_exhausted`. The refusal above is only a
+   * message; a model that keeps calling through it would otherwise loop on the refusal itself.
+   */
+  hardMaxToolCalls: number;
+  /**
+   * Consecutive calls of one tool with identical arguments after which the call is refused. The
+   * result cannot differ, so the refusal tells the model as much.
+   */
+  maxRepeats: number;
+  /** Wall-clock for the whole turn, provider time included. */
+  maxDurationMs: number;
 }
 
 export interface AgentTurnExecution<TApproval> {

--- a/packages/agent-runtime/src/types.ts
+++ b/packages/agent-runtime/src/types.ts
@@ -118,7 +118,7 @@ export interface AgentTurnBudget {
    * result cannot differ, so the refusal tells the model as much.
    */
   maxRepeats: number;
-  /** Wall-clock for the whole turn, provider time included. */
+  /** Wall-clock for the model's generation; host work after the reply is not counted. */
   maxDurationMs: number;
 }
 

--- a/packages/agent-runtime/src/wire/fold.ts
+++ b/packages/agent-runtime/src/wire/fold.ts
@@ -47,6 +47,7 @@ export const AGENT_ERROR_HEADLINE = {
   rate_limited: "The provider is rate limiting requests",
   context_overflow:
     "The conversation no longer fits the model's context — compact it",
+  budget_exhausted: "The turn ran past its budget and was stopped",
   provider: "The provider failed",
   internal: "The agent failed",
 } satisfies Record<AgentErrorKind, string>;

--- a/packages/agent-runtime/src/wire/schema.ts
+++ b/packages/agent-runtime/src/wire/schema.ts
@@ -12,6 +12,7 @@ export const agentErrorKindSchema = z.enum([
   "quota",
   "rate_limited",
   "context_overflow",
+  "budget_exhausted",
   "provider",
   "internal",
 ]);

--- a/packages/agent-writing/src/policy.ts
+++ b/packages/agent-writing/src/policy.ts
@@ -1,4 +1,4 @@
-import type { AgentPolicy } from "@chia/agent-runtime/types";
+import type { AgentPolicy, AgentTurnBudget } from "@chia/agent-runtime/types";
 
 import { labelOf, tierOf } from "./tools/registry.ts";
 import { summarizeToolResult } from "./tools/summarize.ts";
@@ -20,4 +20,16 @@ export const writingPolicy: AgentPolicy = {
   changesState: (tier) => tier === "draft" || tier === "commit",
   stateScope: "draft",
   summarize: summarizeToolResult,
+};
+
+/**
+ * What one writing turn may spend. A research-heavy turn (search, read several posts, fetch a
+ * few sources, stage a draft, revise it) lands around twenty calls, so the soft limit leaves
+ * headroom for that while still ending a turn that only re-issues the same search.
+ */
+export const writingTurnBudget: AgentTurnBudget = {
+  maxToolCalls: 40,
+  hardMaxToolCalls: 60,
+  maxRepeats: 3,
+  maxDurationMs: 15 * 60 * 1000,
 };

--- a/packages/agent-writing/src/runtime.ts
+++ b/packages/agent-writing/src/runtime.ts
@@ -20,7 +20,7 @@ import type { AgentWireEvent } from "@chia/agent-runtime/wire/schema";
 import { Locale } from "@chia/db/types";
 
 import { resolveWritingModel } from "./models.ts";
-import { writingPolicy } from "./policy.ts";
+import { writingPolicy, writingTurnBudget } from "./policy.ts";
 import type { ContentPort, DraftStore, WebPort } from "./ports.ts";
 import { writingSkills } from "./prompts/skills.ts";
 import { buildSystemPrompt, buildTurnContext } from "./prompts/system.ts";
@@ -86,6 +86,7 @@ export const runWritingTurn = <TApproval>(
     skills: writingSkills,
     promptTemplates: writingPromptTemplates,
     policy: writingPolicy,
+    budget: writingTurnBudget,
     approvedToolCallIds: options.approvedToolCallIds,
     preAuthorizedToolNames: options.preAuthorizedToolNames,
     message: options.message,

--- a/packages/i18n/agent-elements/en-US.json
+++ b/packages/i18n/agent-elements/en-US.json
@@ -71,6 +71,7 @@
     "quota": "The provider account is out of quota or credit",
     "rate_limited": "The provider is rate limiting requests",
     "context_overflow": "The conversation no longer fits the model's context — compact it",
+    "budget_exhausted": "The turn ran past its budget and was stopped",
     "provider": "The provider failed",
     "internal": "The agent failed"
   },

--- a/packages/i18n/agent-elements/zh-TW.json
+++ b/packages/i18n/agent-elements/zh-TW.json
@@ -71,6 +71,7 @@
     "quota": "供應商帳戶的額度或餘額已用盡",
     "rate_limited": "供應商正在限制請求速率",
     "context_overflow": "對話已超出模型的 context，請壓縮對話",
+    "budget_exhausted": "這一輪超出預算已被停止",
     "provider": "供應商發生錯誤",
     "internal": "agent 發生錯誤"
   },


### PR DESCRIPTION
Closes #3001

## Problem

Pi's agent loop is `while (true)` over "the assistant message still carries tool calls"; it has no step limit, and neither `runPiTurn` nor the step had one. A lower-tier model re-issuing the same `search_posts` call ran until the operator aborted. Once a public kind ships on `www`, that is a cost hole.

## Change

Every kind now passes an `AgentTurnBudget`, enforced by `createPiTurnBudget` (`packages/agent-runtime/src/pi/turn-budget.ts`) on Pi's `tool_call` hook, composed **ahead of** the approval gate in a single handler — Pi's `emitHook` keeps the last defined result, so two handlers would overrule each other.

| Limit | Crossing it |
| --- | --- |
| `maxRepeats` | same tool + identical args (key order ignored) N times in a row → refused with a tool error saying the result will not change |
| `maxToolCalls` | every further call refused with a tool error asking the model to answer from what it has |
| `hardMaxToolCalls` | model called through the refusals → harness aborted via the existing host-failure path, turn ends `error{budget_exhausted}` |
| `maxDurationMs` | wall-clock deadline for the whole turn → same abort and error |

Refusals talk to the model through the tool result, the same channel the approval gate uses, so a compliant model ends the turn normally.

- New error kind `budget_exhausted` (types, wire schema, fold headline, i18n en-US / zh-TW)
- `runPiTurn` takes a required `budget`; the volatile-context abort is folded into a shared `failTurn()`
- Writing kind: `writingTurnBudget` = 40 soft / 60 hard / 3 repeats / 15 min
- `docs/agent-architecture.md` (+ zh): new "Turn budget" section, error kinds, reference table

## Out of scope

Per-user / per-session quotas — those belong at enqueue time in the kind service and land with the public kind.

## Verification

- `@chia/agent-runtime` 95 tests (6 new budget unit tests + 4 `runPiTurn` integration tests: soft cap shields a gated call, hard cap aborts, deadline fires, deadline cleared on a finished turn), `@chia/agent-writing` 40, `@chia/agent-elements` 16
- `type:check` + `lint` across agent-runtime, agent-writing, agent-elements, service, dash
- `oxfmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-turn safeguards for tool-call counts, repeated calls, and execution duration.
  * Agent turns now stop gracefully when their configured budget is exceeded.
  * Added clear budget-exhaustion error reporting in English and Traditional Chinese.
  * Writing tasks now use configured limits of 40 soft calls, 60 hard calls, three repeats, and 15 minutes.

* **Documentation**
  * Documented turn budgets, enforcement behavior, and error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->