### PR TITLE
fix(agent): close tool calls that never got a result; stop reaches the web port

### DIFF
--- a/apps/service/src/agents/service.ts
+++ b/apps/service/src/agents/service.ts
@@ -33,7 +33,6 @@ import {
   deleteAgentSession,
   getActiveAgentRun,
   getAgentApprovals,
-  getAgentRun,
   getAgentSession,
   getAgentSessionLastSeq,
   patchAgentRunMetadata,
@@ -316,29 +315,43 @@ export const createAgentKindService = <TState>(
   };
 
   /**
-   * How long `abort` waits for the stopped turn to land before cancelling the run regardless. A
-   * tool that ignores its signal keeps Pi waiting on it; the cancel then proceeds and the tool's
-   * result, if it ever comes, is closed on replay as aborted.
+   * How long `abort` waits for the stopped turn's `run:end` before cancelling the run regardless.
+   * A tool that ignores its signal keeps Pi waiting on it; the cancel then proceeds and the
+   * tool's result, if it ever comes, is closed on replay as aborted.
    */
   const ABORT_SETTLE_TIMEOUT_MS = 10_000;
-  const ABORT_SETTLE_POLL_MS = 150;
 
   /**
-   * Waits for the turn step to clear its running marker after the abort signal reached it.
+   * Waits for the turn step to write the stopped turn's `run:end`.
    *
    * The signal stops Pi, but the step still has the partial reply and any in-flight tool result
-   * to persist and its stream to flush before it clears the marker; the client rebuilds the
-   * transcript the moment `abort` returns, so returning earlier would show it a turn that is
-   * still missing its last entries.
+   * to persist before the terminal event; the client rebuilds the transcript the moment `abort`
+   * returns, so returning earlier would show it a turn still missing its last entries. The turn's
+   * own durable stream is the wait: `runPiTurn` appends every entry before emitting its wire
+   * event, so `run:end` arriving means the transcript is complete.
    */
-  const waitForTurnEnd = async (db: DB, activeRunId: string): Promise<void> => {
-    const deadline = Date.now() + ABORT_SETTLE_TIMEOUT_MS;
-    while (Date.now() < deadline) {
-      const run = await getAgentRun(db, activeRunId);
-      if (!run || !readAgentTurnMarker(run.metadata)?.running) return;
-      await new Promise<void>((resolve) =>
-        setTimeout(resolve, ABORT_SETTLE_POLL_MS)
-      );
+  const waitForTurnEnd = async (
+    runId: string,
+    startIndex: number
+  ): Promise<void> => {
+    const reader = getRun(runId)
+      .getReadable<AgentWireEvent>({ startIndex })
+      .getReader();
+    // Cancelling settles the pending read as done; the loop then falls through.
+    const deadline = setTimeout(
+      () => void reader.cancel().catch(() => undefined),
+      ABORT_SETTLE_TIMEOUT_MS
+    );
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done || value?.type === "run:end") return;
+      }
+    } catch {
+      // A dropped stream has nothing more to tell; the cancel below proceeds as before.
+    } finally {
+      clearTimeout(deadline);
+      await reader.cancel().catch(() => undefined);
     }
   };
 
@@ -849,8 +862,8 @@ export const createAgentKindService = <TState>(
           row.abortController.id,
           "stopped by the operator"
         );
-        if (signalled && row.activeRunId && row.turn?.running) {
-          await waitForTurnEnd(caller.context.db, row.activeRunId);
+        if (signalled && row.turn?.running) {
+          await waitForTurnEnd(row.workflowRunId, row.turn.streamIndex);
         }
       }
       await cancelLiveRun(row.workflowRunId);

