### PR TITLE
feat(agent-elements): stream-highlight fenced code with @shikijs/stream

### DIFF
--- a/apps/dash/src/app/globals.css
+++ b/apps/dash/src/app/globals.css
@@ -11,7 +11,6 @@
 @source "../../node_modules/@chia/ui/src/**/*.{js,ts,jsx,tsx}";
 @source "../../node_modules/@chia/agent-elements/src/**/*.{js,ts,jsx,tsx}";
 @source "../../node_modules/@chia/agent-elements/node_modules/streamdown/dist/*.js";
-@source "../../node_modules/@chia/agent-elements/node_modules/@streamdown/code/dist/*.js";
 @source "../../node_modules/@chia/agent-elements/node_modules/@streamdown/cjk/dist/*.js";
 @source "../../node_modules/@chia/contents/src/**/*.tsx";
 

--- a/packages/agent-elements/__tests__/code-block.test.ts
+++ b/packages/agent-elements/__tests__/code-block.test.ts
@@ -1,0 +1,57 @@
+import { StreamingHighlight } from "../src/code-block.tsx";
+import { loadLanguage, resolveLanguage } from "../src/highlighter.ts";
+
+const text = (tokens: { content: string }[]) =>
+  tokens.map((t) => t.content).join("");
+
+describe("resolveLanguage", () => {
+  it("maps aliases and ids to bundled languages", () => {
+    expect(resolveLanguage("ts")).toBe("typescript");
+    expect(resolveLanguage("TSX")).toBe("tsx");
+    expect(resolveLanguage("javascript")).toBe("javascript");
+  });
+
+  it("falls back to plain text for unknown languages", () => {
+    expect(resolveLanguage("")).toBe("text");
+    expect(resolveLanguage("not-a-language")).toBe("text");
+  });
+});
+
+describe("StreamingHighlight", () => {
+  it("tokens always concatenate to the code seen so far", async () => {
+    const { highlighter, language } = await loadLanguage("ts");
+    const session = new StreamingHighlight(highlighter, language);
+    const source = 'const a = "x";\nfunction f() {\n  return a;\n}\n';
+    for (let i = 1; i <= source.length; i += 3) {
+      const code = source.slice(0, i);
+      expect(text(await session.update(code))).toBe(code);
+    }
+    expect(text(await session.update(source))).toBe(source);
+  });
+
+  it("colours completed lines by grammar, not as plain text", async () => {
+    const { highlighter, language } = await loadLanguage("ts");
+    const session = new StreamingHighlight(highlighter, language);
+    const tokens = await session.update("const a = 1;\n");
+    const keyword = tokens.find((t) => t.content === "const");
+    expect(keyword?.htmlStyle?.["--shiki-light"]).toBeDefined();
+    expect(keyword?.htmlStyle?.["--shiki-dark"]).toBeDefined();
+    expect(keyword?.htmlStyle?.["--shiki-light"]).not.toBe(
+      tokens.find((t) => t.content === "1")?.htmlStyle?.["--shiki-light"]
+    );
+  });
+
+  it("restarts when the text is not an extension of what was seen", async () => {
+    const { highlighter, language } = await loadLanguage("ts");
+    const session = new StreamingHighlight(highlighter, language);
+    await session.update("const a = 1;\nconst b");
+    const tokens = await session.update("let c = 2;\n");
+    expect(text(tokens)).toBe("let c = 2;\n");
+  });
+
+  it("streams unknown languages as plain text", async () => {
+    const { highlighter, language } = await loadLanguage("nope");
+    const session = new StreamingHighlight(highlighter, language);
+    expect(text(await session.update("hello\nworld"))).toBe("hello\nworld");
+  });
+});

--- a/packages/agent-elements/package.json
+++ b/packages/agent-elements/package.json
@@ -41,6 +41,14 @@
       "types": "./src/thread.tsx",
       "default": "./src/thread.tsx"
     },
+    "./code-block": {
+      "types": "./src/code-block.tsx",
+      "default": "./src/code-block.tsx"
+    },
+    "./highlighter": {
+      "types": "./src/highlighter.ts",
+      "default": "./src/highlighter.ts"
+    },
     "./markdown": {
       "types": "./src/markdown.tsx",
       "default": "./src/markdown.tsx"
@@ -119,13 +127,14 @@
     "@chia/ui": "workspace:*",
     "@heroui/react": "catalog:heroui-v3",
     "@orpc/contract": "catalog:orpc",
+    "@shikijs/stream": "catalog:ui",
     "@streamdown/cjk": "catalog:streamdown",
-    "@streamdown/code": "catalog:streamdown",
     "@tanstack/react-pacer": "catalog:tanstack",
     "@tanstack/react-query": "catalog:tanstack",
     "border-beam": "catalog:ui",
     "lucide-react": "catalog:ui",
     "react": "catalog:react-is",
+    "shiki": "catalog:ui",
     "streamdown": "catalog:streamdown",
     "thinking-orbs": "catalog:ui",
     "zod": "catalog:",

--- a/packages/agent-elements/src/code-block.tsx
+++ b/packages/agent-elements/src/code-block.tsx
@@ -100,10 +100,7 @@ export const HighlightedCode = ({
   const tokens = useStreamingTokens(code, language);
   return (
     <pre
-      className={cn(
-        "overflow-x-auto font-mono text-[13px] leading-6",
-        className
-      )}>
+      className={cn("overflow-x-auto font-mono text-xs leading-5", className)}>
       <code>
         {tokens
           ? tokens.map((token, index) => (

--- a/packages/agent-elements/src/code-block.tsx
+++ b/packages/agent-elements/src/code-block.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import { ShikiStreamTokenizer } from "@shikijs/stream";
+import type { ThemedToken } from "shiki";
+import { getTokenStyleObject } from "shiki/core";
+
+import { cn } from "@chia/ui/utils/cn.util";
+
+import type { Highlighter } from "./highlighter.ts";
+import { loadLanguage, themes } from "./highlighter.ts";
+
+/**
+ * Incremental highlighting of text that only ever grows. Each `update` feeds the tokenizer just the
+ * suffix appended since the last call; completed lines keep their tokens and grammar state, the
+ * unfinished last line is re-tokenized. Anything other than an append restarts from scratch.
+ */
+export class StreamingHighlight {
+  private readonly tokenizer: ShikiStreamTokenizer;
+  private consumed = "";
+
+  constructor(highlighter: Highlighter, language: string) {
+    this.tokenizer = new ShikiStreamTokenizer({
+      highlighter,
+      lang: language,
+      themes,
+      defaultColor: "light-dark()",
+    });
+  }
+
+  async update(code: string): Promise<ThemedToken[]> {
+    if (!code.startsWith(this.consumed)) {
+      this.tokenizer.clear();
+      this.consumed = "";
+    }
+    const delta = code.slice(this.consumed.length);
+    this.consumed = code;
+    if (delta) await this.tokenizer.enqueue(delta);
+    return [...this.tokenizer.tokensStable, ...this.tokenizer.tokensUnstable];
+  }
+}
+
+/**
+ * Tokens for `code` in `language`, kept up to date as the text streams in. `null` until the
+ * grammar has loaded so the caller can show the raw text meanwhile.
+ */
+export const useStreamingTokens = (code: string, language: string) => {
+  const [grammar, setGrammar] = useState<{
+    highlighter: Highlighter;
+    language: string;
+  } | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    void loadLanguage(language).then((loaded) => {
+      if (alive) setGrammar(loaded);
+    });
+    return () => {
+      alive = false;
+    };
+  }, [language]);
+
+  const session = useMemo(
+    () =>
+      grammar
+        ? new StreamingHighlight(grammar.highlighter, grammar.language)
+        : null,
+    [grammar]
+  );
+
+  const [tokens, setTokens] = useState<ThemedToken[] | null>(null);
+
+  useEffect(() => {
+    if (!session) return;
+    let alive = true;
+    void session.update(code).then((next) => {
+      if (alive) setTokens(next);
+    });
+    return () => {
+      alive = false;
+    };
+  }, [session, code]);
+
+  return session ? tokens : null;
+};
+
+export interface HighlightedCodeProps {
+  code: string;
+  language: string;
+  className?: string;
+}
+
+/** The highlighted `<pre>`; the host wraps it in whatever frame it wants. */
+export const HighlightedCode = ({
+  className,
+  code,
+  language,
+}: HighlightedCodeProps) => {
+  const tokens = useStreamingTokens(code, language);
+  return (
+    <pre
+      className={cn(
+        "overflow-x-auto font-mono text-[13px] leading-6",
+        className
+      )}>
+      <code>
+        {tokens
+          ? tokens.map((token, index) => (
+              <span
+                key={index}
+                style={token.htmlStyle ?? getTokenStyleObject(token)}>
+                {token.content}
+              </span>
+            ))
+          : code}
+      </code>
+    </pre>
+  );
+};

--- a/packages/agent-elements/src/highlighter.ts
+++ b/packages/agent-elements/src/highlighter.ts
@@ -1,0 +1,54 @@
+import type { BundledLanguage, Highlighter } from "shiki";
+import { bundledLanguagesInfo, createHighlighter } from "shiki";
+import { createJavaScriptRegexEngine } from "shiki/engine/javascript";
+
+export type { Highlighter };
+
+/** Token colours are emitted for both and resolved with `light-dark()` from the page's `color-scheme`. */
+export const themes = { light: "github-light", dark: "github-dark" } as const;
+
+const languageIds = new Map<string, BundledLanguage>();
+for (const info of bundledLanguagesInfo) {
+  /* SAFETY: bundledLanguagesInfo enumerates exactly the ids that make up BundledLanguage. */
+  const id = info.id as BundledLanguage;
+  languageIds.set(id, id);
+  for (const alias of info.aliases ?? []) languageIds.set(alias, id);
+}
+
+/** Shiki's `text` grammar: tokens without scopes, so unknown languages still stream. */
+export const PLAIN = "text";
+
+export const resolveLanguage = (
+  language: string
+): BundledLanguage | typeof PLAIN =>
+  languageIds.get(language.trim().toLowerCase()) ?? PLAIN;
+
+let highlighter: Promise<Highlighter> | undefined;
+
+/**
+ * One highlighter for the whole app; the JS engine is used so no wasm has to ship, `forgiving`
+ * because a few bundled grammars use regex features the JS engine cannot compile.
+ */
+const getHighlighter = () =>
+  (highlighter ??= createHighlighter({
+    themes: [themes.light, themes.dark],
+    langs: [],
+    engine: createJavaScriptRegexEngine({ forgiving: true }),
+  }));
+
+const loading = new Map<string, Promise<void>>();
+
+/** Resolves once the grammar for `language` is registered, so tokenizing can start synchronously. */
+export const loadLanguage = async (language: string) => {
+  const id = resolveLanguage(language);
+  const instance = await getHighlighter();
+  if (id !== PLAIN && !instance.getLoadedLanguages().includes(id)) {
+    let pending = loading.get(id);
+    if (!pending) {
+      pending = instance.loadLanguage(id).finally(() => loading.delete(id));
+      loading.set(id, pending);
+    }
+    await pending;
+  }
+  return { highlighter: instance, language: id };
+};

--- a/packages/agent-elements/src/markdown.tsx
+++ b/packages/agent-elements/src/markdown.tsx
@@ -34,7 +34,7 @@ const CodeBlock: Components["code"] = ({ children, className }) => {
   const language = /language-(\S+)/.exec(className ?? "")?.[1] ?? "text";
   const code = codeText(children).replace(/\n$/, "");
   return (
-    <Card className="my-4 gap-0 overflow-hidden p-0">
+    <Card className="my-4 gap-0 overflow-hidden p-0" variant="secondary">
       <div className="border-border flex h-9 items-center justify-between border-b px-3">
         <span className="text-muted font-mono text-xs lowercase">
           {language}

--- a/packages/agent-elements/src/markdown.tsx
+++ b/packages/agent-elements/src/markdown.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { AlertDialog, Button, Alert } from "@heroui/react";
+import { Children, isValidElement } from "react";
+
+import { Alert, AlertDialog, Button, Card } from "@heroui/react";
 import { cjk } from "@streamdown/cjk";
-import { code } from "@streamdown/code";
 import { ExternalLink } from "lucide-react";
 import { Streamdown } from "streamdown";
 import type { Components, LinkSafetyModalProps } from "streamdown";
@@ -11,18 +12,57 @@ import { markdownElements } from "@chia/contents/markdown-elements";
 import { CopyButton } from "@chia/ui/copy-button";
 import { cn } from "@chia/ui/utils/cn.util";
 
+import { HighlightedCode } from "./code-block.tsx";
 import { useAgentLabels } from "./provider.tsx";
+
+/** Streamdown hands the fence body as a string, or as a `<code>` element wrapping one. */
+const codeText = (children: React.ReactNode): string =>
+  Children.toArray(children)
+    .map((child) =>
+      isValidElement<{ children?: React.ReactNode }>(child)
+        ? child.props.children
+        : child
+    )
+    .join("");
+
+/**
+ * Fenced code as streamed by the model. Highlighting is incremental (see {@link HighlightedCode});
+ * the frame is a plain Card so a host can restyle it without touching the tokenizer.
+ */
+const CodeBlock: Components["code"] = ({ children, className }) => {
+  const labels = useAgentLabels();
+  const language = /language-(\S+)/.exec(className ?? "")?.[1] ?? "text";
+  const code = codeText(children).replace(/\n$/, "");
+  return (
+    <Card className="my-4 gap-0 overflow-hidden p-0">
+      <div className="border-border flex h-9 items-center justify-between border-b px-3">
+        <span className="text-muted font-mono text-xs lowercase">
+          {language}
+        </span>
+        <CopyButton
+          aria-label={labels.copy}
+          className="size-7 min-w-7"
+          content={code}
+          translations={{ copy: labels.copy, copied: labels.copied }}
+          variant="ghost"
+        />
+      </div>
+      <HighlightedCode className="p-3" code={code} language={language} />
+    </Card>
+  );
+};
 
 /**
  * Streamdown's defaults are styled with shadcn tokens (`bg-muted`, `text-muted-foreground`…).
  * HeroUI defines `muted` as a text colour, so those defaults come out as mid-grey slabs in both
  * schemes. Tables and emphasis come from the blog's shared elements so assistant prose reads like
  * an article; the rest restates the affected elements in HeroUI tokens. Everything not listed
- * (headings, lists, code blocks) keeps Streamdown's rendering. A host can layer its own on top
- * through `components`.
+ * (headings, lists) keeps Streamdown's rendering. A host can layer its own on top through
+ * `components`.
  */
 export const markdownComponents: Components = {
   ...markdownElements,
+  code: CodeBlock,
   inlineCode: ({ className, node: _node, ...props }) => (
     <code
       className={cn(
@@ -147,16 +187,11 @@ export const Markdown = ({
     components={
       components ? { ...markdownComponents, ...components } : markdownComponents
     }
-    controls={{
-      code: { copy: true, download: false },
-      table: false,
-      mermaid: false,
-    }}
+    controls={{ table: false, mermaid: false }}
     isAnimating={streaming}
     linkSafety={{ enabled: true, renderModal: renderLinkSafety }}
     mode={streaming ? "streaming" : "static"}
-    plugins={{ cjk, code }}
-    shikiTheme={["github-light", "github-dark"]}>
+    plugins={{ cjk }}>
     {text}
   </Streamdown>
 );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -285,9 +285,6 @@ catalogs:
     '@streamdown/cjk':
       specifier: 1.0.3
       version: 1.0.3
-    '@streamdown/code':
-      specifier: 1.1.1
-      version: 1.1.1
     streamdown:
       specifier: 2.5.0
       version: 2.5.0
@@ -340,6 +337,9 @@ catalogs:
       specifier: 4.1.11
       version: 4.1.11
   ui:
+    '@shikijs/stream':
+      specifier: ^4.4.3
+      version: 4.4.3
     border-beam:
       specifier: 1.3.0
       version: 1.3.0
@@ -403,8 +403,6 @@ catalogs:
 
 overrides:
   '@paradedb/drizzle-paradedb>drizzle-orm': 1.0.0-rc.4
-
-packageExtensionsChecksum: sha256-gb8IWRYa0HLC0njrFwOplLteblxDkJjrN7zLnxlfTj0=
 
 importers:
 
@@ -1143,12 +1141,12 @@ importers:
       '@orpc/contract':
         specifier: catalog:orpc
         version: 1.15.0(@opentelemetry/api@1.9.1)
+      '@shikijs/stream':
+        specifier: catalog:ui
+        version: 4.4.3(react@19.2.8)
       '@streamdown/cjk':
         specifier: catalog:streamdown
         version: 1.0.3(@types/mdast@4.0.4)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@10.2.2))(react@19.2.8)(supports-color@10.2.2)(unified@11.0.5)
-      '@streamdown/code':
-        specifier: catalog:streamdown
-        version: 1.1.1(react@19.2.8)
       '@tanstack/react-pacer':
         specifier: catalog:tanstack
         version: 0.23.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -1164,6 +1162,9 @@ importers:
       react:
         specifier: catalog:react-is
         version: 19.2.8
+      shiki:
+        specifier: catalog:ui
+        version: 4.4.3
       streamdown:
         specifier: catalog:streamdown
         version: 2.5.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@10.2.2)
@@ -5971,29 +5972,17 @@ packages:
     peerDependencies:
       webpack: '>=5.0.0'
 
-  '@shikijs/core@3.23.0':
-    resolution: {integrity: sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==}
-
   '@shikijs/core@4.4.3':
     resolution: {integrity: sha512-QCR4q2ZO/ILJEuwiBMel4wdcTDb1JGwfjKTxPDF6x8ixOaluPrVqIn06C99AcRPhmYlBR56d/Fb+GN58GzExpg==}
     engines: {node: '>=20'}
-
-  '@shikijs/engine-javascript@3.23.0':
-    resolution: {integrity: sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==}
 
   '@shikijs/engine-javascript@4.4.3':
     resolution: {integrity: sha512-FbOjFJp9VLdo1Wevs10BBtVxiTWwNLqZh5Gkhjgda/ioL15YOgeSl9n+6XMa3qRlPQzfhFNe641SrynFHYG0nQ==}
     engines: {node: '>=20'}
 
-  '@shikijs/engine-oniguruma@3.23.0':
-    resolution: {integrity: sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==}
-
   '@shikijs/engine-oniguruma@4.4.3':
     resolution: {integrity: sha512-EcOQkxdxGQrc1Row/cC2c96/v1dbZqGnEVu1qTuT/MJmp6+cXCvQussowVmCv5Tqr3KuY3c7IbM6HTW3LJ1k9w==}
     engines: {node: '>=20'}
-
-  '@shikijs/langs@3.23.0':
-    resolution: {integrity: sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==}
 
   '@shikijs/langs@4.4.3':
     resolution: {integrity: sha512-ePic0yfAJGOF83D5wBHK/00EjK65oahBYxFk5epgq33WRv7X9UuxLEV8PtR0szC0z8dl7INIpIodB99JRFlR+A==}
@@ -6003,15 +5992,27 @@ packages:
     resolution: {integrity: sha512-m0wBeLDQDeIxRdUmrCPdQqfuUamDwRL5isCfYbguKD6NiaKpVbsv+3J81DyIKgNW5h4WAIIr8T4EkgQrBBxvaQ==}
     engines: {node: '>=20'}
 
-  '@shikijs/themes@3.23.0':
-    resolution: {integrity: sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==}
+  '@shikijs/stream@4.4.3':
+    resolution: {integrity: sha512-nG30byPDdyua1R9danJjQjv60PlNHTi1q2O0tzW+ocAFqb63Y/5DK5URpbuGt0jEidpRNx3+OgJ+aEMUBWqRNA==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      react: ^19.0.0
+      solid-js: ^1.9.0
+      svelte: ^5.0.0-0
+      vue: ^3.2.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      solid-js:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
 
   '@shikijs/themes@4.4.3':
     resolution: {integrity: sha512-w8UHjeUnIR965KMWJHUPXOc2mNJUnK3vpVLYLvw5IYU2mnTTJ89E24OrJDBNiJDQ0qzb0tc4l7mrIXx5cFeIyw==}
     engines: {node: '>=20'}
-
-  '@shikijs/types@3.23.0':
-    resolution: {integrity: sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==}
 
   '@shikijs/types@4.4.3':
     resolution: {integrity: sha512-UEJxmRR++MAGR6hugn0vgVS2W/6lWAts84FFSrnlH9sP0LNol7E5+NQ792pH8liWUhyMyjhTgSUH3k7iD7tc5g==}
@@ -6114,11 +6115,6 @@ packages:
 
   '@streamdown/cjk@1.0.3':
     resolution: {integrity: sha512-WRg8HR/gHbBoTgsMd91OKFUClIoDcEFVofJvluvEAyjx3KpU0aGgD9tGDqHkHj14ShoMSkX0IYetWGegTcwIJw==}
-    peerDependencies:
-      react: ^18.0.0 || ^19.0.0
-
-  '@streamdown/code@1.1.1':
-    resolution: {integrity: sha512-i7HTNuDgZWb+VdrNVOam9gQhIc5MSSDXKWXgbUrn/4vSRaSMM+Rtl10MQj4wLWPNpF7p80waJsAqFP8HZfb0Jg==}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
 
@@ -12704,9 +12700,6 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shiki@3.23.0:
-    resolution: {integrity: sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==}
-
   shiki@4.4.3:
     resolution: {integrity: sha512-Mb/GvXPHBAXdgGIcnfU5L3ldpn1XcxrGkPHwqgRx17/I2XRfqlFKk2vGkHWINn1kdXvzJZeuO3is6I9KLPFm0g==}
     engines: {node: '>=20'}
@@ -17844,13 +17837,6 @@ snapshots:
       - rollup
       - supports-color
 
-  '@shikijs/core@3.23.0':
-    dependencies:
-      '@shikijs/types': 3.23.0
-      '@shikijs/vscode-textmate': 10.0.2
-      '@types/hast': 3.0.5
-      hast-util-to-html: 9.0.5
-
   '@shikijs/core@4.4.3':
     dependencies:
       '@shikijs/primitive': 4.4.3
@@ -17859,31 +17845,16 @@ snapshots:
       '@types/hast': 3.0.5
       hast-util-to-html: 9.0.5
 
-  '@shikijs/engine-javascript@3.23.0':
-    dependencies:
-      '@shikijs/types': 3.23.0
-      '@shikijs/vscode-textmate': 10.0.2
-      oniguruma-to-es: 4.3.6
-
   '@shikijs/engine-javascript@4.4.3':
     dependencies:
       '@shikijs/types': 4.4.3
       '@shikijs/vscode-textmate': 10.0.2
       oniguruma-to-es: 4.3.6
 
-  '@shikijs/engine-oniguruma@3.23.0':
-    dependencies:
-      '@shikijs/types': 3.23.0
-      '@shikijs/vscode-textmate': 10.0.2
-
   '@shikijs/engine-oniguruma@4.4.3':
     dependencies:
       '@shikijs/types': 4.4.3
       '@shikijs/vscode-textmate': 10.0.2
-
-  '@shikijs/langs@3.23.0':
-    dependencies:
-      '@shikijs/types': 3.23.0
 
   '@shikijs/langs@4.4.3':
     dependencies:
@@ -17895,18 +17866,15 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.5
 
-  '@shikijs/themes@3.23.0':
+  '@shikijs/stream@4.4.3(react@19.2.8)':
     dependencies:
-      '@shikijs/types': 3.23.0
+      '@shikijs/core': 4.4.3
+    optionalDependencies:
+      react: 19.2.8
 
   '@shikijs/themes@4.4.3':
     dependencies:
       '@shikijs/types': 4.4.3
-
-  '@shikijs/types@3.23.0':
-    dependencies:
-      '@shikijs/vscode-textmate': 10.0.2
-      '@types/hast': 3.0.5
 
   '@shikijs/types@4.4.3':
     dependencies:
@@ -18030,11 +17998,6 @@ snapshots:
       - micromark-util-types
       - supports-color
       - unified
-
-  '@streamdown/code@1.1.1(react@19.2.8)':
-    dependencies:
-      react: 19.2.8
-      shiki: 3.23.0
 
   '@sveltejs/load-config@0.2.3': {}
 
@@ -25321,17 +25284,6 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shiki@3.23.0:
-    dependencies:
-      '@shikijs/core': 3.23.0
-      '@shikijs/engine-javascript': 3.23.0
-      '@shikijs/engine-oniguruma': 3.23.0
-      '@shikijs/langs': 3.23.0
-      '@shikijs/themes': 3.23.0
-      '@shikijs/types': 3.23.0
-      '@shikijs/vscode-textmate': 10.0.2
-      '@types/hast': 3.0.5
-
   shiki@4.4.3:
     dependencies:
       '@shikijs/core': 4.4.3
@@ -25630,7 +25582,6 @@ snapshots:
       remark-parse: 11.0.0(supports-color@10.2.2)
       remark-rehype: 11.1.2
       remend: 1.3.0
-      shiki: 3.23.0
       tailwind-merge: 3.6.0
       unified: 11.0.5
       unist-util-visit: 5.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -49,7 +49,6 @@ catalog:
 catalogs:
   streamdown:
     "@streamdown/cjk": 1.0.3
-    "@streamdown/code": 1.1.1
     streamdown: 2.5.0
   agent:
     "@earendil-works/pi-agent-core": 0.84.3
@@ -163,6 +162,7 @@ catalogs:
     react-medium-image-zoom: ^5.4.9
     schema-dts: 2.0.0
     shiki: ^4.4.3
+    "@shikijs/stream": ^4.4.3
     sonner: 2.0.8
     tailwind-merge: ^3.6.0
     thinking-orbs: 0.3.1
@@ -204,9 +204,3 @@ strictPeerDependencies: false
 overrides:
   "@paradedb/drizzle-paradedb>drizzle-orm": 1.0.0-rc.4
 
-# streamdown's types import shiki but it only lists shiki as a devDependency; without this the
-# import resolves to whatever shiki is hoisted (v4 here) and no longer matches @streamdown/code's v3.
-packageExtensions:
-  streamdown:
-    dependencies:
-      shiki: ^3.19.0


### PR DESCRIPTION
## Summary
- New `@chia/agent-elements/code-block`: `StreamingHighlight` wraps `ShikiStreamTokenizer` and, on every update, feeds it only the text appended since the previous call — completed lines keep their tokens and grammar state, only the unfinished last line is re-tokenized. A non-append update (edited prefix, language change) restarts. `useStreamingTokens` / `HighlightedCode` expose this to React; `HighlightedCode` renders just the `<pre><code>` so the host owns the frame.
- New `@chia/agent-elements/highlighter`: one shiki v4 highlighter per app (JS regex engine, `forgiving`), bundled-language alias resolution, on-demand grammar loading with `text` as the fallback.
- `markdown.tsx` overrides Streamdown's `code` element with a thin HeroUI `Card` (language label + `CopyButton`) around `HighlightedCode`; `@streamdown/code`, `shikiTheme` and the code `controls` are gone. Inline code is unchanged.
- Dual themes: tokens carry `--shiki-light` / `--shiki-dark` and `color: light-dark(...)`; `.dark { color-scheme: dark }` in `@chia/themes` already flips it, so no theme hook is needed.
- Removes the `packageExtensions` pin of shiki v3 for `streamdown` — the repo is back on a single shiki major (v4, already in `catalog:ui`).

## Why
`@streamdown/code` re-runs `codeToTokens` on the whole block for every streamed chunk (O(n²) over a stream) and caches every intermediate `TokensResult` in a module-level `Map` keyed by length, which is never cleared.

## Test plan
- [x] `__tests__/code-block.test.ts` (6 cases): alias resolution, tokens always concatenate to the code seen so far while streaming char-by-char, completed lines are grammar-coloured with both theme vars, non-append input restarts, unknown languages stream as plain text
- [x] `pnpm turbo run lint type:check test` for `@chia/agent-elements` and `dash`
- [ ] `pnpm dev:dash`: ask the agent for a code block and watch it colour in while streaming, in both light and dark

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added syntax-highlighted code blocks for Markdown with light and dark theme support.
  - Code highlighting now updates smoothly as streamed content arrives.
  - Added language labels and copy controls within styled code cards.
  - Common language aliases are recognized automatically, with plain-text fallback for unsupported languages.

- **Bug Fixes**
  - Improved handling when streamed code changes or restarts, preventing stale highlighting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->