--- a/apps/service/src/agents/service.ts
+++ b/apps/service/src/agents/service.ts
@@ -33,6 +33,7 @@ import {
   deleteAgentSession,
   getActiveAgentRun,
   getAgentApprovals,
+  getAgentRun,
   getAgentSession,
   getAgentSessionLastSeq,
   patchAgentRunMetadata,
@@ -312,6 +313,33 @@ export const createAgentKindService = <TState>(
     await patchAgentRunMetadata(db, row.activeRunId, {
       [AGENT_TURN_KEY]: turn,
     });
+  };
+
+  /**
+   * How long `abort` waits for the stopped turn to land before cancelling the run regardless. A
+   * tool that ignores its signal keeps Pi waiting on it; the cancel then proceeds and the tool's
+   * result, if it ever comes, is closed on replay as aborted.
+   */
+  const ABORT_SETTLE_TIMEOUT_MS = 10_000;
+  const ABORT_SETTLE_POLL_MS = 150;
+
+  /**
+   * Waits for the turn step to clear its running marker after the abort signal reached it.
+   *
+   * The signal stops Pi, but the step still has the partial reply and any in-flight tool result
+   * to persist and its stream to flush before it clears the marker; the client rebuilds the
+   * transcript the moment `abort` returns, so returning earlier would show it a turn that is
+   * still missing its last entries.
+   */
+  const waitForTurnEnd = async (db: DB, activeRunId: string): Promise<void> => {
+    const deadline = Date.now() + ABORT_SETTLE_TIMEOUT_MS;
+    while (Date.now() < deadline) {
+      const run = await getAgentRun(db, activeRunId);
+      if (!run || !readAgentTurnMarker(run.metadata)?.running) return;
+      await new Promise<void>((resolve) =>
+        setTimeout(resolve, ABORT_SETTLE_POLL_MS)
+      );
+    }
   };
 
   /**
@@ -817,10 +845,13 @@ export const createAgentKindService = <TState>(
       // leaves a live run behind a non-active row (the next prompt would start a second workflow and
       // hit the hook conflict).
       if (row.abortController) {
-        await signalAgentAbort(
+        const signalled = await signalAgentAbort(
           row.abortController.id,
           "stopped by the operator"
         );
+        if (signalled && row.activeRunId && row.turn?.running) {
+          await waitForTurnEnd(caller.context.db, row.activeRunId);
+        }
       }
       await cancelLiveRun(row.workflowRunId);
       if (row.activeRunId) {

--- a/apps/service/src/services/agent-web.port.ts
+++ b/apps/service/src/services/agent-web.port.ts
@@ -1,5 +1,5 @@
 import { Firecrawl, SdkError } from "firecrawl";
-import type { Document, SearchResultWeb } from "firecrawl";
+import type { Document, SearchData, SearchResultWeb } from "firecrawl";
 
 import type {
   FetchedPage,
@@ -8,6 +8,7 @@ import type {
   WebSearchRecency,
   WebSearchResult,
 } from "@chia/agent-writing/ports";
+import { untilAborted } from "@chia/utils/request/abort";
 
 import { env } from "../env";
 
@@ -30,26 +31,6 @@ const TBS_BY_RECENCY = {
 } satisfies Record<WebSearchRecency, string>;
 
 const firecrawl = new Firecrawl({ apiKey: env.FIRECRAWL_API_KEY });
-
-/**
- * Rejects with the signal's reason the moment it fires. The SDK has no cancellation of its own,
- * so the request runs on to `REQUEST_TIMEOUT_MS` in the background; what matters is that the
- * tool returns to Pi at once, so a stopped turn can end instead of waiting on the page.
- */
-const untilAborted = <TValue>(
-  request: Promise<TValue>,
-  signal: AbortSignal | undefined
-): Promise<TValue> => {
-  if (!signal) return request;
-  if (signal.aborted) return Promise.reject(signal.reason);
-  return new Promise<TValue>((resolve, reject) => {
-    const onAbort = () => reject(signal.reason);
-    signal.addEventListener("abort", onAbort, { once: true });
-    void request.then(resolve, reject).finally(() => {
-      signal.removeEventListener("abort", onAbort);
-    });
-  });
-};
 
 /** The SDK message carries the provider's response body; the model needs the status only. */
 const toModelError = (operation: string, error: SdkError): Error =>
@@ -81,7 +62,7 @@ const search = async (
   input: WebSearchInput,
   signal?: AbortSignal
 ): Promise<WebSearchResult[]> => {
-  let data;
+  let data: SearchData;
   try {
     data = await untilAborted(
       firecrawl.search(input.query, {
@@ -107,7 +88,7 @@ const fetchPage = async (
   url: string,
   signal?: AbortSignal
 ): Promise<FetchedPage> => {
-  let document;
+  let document: Omit<Document, "json">;
   try {
     document = await untilAborted(
       firecrawl.scrape(url, {

--- a/apps/service/src/services/agent-web.port.ts
+++ b/apps/service/src/services/agent-web.port.ts
@@ -31,6 +31,26 @@ const TBS_BY_RECENCY = {
 
 const firecrawl = new Firecrawl({ apiKey: env.FIRECRAWL_API_KEY });
 
+/**
+ * Rejects with the signal's reason the moment it fires. The SDK has no cancellation of its own,
+ * so the request runs on to `REQUEST_TIMEOUT_MS` in the background; what matters is that the
+ * tool returns to Pi at once, so a stopped turn can end instead of waiting on the page.
+ */
+const untilAborted = <TValue>(
+  request: Promise<TValue>,
+  signal: AbortSignal | undefined
+): Promise<TValue> => {
+  if (!signal) return request;
+  if (signal.aborted) return Promise.reject(signal.reason);
+  return new Promise<TValue>((resolve, reject) => {
+    const onAbort = () => reject(signal.reason);
+    signal.addEventListener("abort", onAbort, { once: true });
+    void request.then(resolve, reject).finally(() => {
+      signal.removeEventListener("abort", onAbort);
+    });
+  });
+};
+
 /** The SDK message carries the provider's response body; the model needs the status only. */
 const toModelError = (operation: string, error: SdkError): Error =>
   new Error(
@@ -57,16 +77,22 @@ const toSearchResult = (
     : undefined;
 };
 
-const search = async (input: WebSearchInput): Promise<WebSearchResult[]> => {
+const search = async (
+  input: WebSearchInput,
+  signal?: AbortSignal
+): Promise<WebSearchResult[]> => {
   let data;
   try {
-    data = await firecrawl.search(input.query, {
-      limit: input.limit,
-      tbs: input.recency ? TBS_BY_RECENCY[input.recency] : undefined,
-      includeDomains: input.includeDomains,
-      sources: ["web"],
-      timeout: REQUEST_TIMEOUT_MS,
-    });
+    data = await untilAborted(
+      firecrawl.search(input.query, {
+        limit: input.limit,
+        tbs: input.recency ? TBS_BY_RECENCY[input.recency] : undefined,
+        includeDomains: input.includeDomains,
+        sources: ["web"],
+        timeout: REQUEST_TIMEOUT_MS,
+      }),
+      signal
+    );
   } catch (error) {
     throw error instanceof SdkError ? toModelError("Web search", error) : error;
   }
@@ -77,14 +103,20 @@ const search = async (input: WebSearchInput): Promise<WebSearchResult[]> => {
   });
 };
 
-const fetchPage = async (url: string): Promise<FetchedPage> => {
+const fetchPage = async (
+  url: string,
+  signal?: AbortSignal
+): Promise<FetchedPage> => {
   let document;
   try {
-    document = await firecrawl.scrape(url, {
-      formats: ["markdown"],
-      onlyMainContent: true,
-      timeout: REQUEST_TIMEOUT_MS,
-    });
+    document = await untilAborted(
+      firecrawl.scrape(url, {
+        formats: ["markdown"],
+        onlyMainContent: true,
+        timeout: REQUEST_TIMEOUT_MS,
+      }),
+      signal
+    );
   } catch (error) {
     throw error instanceof SdkError
       ? toModelError("Fetching the page", error)

--- a/docs/agent-architecture.md
+++ b/docs/agent-architecture.md
@@ -271,10 +271,11 @@ marks the `agent.run` row `cancelled`; `completeAgentRunStep` resumes it too, so
 not leave a controller parked until its TTL. Firing the signal aborts the run at once, mid-generation included: Pi cancels the
 in-flight provider stream, the partial reply is persisted as `aborted`, and the turn ends with
 `run:end{aborted}`; no approvals are persisted and no compaction runs. A tool already executing
-only receives the signal — Pi waits for it to return — so `abort` waits (bounded by
-`ABORT_SETTLE_TIMEOUT_MS`) for the step to clear its running marker before cancelling the run:
-the client rebuilds the transcript the moment `abort` returns, and the marker is cleared only
-after the stream and every entry of the stopped turn have landed. Delivery is the SDK's own
+only receives the signal — Pi waits for it to return — so `abort` tails the turn's own durable
+stream from the marker's `streamIndex` until `run:end` (bounded by `ABORT_SETTLE_TIMEOUT_MS`)
+before cancelling the run: the client rebuilds the transcript the moment `abort` returns, and
+every entry is appended before its wire event, so `run:end` means the stopped turn has landed
+whole. Delivery is the SDK's own
 durable stream, so it works from any process — no registry, no timer, no second channel. The next
 prompt starts a fresh session run over the persisted transcript. An expired controller (TTL) never
 aborts a turn; readers ignore `expired` and the next turn starts a new one.

--- a/docs/agent-architecture.md
+++ b/docs/agent-architecture.md
@@ -500,7 +500,10 @@ Destructive deletion and image upload are not available agent tools.
 `WebPort` is host-implemented on Firecrawl (`apps/service/src/services/agent-web.port.ts`,
 `FIRECRAWL_API_KEY`). Search returns snippets only — no per-result scrape — so a call has a
 fixed cost; `fetch_url` is one scrape per page, main content as markdown, and is how the model
-reads a source it chose. There is no direct outbound fetch in the agent path.
+reads a source it chose. There is no direct outbound fetch in the agent path. Both tools hand
+the turn's abort signal to the port; the Firecrawl SDK cannot cancel a request, so the port
+settles with the signal's reason at once and lets the request run out its timeout in the
+background — a stopped turn ends as soon as the signal fires instead of when the page arrives.
 
 ### Content visibility
 

--- a/docs/agent-architecture.md
+++ b/docs/agent-architecture.md
@@ -1,7 +1,7 @@
 # Agent Architecture & Turn Flow
 
 > Status: as-built
-> Last updated: 2026-08-24
+> Last updated: 2026-08-26
 > 中文版：[docs/agent-architecture.zh.md](./agent-architecture.zh.md)
 > Related: [docs/rag-architecture.md](./rag-architecture.md)
 
@@ -270,7 +270,11 @@ subscription when the turn ends. `abort` resumes the hook first, then cancels th
 marks the `agent.run` row `cancelled`; `completeAgentRunStep` resumes it too, so a finished run does
 not leave a controller parked until its TTL. Firing the signal aborts the run at once, mid-generation included: Pi cancels the
 in-flight provider stream, the partial reply is persisted as `aborted`, and the turn ends with
-`run:end{aborted}`; no approvals are persisted and no compaction runs. Delivery is the SDK's own
+`run:end{aborted}`; no approvals are persisted and no compaction runs. A tool already executing
+only receives the signal — Pi waits for it to return — so `abort` waits (bounded by
+`ABORT_SETTLE_TIMEOUT_MS`) for the step to clear its running marker before cancelling the run:
+the client rebuilds the transcript the moment `abort` returns, and the marker is cleared only
+after the stream and every entry of the stopped turn have landed. Delivery is the SDK's own
 durable stream, so it works from any process — no registry, no timer, no second channel. The next
 prompt starts a fresh session run over the persisted transcript. An expired controller (TTL) never
 aborts a turn; readers ignore `expired` and the next turn starts a new one.
@@ -354,6 +358,14 @@ session:compacted · session:rewound · state:changed · error · run:end
   message with `stopReason: "error"` replays as the same `error` event the live turn emitted;
   a `branch_summary` entry replays as `session:rewound`, so a rewind that kept a summary stays
   visible where it happened.
+- A tool call is only ever `running` between its `tool:start` and `tool:end`, and both sides
+  guarantee the end arrives. Pi persists a call's result right after the assistant message that
+  issued it, so replay closes any call whose result is not the next thing on the branch — a turn
+  stopped mid-execution, a process that died, a fork cut at the assistant message — with
+  `tool:end{aborted}`, and skips the calls of a message that ended `error` or `aborted`, which
+  Pi never executed and the live turn never showed. `run:end` closes whatever the live turn left
+  running the same way. `aborted` is its own status, not `isError`: the tool did not fail, it
+  never finished.
 - `error` carries a `kind` (`auth · quota · rate_limited · context_overflow · budget_exhausted ·
 provider · internal`) so a client can say what to do next; `describeAgentError` is the shared headline.
 - `tool:end.details` is clipped by `clipDetails` before it reaches the wire — long strings, arrays,

--- a/docs/agent-architecture.zh.md
+++ b/docs/agent-architecture.zh.md
@@ -249,9 +249,10 @@ Workflow SDK 沒有任何東西能碰到已經在執行的 step——取消 run 
 `completeAgentRunStep` 也會 resume 它，讓跑完的 run 不會留下一個停到 TTL 的 controller。Signal 一
 觸發 run 立刻中止，生成到一半也一樣：Pi 取消進行中的 provider stream，部分回覆以 `aborted`
 持久化，turn 以 `run:end{aborted}` 結束；不持久化 approval，也不 compaction。已經在執行的 tool
-只會收到 signal——Pi 會等它返回——所以 `abort` 會先等（上限 `ABORT_SETTLE_TIMEOUT_MS`）step 清掉
-running marker 才取消 run：client 在 `abort` 回來的瞬間就重建 transcript，而 marker 是在被中止的
-turn 的 stream 與每一筆 entry 都落地之後才清的。送達走的是 SDK 自
+只會收到 signal——Pi 會等它返回——所以 `abort` 會先從 marker 的 `streamIndex` tail 這個 turn 自己
+的 durable stream 直到 `run:end`（上限 `ABORT_SETTLE_TIMEOUT_MS`）才取消 run：client 在 `abort` 回
+來的瞬間就重建 transcript，而每一筆 entry 都是先 append 再發 wire event，所以讀到 `run:end` 就代表
+被中止的 turn 已完整落地。送達走的是 SDK 自
 己的 durable stream，所以跨 process 也成立——沒有 registry、沒有 timer、沒有第二條 channel。下一
 次 prompt 會在持久化的 transcript 上開新 session run。過期（TTL）的 controller 不會中止任何 turn；
 reader 忽略 `expired`，下一個 turn 會建新的。

--- a/docs/agent-architecture.zh.md
+++ b/docs/agent-architecture.zh.md
@@ -443,7 +443,9 @@ buffer；只有 commit-tier tool 會把 staged data 提升到正式 feed/content
 開放給 agent。`WebPort` 由 host 用 Firecrawl 實作（`apps/service/src/services/agent-web.port.ts`、
 `FIRECRAWL_API_KEY`）：search 只回 snippet、不逐筆 scrape，所以每次呼叫成本固定；`fetch_url`
 是一頁一次 scrape、回主要內容的 markdown，模型要讀哪一頁自己決定。Agent 路徑上沒有直接對外的
-fetch。`buildSystemPrompt` 是穩定的
+fetch。兩個 tool 都把 turn 的 abort signal 交給 port；Firecrawl SDK 無法取消 request，所以 port
+在 signal 一觸發就以它的 reason settle、讓 request 在背景跑到 timeout——被中止的 turn 在 signal
+觸發時就結束，而不是等頁面回來。`buildSystemPrompt` 是穩定的
 system prompt，`buildTurnContext` 是帶 draft 狀態與目前時間的 volatile block（見 §4）；skills
 與 templates 位於 `packages/agent-writing/src/prompts/`。
 

--- a/docs/agent-architecture.zh.md
+++ b/docs/agent-architecture.zh.md
@@ -1,7 +1,7 @@
 # Agent 架構與 Turn 流程
 
 > 狀態：as-built
-> 最後更新：2026-08-24
+> 最後更新：2026-08-26
 > English: [docs/agent-architecture.md](./agent-architecture.md)
 > 相關文件：[docs/rag-architecture.md](./rag-architecture.md)
 
@@ -248,7 +248,10 @@ Workflow SDK 沒有任何東西能碰到已經在執行的 step——取消 run 
 `abort` 先 resume 這個 hook，再取消 session run、把 `agent.run` 列標成 `cancelled`；
 `completeAgentRunStep` 也會 resume 它，讓跑完的 run 不會留下一個停到 TTL 的 controller。Signal 一
 觸發 run 立刻中止，生成到一半也一樣：Pi 取消進行中的 provider stream，部分回覆以 `aborted`
-持久化，turn 以 `run:end{aborted}` 結束；不持久化 approval，也不 compaction。送達走的是 SDK 自
+持久化，turn 以 `run:end{aborted}` 結束；不持久化 approval，也不 compaction。已經在執行的 tool
+只會收到 signal——Pi 會等它返回——所以 `abort` 會先等（上限 `ABORT_SETTLE_TIMEOUT_MS`）step 清掉
+running marker 才取消 run：client 在 `abort` 回來的瞬間就重建 transcript，而 marker 是在被中止的
+turn 的 stream 與每一筆 entry 都落地之後才清的。送達走的是 SDK 自
 己的 durable stream，所以跨 process 也成立——沒有 registry、沒有 timer、沒有第二條 channel。下一
 次 prompt 會在持久化的 transcript 上開新 session run。過期（TTL）的 controller 不會中止任何 turn；
 reader 忽略 `expired`，下一個 turn 會建新的。
@@ -314,6 +317,12 @@ session:compacted · session:rewound · state:changed · error · run:end
 - `entriesToWireEvents`：persisted Pi entries → replay history。`stopReason: "error"` 的持久化
   assistant message 會 replay 成與 live turn 相同的 `error` event；`branch_summary` entry 會
   replay 成 `session:rewound`，所以帶摘要的 rewind 會留在它發生的位置。
+- Tool call 只在 `tool:start` 與 `tool:end` 之間是 `running`，而兩邊都保證 end 一定會到。Pi 把
+  call 的結果緊接在發出它的 assistant message 之後持久化，所以 replay 遇到結果不是 branch 上下一
+  筆的 call——turn 在執行中被中止、process 死掉、fork 切在 assistant message 上——就以
+  `tool:end{aborted}` 收掉；`error` 或 `aborted` 收尾的 message 裡的 call 則直接略過，Pi 從沒執行
+  它們，live turn 也沒顯示過。`run:end` 對 live turn 留下的 running call 做同樣的事。`aborted` 是
+  獨立的狀態而不是 `isError`：tool 沒有失敗，它只是沒跑完。
 - `error` 帶 `kind`（`auth · quota · rate_limited · context_overflow · budget_exhausted · provider ·
 internal`），
   讓 client 能提示下一步；`describeAgentError` 是共用的 headline。

--- a/packages/agent-elements/src/tool-call.tsx
+++ b/packages/agent-elements/src/tool-call.tsx
@@ -3,7 +3,7 @@
 import type { ComponentType } from "react";
 
 import { Chip, Disclosure } from "@heroui/react";
-import { Check, CircleX, LoaderCircle, ShieldAlert } from "lucide-react";
+import { Ban, Check, CircleX, LoaderCircle, ShieldAlert } from "lucide-react";
 import { ThinkingOrb } from "thinking-orbs";
 
 import type { ToolCallView } from "@chia/agent-runtime/wire/fold";
@@ -33,11 +33,12 @@ const statusMeta = {
   running: { color: "accent", icon: LoaderCircle, spin: true },
   ok: { color: "success", icon: Check, spin: false },
   error: { color: "danger", icon: CircleX, spin: false },
+  aborted: { color: "default", icon: Ban, spin: false },
   awaiting_approval: { color: "warning", icon: ShieldAlert, spin: false },
 } as const satisfies Record<
   ToolCallView["status"],
   {
-    color: "accent" | "danger" | "success" | "warning";
+    color: "accent" | "danger" | "default" | "success" | "warning";
     icon: ComponentType<{ className?: string }>;
     spin: boolean;
   }
@@ -50,6 +51,7 @@ export const ToolStatusChip = ({ tool }: { tool: ToolCallView }) => {
     running: labels.toolRunning,
     ok: labels.toolDone,
     error: labels.toolFailed,
+    aborted: labels.toolAborted,
     awaiting_approval: labels.toolAwaitingApproval,
   }[tool.status];
   return (
@@ -109,6 +111,8 @@ export const ToolCall = ({ className, renderers, tool }: ToolCallProps) => {
               />
             ) : tool.status === "ok" ? (
               <Check className="text-success size-3.5" />
+            ) : tool.status === "aborted" ? (
+              <Ban className="text-muted size-3.5" />
             ) : (
               <CircleX className="text-danger size-3.5" />
             )}

--- a/packages/agent-runtime/__tests__/events.test.ts
+++ b/packages/agent-runtime/__tests__/events.test.ts
@@ -12,6 +12,28 @@ import type { AgentWireEvent } from "../src/wire/schema.ts";
  * than usual: any divergence shows up as a UI that renders differently after a refresh.
  */
 
+const presentation = {
+  tierOf: () => "read",
+  labelOf: (name: string) => name,
+  summarize: () => "",
+};
+
+const assistantWithCall = (
+  id: string,
+  parentId: string | null,
+  stopReason: "toolUse" | "aborted"
+): SessionEntry => ({
+  type: "message",
+  id,
+  parentId,
+  seq: 1,
+  timestamp: 1,
+  message: fauxAssistantMessage(
+    [{ type: "toolCall", id: "call-1", name: "get_post", arguments: {} }],
+    { stopReason, timestamp: 1 }
+  ),
+});
+
 describe("foldEvents", () => {
   it("carries an arbitrary tier through, not just the writing agent's three", () => {
     const state = foldEvents([
@@ -139,12 +161,6 @@ describe("foldEvents", () => {
         message: fauxAssistantMessage("Second", { timestamp: 2 }),
       },
     ];
-    const presentation = {
-      tierOf: () => "read",
-      labelOf: (name: string) => name,
-      summarize: () => "",
-    };
-
     const all = entriesToWireEvents(entries, presentation).filter(
       (event) => event.type === "assistant:end"
     );
@@ -231,6 +247,56 @@ describe("foldEvents", () => {
       code: "rate_limited",
       text: "429 Too Many Requests",
     });
+  });
+
+  it("closes a call whose result never landed as aborted on replay", () => {
+    const events = entriesToWireEvents(
+      [
+        assistantWithCall("a1", null, "toolUse"),
+        {
+          type: "message",
+          id: "u2",
+          parentId: "a1",
+          seq: 2,
+          timestamp: 2,
+          message: { role: "user", content: "again", timestamp: 2 },
+        },
+      ],
+      presentation
+    );
+    expect(events.map((event) => event.type)).toEqual([
+      "assistant:end",
+      "tool:start",
+      "tool:end",
+      "user",
+    ]);
+    expect(events[2]).toMatchObject({
+      toolCallId: "call-1",
+      isError: true,
+      aborted: true,
+    });
+    const tool = foldEvents(events).items.find((item) => item.kind === "tool");
+    expect(tool).toMatchObject({ status: "aborted" });
+  });
+
+  it("closes a call cut off at the end of the branch, as a fork at the message leaves it", () => {
+    const events = entriesToWireEvents(
+      [assistantWithCall("a1", null, "toolUse")],
+      presentation
+    );
+    expect(events.map((event) => event.type)).toEqual([
+      "assistant:end",
+      "tool:start",
+      "tool:end",
+    ]);
+  });
+
+  it("shows no card for calls in a message the stop cut short, as the live turn did not", () => {
+    const events = entriesToWireEvents(
+      [assistantWithCall("a1", null, "aborted")],
+      presentation
+    );
+    expect(events.map((event) => event.type)).toEqual(["assistant:end"]);
   });
 
   it("clips oversized tool details on replay while keeping their shape", () => {

--- a/packages/agent-runtime/__tests__/events.test.ts
+++ b/packages/agent-runtime/__tests__/events.test.ts
@@ -272,7 +272,7 @@ describe("foldEvents", () => {
     ]);
     expect(events[2]).toMatchObject({
       toolCallId: "call-1",
-      isError: true,
+      isError: false,
       aborted: true,
     });
     const tool = foldEvents(events).items.find((item) => item.kind === "tool");

--- a/packages/agent-runtime/__tests__/fold.test.ts
+++ b/packages/agent-runtime/__tests__/fold.test.ts
@@ -103,3 +103,30 @@ describe("approval fold", () => {
     expect(view.runStatus).toBe("error");
   });
 });
+
+describe("stopped turns", () => {
+  it("closes a call still running when the turn ends without its result", () => {
+    const { view, tool } = toolOf([
+      { type: "run:start", sessionId: "s" },
+      toolStart,
+      { type: "run:end", reason: "aborted" },
+    ]);
+    expect(tool.status).toBe("aborted");
+    expect(view.runStatus).toBe("idle");
+  });
+
+  it("renders a replayed aborted result as stopped, not failed", () => {
+    const { tool } = toolOf([
+      toolStart,
+      {
+        type: "tool:end",
+        toolCallId: "call-1",
+        toolName: "commit_draft",
+        isError: true,
+        aborted: true,
+        summary: "",
+      },
+    ]);
+    expect(tool.status).toBe("aborted");
+  });
+});

--- a/packages/agent-runtime/__tests__/fold.test.ts
+++ b/packages/agent-runtime/__tests__/fold.test.ts
@@ -122,7 +122,7 @@ describe("stopped turns", () => {
         type: "tool:end",
         toolCallId: "call-1",
         toolName: "commit_draft",
-        isError: true,
+        isError: false,
         aborted: true,
         summary: "",
       },

--- a/packages/agent-runtime/src/wire/fold.ts
+++ b/packages/agent-runtime/src/wire/fold.ts
@@ -13,7 +13,7 @@ export interface ToolCallView {
   label: string;
   tier: ToolTier;
   args: unknown;
-  status: "running" | "ok" | "error" | "awaiting_approval";
+  status: "running" | "ok" | "error" | "aborted" | "awaiting_approval";
   summary?: string;
   details?: unknown;
   approval?: { approved: boolean; comment?: string };
@@ -201,9 +201,11 @@ export const applyEvent = (
         }),
         status: blockedPendingApproval
           ? "awaiting_approval"
-          : event.isError
-            ? "error"
-            : "ok",
+          : event.aborted
+            ? "aborted"
+            : event.isError
+              ? "error"
+              : "ok",
         summary: blockedPendingApproval ? existing.summary : event.summary,
         details: blockedPendingApproval ? existing.details : event.details,
       };
@@ -313,13 +315,18 @@ export const applyEvent = (
       }
       // `approval:request` is announced as soon as the gate refuses, before the turn has proven it
       // can persist the request. A turn that then ends any other way has nothing for the operator
-      // to decide — drop the prompts rather than leave cards nobody can act on.
+      // to decide — drop the prompts rather than leave cards nobody can act on. A call still
+      // running has no `tool:end` coming either: the turn is over, so it was stopped.
       return {
         ...state,
         items: items.map((item) =>
-          item.kind === "tool" && item.status === "awaiting_approval"
-            ? { ...item, status: "error" }
-            : item
+          item.kind !== "tool"
+            ? item
+            : item.status === "awaiting_approval"
+              ? { ...item, status: "error" }
+              : item.status === "running"
+                ? { ...item, status: "aborted" }
+                : item
         ),
         pendingApprovals: [],
         runStatus: event.reason === "error" ? "error" : "idle",

--- a/packages/agent-runtime/src/wire/replay.ts
+++ b/packages/agent-runtime/src/wire/replay.ts
@@ -38,7 +38,7 @@ export const entriesToWireEvents = (
         type: "tool:end",
         toolCallId,
         toolName,
-        isError: true,
+        isError: false,
         aborted: true,
         summary: "",
       });

--- a/packages/agent-runtime/src/wire/replay.ts
+++ b/packages/agent-runtime/src/wire/replay.ts
@@ -19,14 +19,37 @@ import type { AgentWireEvent } from "./schema.ts";
  *
  * A message's wire id is its entry id, live and replayed alike, so a client can name the entry
  * behind any message it shows — which is what rewind and fork targets are.
+ *
+ * Pi appends a call's result right after the assistant message that issued it, so a call whose
+ * result is not the next thing on the branch never got one — the turn was stopped mid-execution,
+ * the process died, or a fork cut the branch at the assistant message. Those are closed as
+ * `aborted` here, because a `tool:start` with no end would read as still running forever.
  */
 export const entriesToWireEvents = (
   entries: readonly SessionEntry[],
   options: AgentEventPresentation
 ): AgentWireEvent[] => {
   const events: AgentWireEvent[] = [];
+  /** Calls from the last assistant message whose results have not arrived yet. */
+  let open = new Map<string, string>();
+  const closeOpen = () => {
+    for (const [toolCallId, toolName] of open) {
+      events.push({
+        type: "tool:end",
+        toolCallId,
+        toolName,
+        isError: true,
+        aborted: true,
+        summary: "",
+      });
+    }
+    open = new Map();
+  };
 
   for (const entry of entries) {
+    if (entry.type !== "message" || entry.message.role !== "toolResult") {
+      closeOpen();
+    }
     if (entry.type === "compaction") {
       events.push({
         type: "session:compacted",
@@ -87,9 +110,15 @@ export const entriesToWireEvents = (
       if (message.stopReason === "error") {
         events.push({ type: "error", ...errorOfAssistantMessage(message) });
       }
+      // Pi never executes the calls of a message that ended in `error` or `aborted`, and the live
+      // turn showed no card for them; replay matches, or a stop mid-generation grows cards on reload.
+      if (message.stopReason === "error" || message.stopReason === "aborted") {
+        continue;
+      }
 
       for (const part of message.content) {
         if (part.type !== "toolCall") continue;
+        open.set(part.id, part.name);
         events.push({
           type: "tool:start",
           toolCallId: part.id,
@@ -103,6 +132,7 @@ export const entriesToWireEvents = (
     }
 
     if (message.role === "toolResult") {
+      open.delete(message.toolCallId);
       events.push({
         type: "tool:end",
         toolCallId: message.toolCallId,
@@ -113,6 +143,7 @@ export const entriesToWireEvents = (
       });
     }
   }
+  closeOpen();
 
   return events;
 };

--- a/packages/agent-runtime/src/wire/schema.ts
+++ b/packages/agent-runtime/src/wire/schema.ts
@@ -74,6 +74,12 @@ export const agentWireEventSchema = z.discriminatedUnion("type", [
     toolCallId: z.string(),
     toolName: z.string(),
     isError: z.boolean(),
+    /**
+     * The call never produced a result: the turn was stopped, the process died, or a fork cut
+     * the branch between the call and its result. Distinct from `isError`, which is the tool
+     * itself failing — the model sees an empty result for these, so the client says "stopped".
+     */
+    aborted: z.literal(true).optional(),
     summary: z.string(),
     /** Per-tool view model. Shape is the tool's `details`, narrowed by the tool itself. */
     details: z.unknown().optional(),

--- a/packages/agent-writing/__tests__/fixtures.ts
+++ b/packages/agent-writing/__tests__/fixtures.ts
@@ -76,6 +76,8 @@ export interface FakeWebPortOptions {
 
 export interface FakeWebPort extends WebPort {
   readonly searches: WebSearchInput[];
+  /** The signal each call received, search and fetch alike, in call order. */
+  readonly signals: (AbortSignal | undefined)[];
   /** What every `search` returns; mutable so a test can script it after construction. */
   readonly results: WebSearchResult[];
 }
@@ -84,18 +86,23 @@ export const createFakeWebPort = (
   options: FakeWebPortOptions = {}
 ): FakeWebPort => {
   const searches: WebSearchInput[] = [];
+  const signals: (AbortSignal | undefined)[] = [];
   const results: WebSearchResult[] = options.results ?? [];
 
   return {
     searches,
+    signals,
     results,
-    search: (input) => {
+    search: (input, signal) => {
       searches.push(input);
+      signals.push(signal);
       return Promise.resolve([...results]);
     },
-    fetchPage: (url) =>
-      Promise.resolve(
+    fetchPage: (url, signal) => {
+      signals.push(signal);
+      return Promise.resolve(
         options.pages?.[url] ?? { url, title: "Untitled", text: "" }
-      ),
+      );
+    },
   };
 };

--- a/packages/agent-writing/__tests__/tools.test.ts
+++ b/packages/agent-writing/__tests__/tools.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { InMemoryDraftStore } from "../src/draft/memory-draft-store.ts";
 import { commitDraftTool } from "../src/tools/commit.tool.ts";
 import { patchDraftMetaTool } from "../src/tools/draft.tool.ts";
-import { webSearchTool } from "../src/tools/retrieval.tool.ts";
+import { fetchUrlTool, webSearchTool } from "../src/tools/retrieval.tool.ts";
 import { createWritingTools } from "../src/tools/tool-set.ts";
 import type { WritingToolContext } from "../src/types.ts";
 
@@ -25,6 +25,28 @@ const createContext = (): TestContext => ({
 });
 
 describe("webSearchTool", () => {
+  it("hands the turn's abort signal to the port, so a stop reaches the request", async () => {
+    const context = createContext();
+    const controller = new AbortController();
+
+    await webSearchTool.execute(
+      "call-1",
+      { query: "embeddings guide" },
+      controller.signal,
+      undefined,
+      context
+    );
+    await fetchUrlTool.execute(
+      "call-2",
+      { url: "https://example.com/" },
+      controller.signal,
+      undefined,
+      context
+    );
+
+    expect(context.web.signals).toEqual([controller.signal, controller.signal]);
+  });
+
   it("normalizes and forwards bare include domains", async () => {
     const context = createContext();
 

--- a/packages/agent-writing/src/ports.ts
+++ b/packages/agent-writing/src/ports.ts
@@ -66,8 +66,11 @@ export interface ContentPort extends ContentReadPort {
  * builds one.
  */
 export interface WebPort {
-  search(input: WebSearchInput): Promise<WebSearchResult[]>;
-  fetchPage(url: string): Promise<FetchedPage>;
+  search(
+    input: WebSearchInput,
+    signal?: AbortSignal
+  ): Promise<WebSearchResult[]>;
+  fetchPage(url: string, signal?: AbortSignal): Promise<FetchedPage>;
 }
 
 // ============================================

--- a/packages/agent-writing/src/tools/retrieval.tool.ts
+++ b/packages/agent-writing/src/tools/retrieval.tool.ts
@@ -79,14 +79,17 @@ export const webSearchTool = defineTool({
     ),
   }),
   executionMode: "parallel",
-  async execute(_toolCallId, params, _signal, _onUpdate, context) {
+  async execute(_toolCallId, params, signal, _onUpdate, context) {
     const includeDomains = params.includeDomains?.map(normalizeSearchDomain);
-    const results = await context.web.search({
-      query: params.query,
-      limit: params.limit ?? DEFAULT_SEARCH_RESULTS,
-      recency: params.recency,
-      includeDomains,
-    });
+    const results = await context.web.search(
+      {
+        query: params.query,
+        limit: params.limit ?? DEFAULT_SEARCH_RESULTS,
+        recency: params.recency,
+        includeDomains,
+      },
+      signal
+    );
 
     return textResult(
       results.length === 0
@@ -125,7 +128,7 @@ export const fetchUrlTool = defineTool({
     }),
   }),
   executionMode: "parallel",
-  async execute(_toolCallId, params, _signal, _onUpdate, context) {
+  async execute(_toolCallId, params, signal, _onUpdate, context) {
     let parsed: URL;
     try {
       parsed = new URL(params.url);
@@ -136,7 +139,7 @@ export const fetchUrlTool = defineTool({
       throw new Error("Only http and https URLs can be fetched.");
     }
 
-    const page = await context.web.fetchPage(parsed.toString());
+    const page = await context.web.fetchPage(parsed.toString(), signal);
     const body = truncate(page.text, MAX_PAGE_CHARS);
 
     return textResult(

--- a/packages/db/src/libs/agent/index.ts
+++ b/packages/db/src/libs/agent/index.ts
@@ -207,10 +207,6 @@ export const createAgentRun = async (
     return row;
   });
 
-/** By the row's own id — the one the turn step's marker writes are addressed to. */
-export const getAgentRun = async (db: DB, runId: string) =>
-  await db.query.agentRuns.findFirst({ where: { id: runId } });
-
 export const getActiveAgentRun = async (db: DB, sessionId: string) =>
   await db.query.agentRuns.findFirst({
     where: { sessionId, status: "active" },

--- a/packages/db/src/libs/agent/index.ts
+++ b/packages/db/src/libs/agent/index.ts
@@ -207,6 +207,10 @@ export const createAgentRun = async (
     return row;
   });
 
+/** By the row's own id — the one the turn step's marker writes are addressed to. */
+export const getAgentRun = async (db: DB, runId: string) =>
+  await db.query.agentRuns.findFirst({ where: { id: runId } });
+
 export const getActiveAgentRun = async (db: DB, sessionId: string) =>
   await db.query.agentRuns.findFirst({
     where: { sessionId, status: "active" },

--- a/packages/i18n/agent-elements/en-US.json
+++ b/packages/i18n/agent-elements/en-US.json
@@ -29,6 +29,7 @@
   "toolRunning": "Running…",
   "toolDone": "Done",
   "toolFailed": "Failed",
+  "toolAborted": "Stopped",
   "toolAwaitingApproval": "Waiting for approval",
   "arguments": "Arguments",
   "result": "Result",

--- a/packages/i18n/agent-elements/zh-TW.json
+++ b/packages/i18n/agent-elements/zh-TW.json
@@ -29,6 +29,7 @@
   "toolRunning": "執行中…",
   "toolDone": "完成",
   "toolFailed": "失敗",
+  "toolAborted": "已中止",
   "toolAwaitingApproval": "等待授權",
   "arguments": "參數",
   "result": "結果",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -49,6 +49,10 @@
       "types": "./src/request/index.ts",
       "default": "./src/request/index.ts"
     },
+    "./request/abort": {
+      "types": "./src/request/abort.ts",
+      "default": "./src/request/abort.ts"
+    },
     "./server": {
       "types": "./src/server/index.ts",
       "default": "./src/server/index.ts"

--- a/packages/utils/src/request/abort.ts
+++ b/packages/utils/src/request/abort.ts
@@ -1,0 +1,14 @@
+export const untilAborted = <TValue>(
+  request: Promise<TValue>,
+  signal: AbortSignal | undefined
+): Promise<TValue> => {
+  if (!signal) return request;
+  if (signal.aborted) return Promise.reject(signal.reason);
+  return new Promise<TValue>((resolve, reject) => {
+    const onAbort = () => reject(signal.reason);
+    signal.addEventListener("abort", onAbort, { once: true });
+    void request.then(resolve, reject).finally(() => {
+      signal.removeEventListener("abort", onAbort);
+    });
+  });
+};


### PR DESCRIPTION
## Problem

A tool card is only ever "running" between `tool:start` and `tool:end`, but nothing guaranteed the end arrives:

- **Replay** (`entriesToWireEvents`) emitted `tool:start` for every `toolCall` part and `tool:end` only from a `toolResult` entry. A turn stopped mid-execution, a process that died, or a **fork cut at an assistant message** (its results sit below the target and are not copied) left the card spinning forever on reload and in the fork.
- A message that ended `aborted` still replayed its `tool:start`s even though Pi never executed them and the live turn showed no card — so a stop mid-generation *grew* stuck cards on reload.
- `run:end` did not close still-running cards on the live side.
- `abort` returned before the stopped turn had persisted its last entries; the client rebuilds the transcript on success, so it raced them.
- Every writing tool ignored its `signal`, so a stop during `fetch_url` / `web_search` waited on Firecrawl.

## Changes

**Wire (`@chia/agent-runtime`)**
- `tool:end` gains `aborted: true`; `ToolCallView.status` gains `"aborted"` — stopped, not failed (the model sees an empty result for these).
- Replay closes any call whose result is not the next thing on the branch with `tool:end{aborted}`, and skips the calls of a message that ended `error`/`aborted`, matching the live turn.
- `run:end` closes whatever the live turn left running.

**Host (`apps/service`)**
- `abort` tails the turn's own durable stream from the marker's `streamIndex` until `run:end` (bounded by `ABORT_SETTLE_TIMEOUT_MS`, 10s) before cancelling the run. Every entry is appended before its wire event, so `run:end` means the transcript is whole. No DB polling.
- `WebPort.search` / `fetchPage` take the turn's `AbortSignal`; the Firecrawl port settles with the signal's reason at once (the SDK cannot cancel a request, so it runs out its timeout in the background). The 10s bound now only matters if the stream drops.

**Client (`@chia/agent-elements`)**
- `aborted` status on the tool card (`Ban` icon, muted) with `toolAborted` in both catalogs.

**Docs** — `agent-architecture.md` / `.zh.md`: Abort, wire-event and `WebPort` sections.

## Verification

- New tests: replay orphan closing, fork cut at the message, aborted message shows no card, `run:end` closes running, aborted status rendering, web tools forward the signal.
- `agent-runtime` 136/136, `agent-elements` 43/43, `agent-writing` 48/48.
- `type:check` clean for `agent-elements`, `agent-writing`, `service`, `db`. `agent-runtime` has two pre-existing errors in `__tests__/pg-storage.test.ts` (present on `develop`, unrelated).
- oxlint / oxfmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer handling for stopped or interrupted tool calls, including a localized “Stopped” status.
  - Web searches and page retrievals now respond promptly when a run is cancelled.
- **Bug Fixes**
  - Improved cancellation reliability by allowing active turns and generated content to settle before termination.
  - Transcript replay now correctly handles incomplete, skipped, or interrupted tool calls without displaying misleading results.
- **Documentation**
  - Updated architecture documentation to describe cancellation, replay, and web-request behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->