### PR TITLE
feat: bump oRPC to `v2-beta`

### DIFF
--- a/apps/dash/src/components/projects/api-key-table.tsx
+++ b/apps/dash/src/components/projects/api-key-table.tsx
@@ -113,13 +113,8 @@ const CreateForm = (props: { projectId?: number; onSuccess?: () => void }) => {
       onSuccess: async (data) => {
         if (data) {
           toast.success("API Key created successfully");
-          queryClient.invalidateQueries(
-            orpc.apikey.list.queryOptions({
-              input: {
-                projectId: props.projectId,
-              },
-            })
-          );
+          /** Partial-matching key: refreshes both the global `list` and the project-scoped `project-list` tables. */
+          queryClient.invalidateQueries({ queryKey: orpc.apikey.key() });
           props.onSuccess?.();
         }
       },
@@ -173,13 +168,7 @@ const CreateAction = (props: { projectId?: number }) => {
   const queryClient = useQueryClient();
 
   const handleSuccess = () => {
-    queryClient.invalidateQueries(
-      orpc.apikey.list.queryOptions({
-        input: {
-          projectId: props.projectId,
-        },
-      })
-    );
+    queryClient.invalidateQueries({ queryKey: orpc.apikey.key() });
   };
 
   return (

--- a/apps/dash/src/components/rag/rag-maintenance.tsx
+++ b/apps/dash/src/components/rag/rag-maintenance.tsx
@@ -314,7 +314,7 @@ export const RagMaintenance = () => {
         onCancel={() => setAction(null)}
         onConfirm={() => {
           if (action === "prune") {
-            prune.mutate({});
+            prune.mutate();
           } else if (action) {
             reindex.mutate({ onlyMissing: action === "top-up" });
           }

--- a/apps/dash/src/libs/orpc/client.ts
+++ b/apps/dash/src/libs/orpc/client.ts
@@ -1,23 +1,29 @@
 import { createORPCClient } from "@orpc/client";
 import { RPCLink } from "@orpc/client/fetch";
-import type { ContractRouterClient } from "@orpc/contract";
+import type { RouterContractClient } from "@orpc/contract";
 import { createTanstackQueryUtils } from "@orpc/tanstack-query";
 
 import type { routerContract } from "@chia/api/orpc/contracts";
 import { withServiceEndpoint } from "@chia/utils/config";
 import { Service } from "@chia/utils/schema";
 
-/** The dashboard's only oRPC client. Every call is from the browser with the session cookie; there is no server-side or in-process path. */
-export const link = new RPCLink({
-  url: withServiceEndpoint("/rpc", Service.LegacyService, {
+const endpoint = new URL(
+  withServiceEndpoint("/rpc", Service.LegacyService, {
     isInternal: false,
     version: "LEGACY",
-  }),
-  fetch: (request, init) =>
-    globalThis.fetch(request, { ...init, credentials: "include" }),
+  })
+);
+
+/** The dashboard's only oRPC client. Every call is from the browser with the session cookie; there is no server-side or in-process path. */
+export const link = new RPCLink({
+  origin: endpoint.origin,
+  /** SAFETY: `URL.pathname` always starts with `/`. */
+  url: endpoint.pathname as `/${string}`,
+  fetch: (url, init) =>
+    globalThis.fetch(url, { ...init, credentials: "include" }),
 });
 
-export const client: ContractRouterClient<typeof routerContract> =
+export const client: RouterContractClient<typeof routerContract> =
   createORPCClient(link);
 
 export const orpc = createTanstackQueryUtils(client);

--- a/apps/dash/src/libs/orpc/types.ts
+++ b/apps/dash/src/libs/orpc/types.ts
@@ -1,10 +1,10 @@
 import type {
-  InferContractRouterOutputs,
-  InferContractRouterInputs,
+  InferRouterContractOutputs,
+  InferRouterContractInputs,
 } from "@orpc/contract";
 
 import type { routerContract } from "@chia/api/orpc/contracts";
 
-export type RouterOutputs = InferContractRouterOutputs<typeof routerContract>;
+export type RouterOutputs = InferRouterContractOutputs<typeof routerContract>;
 
-export type RouterInputs = InferContractRouterInputs<typeof routerContract>;
+export type RouterInputs = InferRouterContractInputs<typeof routerContract>;

--- a/apps/service/__tests__/admin.controller.test.ts
+++ b/apps/service/__tests__/admin.controller.test.ts
@@ -1,12 +1,11 @@
+import { safe } from "@orpc/client";
 import { beforeEach, describe, expect, it } from "vitest";
+
 import { CallerTier } from "@chia/service-kit/policies/caller.policy";
-
 import * as dbMocks from "@chia/test/mocks/db-feeds";
-import * as guardMocks from "./helpers/guards";
-import { rpc as rpcOf } from "./helpers/rpc";
 
-const rpc = (procedure: string, input: unknown = {}) =>
-  rpcOf(`feeds/${encodeURIComponent(procedure)}`, input);
+import * as guardMocks from "./helpers/guards";
+import { client, errorCode } from "./helpers/rpc";
 
 /** Upserts use the project API key; deletes need the operator session. */
 describe("feeds writes require the right tier", () => {
@@ -21,13 +20,12 @@ describe("feeds writes require the right tier", () => {
     it("upserts a translation and reindexes its feed", async () => {
       dbMocks.upsertFeedTranslation.mockResolvedValue({ id: 9, feedId: 1 });
 
-      const res = await rpc("translation:upsert", {
+      await client.feeds["translation:upsert"]({
         feedId: 1,
         locale: "zh-TW",
         title: "Title",
       });
 
-      expect(res.status).toBe(200);
       expect(dbMocks.upsertFeedTranslation).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({ feedId: 1, locale: "zh-TW" })
@@ -35,12 +33,11 @@ describe("feeds writes require the right tier", () => {
     });
 
     it("upserts a translation body", async () => {
-      const res = await rpc("content:upsert", {
+      await client.feeds["content:upsert"]({
         feedTranslationId: 9,
         content: "# hello",
       });
 
-      expect(res.status).toBe(200);
       expect(dbMocks.upsertContent).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({ feedTranslationId: 9 })
@@ -48,9 +45,8 @@ describe("feeds writes require the right tier", () => {
     });
 
     it("may update a feed", async () => {
-      const res = await rpc("update", { feedId: 1, published: true });
+      await client.feeds.update({ feedId: 1, published: true });
 
-      expect(res.status).toBe(200);
       expect(dbMocks.updateFeed).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({ feedId: 1, published: true })
@@ -60,18 +56,20 @@ describe("feeds writes require the right tier", () => {
     it("reports a content:upsert against an unknown translation as NOT_FOUND", async () => {
       dbMocks.upsertContent.mockResolvedValue(undefined);
 
-      const res = await rpc("content:upsert", {
-        feedTranslationId: 999,
-        content: "# hello",
-      });
+      const { error } = await safe(
+        client.feeds["content:upsert"]({
+          feedTranslationId: 999,
+          content: "# hello",
+        })
+      );
 
-      expect(res.status).toBe(404);
+      expect(errorCode(error)).toBe("NOT_FOUND");
     });
 
     it("may not delete a feed", async () => {
-      const res = await rpc("delete", { feedId: 1 });
+      const { error } = await safe(client.feeds.delete({ feedId: 1 }));
 
-      expect(res.status).toBe(403);
+      expect(errorCode(error)).toBe("FORBIDDEN");
     });
   });
 
@@ -80,14 +78,29 @@ describe("feeds writes require the right tier", () => {
 
     // Input validation runs before the guard, so each case sends schema-valid input.
     it.each([
-      ["translation:upsert", { feedId: 1, locale: "zh-TW", title: "Title" }],
-      ["content:upsert", { feedTranslationId: 9, content: "# hello" }],
-      ["update", { feedId: 1 }],
-      ["delete", { feedId: 1 }],
-    ])("rejects %s outright", async (procedure, input) => {
-      const res = await rpc(procedure, input);
+      [
+        "translation:upsert",
+        () =>
+          client.feeds["translation:upsert"]({
+            feedId: 1,
+            locale: "zh-TW",
+            title: "Title",
+          }),
+      ],
+      [
+        "content:upsert",
+        () =>
+          client.feeds["content:upsert"]({
+            feedTranslationId: 9,
+            content: "# hello",
+          }),
+      ],
+      ["update", () => client.feeds.update({ feedId: 1 })],
+      ["delete", () => client.feeds.delete({ feedId: 1 })],
+    ])("rejects %s outright", async (_procedure, call) => {
+      const { error } = await safe(call());
 
-      expect(res.status).toBe(401);
+      expect(errorCode(error)).toBe("UNAUTHORIZED");
     });
   });
 
@@ -95,9 +108,8 @@ describe("feeds writes require the right tier", () => {
     beforeEach(() => guardMocks.setCallerTier(CallerTier.Root));
 
     it("soft-deletes a feed and drops its chunks", async () => {
-      const res = await rpc("delete", { feedId: 1 });
+      await client.feeds.delete({ feedId: 1 });
 
-      expect(res.status).toBe(200);
       expect(dbMocks.softDeleteFeed).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({ feedId: 1 })
@@ -122,11 +134,12 @@ describe("feeds writes require the right tier", () => {
       },
     ]);
 
-    const res = await rpc("related", { slug: "test-feed", locale: "zh-TW" });
+    const data = await client.feeds.related({
+      slug: "test-feed",
+      locale: "zh-TW",
+    });
 
-    expect(res.status).toBe(200);
-    const body = (await res.json()) as { json: { items: unknown[] } };
-    expect(body.json.items).toHaveLength(1);
+    expect(data.items).toHaveLength(1);
     expect(dbMocks.getRelatedFeeds).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({

--- a/apps/service/__tests__/agent-access.controller.test.ts
+++ b/apps/service/__tests__/agent-access.controller.test.ts
@@ -1,3 +1,4 @@
+import { safe } from "@orpc/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { getAgentSessions } from "@chia/db/repos/agent";
@@ -5,7 +6,7 @@ import { CallerTier } from "@chia/service-kit/policies/caller.policy";
 import * as dbMocks from "@chia/test/mocks/db-feeds";
 
 import { setCallerTier } from "./helpers/guards";
-import { rpc as rpcOf } from "./helpers/rpc";
+import { client, errorCode } from "./helpers/rpc";
 
 /**
  * Kind `minTier` is enforced at the guard, before session lookup or model load.
@@ -17,9 +18,6 @@ vi.mock("@chia/db/repos/agent", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@chia/db/repos/agent")>()),
   getAgentSessions: vi.fn().mockResolvedValue([]),
 }));
-
-const rpc = (procedure: string, input?: Record<string, unknown>) =>
-  rpcOf(`agent/${procedure}`, input);
 
 describe("agent kind access", () => {
   beforeEach(() => {
@@ -38,29 +36,35 @@ describe("agent kind access", () => {
     async (_label, tier) => {
       setCallerTier(tier);
 
-      const res = await rpc("capabilities/list", { kind: "writing" });
+      const { error } = await safe(
+        client.agent.capabilities.list({ kind: "writing" })
+      );
 
-      expect(res.status).toBe(401);
+      expect(errorCode(error)).toBe("UNAUTHORIZED");
     }
   );
 
   it("refuses a non-admin session on the writing kind", async () => {
     setCallerTier(CallerTier.Session);
 
-    const res = await rpc("capabilities/list", { kind: "writing" });
+    const { error } = await safe(
+      client.agent.capabilities.list({ kind: "writing" })
+    );
 
-    expect(res.status).toBe(403);
+    expect(errorCode(error)).toBe("FORBIDDEN");
   });
 
   it("admits a guest to the agent surface but not to the writing kind", async () => {
     setCallerTier(CallerTier.Guest);
 
     // Guests own sessions, so list is 200 with an empty list.
-    const list = await rpc("sessions/list");
-    expect(list.status).toBe(200);
+    const list = await client.agent.sessions.list();
+    expect(list).toEqual({ items: [], nextCursor: null });
 
-    const writing = await rpc("capabilities/list", { kind: "writing" });
-    expect(writing.status).toBe(403);
+    const { error } = await safe(
+      client.agent.capabilities.list({ kind: "writing" })
+    );
+    expect(errorCode(error)).toBe("FORBIDDEN");
   });
 
   it.each([
@@ -71,38 +75,39 @@ describe("agent kind access", () => {
     async (_label, tier) => {
       setCallerTier(tier);
 
-      const res = await rpc("capabilities/list", { kind: "public" });
+      const { error } = await safe(
+        client.agent.capabilities.list({ kind: "public" })
+      );
 
-      expect(res.status).toBe(403);
+      expect(errorCode(error)).toBe("FORBIDDEN");
     }
   );
 
   it("refuses the usage standing to a caller with no user to stand for", async () => {
     setCallerTier(CallerTier.ApiKey);
 
-    const res = await rpc("usage/me");
+    const { error } = await safe(client.agent.usage.me());
 
-    expect(res.status).toBe(401);
+    expect(errorCode(error)).toBe("UNAUTHORIZED");
   });
 
   it("refuses an explicit kind the caller may not use when listing", async () => {
     setCallerTier(CallerTier.Session);
 
-    const res = await rpc("sessions/list", { kind: "writing" });
+    const { error } = await safe(
+      client.agent.sessions.list({ kind: "writing" })
+    );
 
-    expect(res.status).toBe(403);
+    expect(errorCode(error)).toBe("FORBIDDEN");
   });
 
   it("lists only the kinds the caller may use when no kind is given", async () => {
     setCallerTier(CallerTier.Session);
     vi.mocked(getAgentSessions).mockClear();
 
-    const res = await rpc("sessions/list");
+    const data = await client.agent.sessions.list();
 
-    expect(res.status).toBe(200);
-    await expect(res.json()).resolves.toEqual({
-      json: { items: [], nextCursor: null },
-    });
+    expect(data).toEqual({ items: [], nextCursor: null });
     // A signed-in visitor may use neither kind, so the repository is never read.
     expect(vi.mocked(getAgentSessions)).not.toHaveBeenCalled();
   });
@@ -110,8 +115,6 @@ describe("agent kind access", () => {
   it("admits the configured admin", async () => {
     setCallerTier(CallerTier.Root);
 
-    const res = await rpc("capabilities/list", { kind: "writing" });
-
-    expect(res.status).toBe(200);
+    await client.agent.capabilities.list({ kind: "writing" });
   });
 });

--- a/apps/service/__tests__/content-surfaces.controller.test.ts
+++ b/apps/service/__tests__/content-surfaces.controller.test.ts
@@ -1,12 +1,11 @@
+import { safe } from "@orpc/client";
 import { beforeEach, describe, expect, it } from "vitest";
+
 import { CallerTier } from "@chia/service-kit/policies/caller.policy";
-
 import * as dbMocks from "@chia/test/mocks/db-feeds";
-import * as guardMocks from "./helpers/guards";
-import { rpc as rpcOf } from "./helpers/rpc";
 
-const rpc = (procedure: string, input: unknown = {}) =>
-  rpcOf(`feeds/${procedure}`, input);
+import * as guardMocks from "./helpers/guards";
+import { client, errorCode } from "./helpers/rpc";
 
 /** Assert the repository is called with the clamped scope, not only that the response looks right. */
 describe("feeds reads scale with the caller's tier", () => {
@@ -19,9 +18,8 @@ describe("feeds reads scale with the caller's tier", () => {
     beforeEach(() => guardMocks.setCallerTier(CallerTier.Anonymous));
 
     it("lists only the admin's published feeds", async () => {
-      const res = await rpc("list", { limit: 10, type: "all" });
+      await client.feeds.list({ limit: 10, type: "all" });
 
-      expect(res.status).toBe(200);
       expect(dbMocks.getInfiniteFeedsByUserId).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({
@@ -33,7 +31,7 @@ describe("feeds reads scale with the caller's tier", () => {
     });
 
     it("ignores a request for drafts and deleted feeds", async () => {
-      await rpc("list", {
+      await client.feeds.list({
         limit: 10,
         includeUnpublished: true,
         includeDeleted: true,
@@ -49,7 +47,7 @@ describe("feeds reads scale with the caller's tier", () => {
     });
 
     it("clamps an oversized page down to the anonymous cap", async () => {
-      await rpc("list", { limit: 1000 });
+      await client.feeds.list({ limit: 1000 });
 
       expect(dbMocks.getInfiniteFeedsByUserId).toHaveBeenCalledWith(
         expect.anything(),
@@ -61,21 +59,25 @@ describe("feeds reads scale with the caller's tier", () => {
      * Detail and `related` require the project API key (`apps/www` server client);
      * anonymous cannot reach them.
      */
-    it.each(["details-by-slug", "details-by-id", "related"])(
-      "cannot reach %s at all",
-      async (procedure) => {
-        const res = await rpc(procedure, { slug: "test-feed-1", feedId: 1 });
+    it.each<[string, () => Promise<unknown>]>([
+      [
+        "details-by-slug",
+        () => client.feeds["details-by-slug"]({ slug: "test-feed-1" }),
+      ],
+      ["details-by-id", () => client.feeds["details-by-id"]({ feedId: 1 })],
+      ["related", () => client.feeds.related({ slug: "test-feed-1" })],
+    ])("cannot reach %s at all", async (_procedure, call) => {
+      const { error } = await safe(call());
 
-        expect(res.status).toBe(401);
-      }
-    );
+      expect(errorCode(error)).toBe("UNAUTHORIZED");
+    });
   });
 
   describe("API key", () => {
     beforeEach(() => guardMocks.setCallerTier(CallerTier.ApiKey));
 
     it("still defaults to published feeds", async () => {
-      await rpc("list", { limit: 10 });
+      await client.feeds.list({ limit: 10 });
 
       expect(dbMocks.getInfiniteFeedsByUserId).toHaveBeenCalledWith(
         expect.anything(),
@@ -84,7 +86,7 @@ describe("feeds reads scale with the caller's tier", () => {
     });
 
     it("drops the published filter when it asks for drafts", async () => {
-      await rpc("list", { limit: 10, includeUnpublished: true });
+      await client.feeds.list({ limit: 10, includeUnpublished: true });
 
       expect(dbMocks.getInfiniteFeedsByUserId).toHaveBeenCalledWith(
         expect.anything(),
@@ -93,7 +95,7 @@ describe("feeds reads scale with the caller's tier", () => {
     });
 
     it("does not gain access to deleted feeds", async () => {
-      await rpc("list", { limit: 10, includeDeleted: true });
+      await client.feeds.list({ limit: 10, includeDeleted: true });
 
       expect(dbMocks.getInfiniteFeedsByUserId).toHaveBeenCalledWith(
         expect.anything(),
@@ -102,7 +104,7 @@ describe("feeds reads scale with the caller's tier", () => {
     });
 
     it("may ask for the page size the sitemap needs", async () => {
-      await rpc("list", { limit: 1000 });
+      await client.feeds.list({ limit: 1000 });
 
       expect(dbMocks.getInfiniteFeedsByUserId).toHaveBeenCalledWith(
         expect.anything(),
@@ -111,7 +113,7 @@ describe("feeds reads scale with the caller's tier", () => {
     });
 
     it("scopes details-by-slug to the admin's published feeds", async () => {
-      await rpc("details-by-slug", { slug: "test-feed-1" });
+      await client.feeds["details-by-slug"]({ slug: "test-feed-1" });
 
       expect(dbMocks.getFeedBySlug).toHaveBeenCalledWith(
         expect.anything(),
@@ -125,9 +127,11 @@ describe("feeds reads scale with the caller's tier", () => {
 
     // `details-by-id` backs the dash edit view only, so a key is not enough.
     it("cannot reach details-by-id", async () => {
-      const res = await rpc("details-by-id", { feedId: 1 });
+      const { error } = await safe(
+        client.feeds["details-by-id"]({ feedId: 1 })
+      );
 
-      expect(res.status).toBe(403);
+      expect(errorCode(error)).toBe("FORBIDDEN");
     });
   });
 
@@ -135,7 +139,7 @@ describe("feeds reads scale with the caller's tier", () => {
     beforeEach(() => guardMocks.setCallerTier(CallerTier.Root));
 
     it("sees its own drafts and deleted feeds when it asks", async () => {
-      await rpc("list", {
+      await client.feeds.list({
         limit: 10,
         includeUnpublished: true,
         includeDeleted: true,
@@ -155,7 +159,7 @@ describe("feeds reads scale with the caller's tier", () => {
   it("serves the dash edit view its draft, deleted feed", async () => {
     guardMocks.setCallerTier(CallerTier.Session);
 
-    await rpc("details-by-id", {
+    await client.feeds["details-by-id"]({
       feedId: 1,
       includeUnpublished: true,
       includeDeleted: true,
@@ -175,8 +179,6 @@ describe("feeds reads scale with the caller's tier", () => {
     guardMocks.setCallerTier(CallerTier.ApiKey);
     dbMocks.getRelatedFeeds.mockResolvedValue([]);
 
-    const related = await rpc("related", { slug: "test-feed", limit: 3 });
-
-    expect(related.status).toBe(200);
+    await client.feeds.related({ slug: "test-feed", limit: 3 });
   });
 });

--- a/apps/service/__tests__/email.controller.test.ts
+++ b/apps/service/__tests__/email.controller.test.ts
@@ -1,9 +1,10 @@
+import { safe } from "@orpc/client";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import * as guardMocks from "./helpers/guards";
-import { rpc } from "./helpers/rpc";
+import { client, errorCode } from "./helpers/rpc";
 
-const send = (body: Record<string, unknown>) => rpc("email/send", body);
+const captchaToken = "test-captcha-token";
 
 describe("email.send", () => {
   beforeEach(() => {
@@ -11,39 +12,50 @@ describe("email.send", () => {
   });
 
   it("rejects an invalid email format", async () => {
-    const res = await send({
-      email: "not-an-email",
-      title: "Test Title",
-      message: "Test Message",
-    });
+    const { error } = await safe(
+      client.email.send({
+        email: "not-an-email",
+        title: "Test Title",
+        message: "Test Message",
+        captchaToken,
+      })
+    );
 
-    expect(res.status).toBe(400);
+    expect(errorCode(error)).toBe("BAD_REQUEST");
   }, 15000);
 
   it("rejects a short title", async () => {
-    const res = await send({
-      email: "test@example.com",
-      title: "Hi",
-      message: "Test Message",
-    });
+    const { error } = await safe(
+      client.email.send({
+        email: "test@example.com",
+        title: "Hi",
+        message: "Test Message",
+        captchaToken,
+      })
+    );
 
-    expect(res.status).toBe(400);
+    expect(errorCode(error)).toBe("BAD_REQUEST");
   }, 15000);
 
   it("rejects a short message", async () => {
-    const res = await send({
-      email: "test@example.com",
-      title: "Test Title",
-      message: "Hi",
-    });
+    const { error } = await safe(
+      client.email.send({
+        email: "test@example.com",
+        title: "Test Title",
+        message: "Hi",
+        captchaToken,
+      })
+    );
 
-    expect(res.status).toBe(400);
+    expect(errorCode(error)).toBe("BAD_REQUEST");
   }, 15000);
 
   it("rejects missing required fields", async () => {
-    const res = await send({ email: "test@example.com" });
+    const { error } = await safe(
+      client.email.send({ email: "test@example.com" } as never)
+    );
 
-    expect(res.status).toBe(400);
+    expect(errorCode(error)).toBe("BAD_REQUEST");
   }, 15000);
 
   it(
@@ -52,13 +64,21 @@ describe("email.send", () => {
       skip: true,
     },
     async () => {
-      const res = await send({
-        email: "test@example.com",
-        title: "Test Title",
-        message: "This is a test message",
-      });
+      const { error } = await safe(
+        client.email.send({
+          email: "test@example.com",
+          title: "Test Title",
+          message: "This is a test message",
+          captchaToken,
+        })
+      );
 
-      expect([200, 401, 403, 500]).toContain(res.status);
+      expect(
+        error === null ||
+          ["UNAUTHORIZED", "FORBIDDEN", "INTERNAL_SERVER_ERROR"].includes(
+            errorCode(error) ?? ""
+          )
+      ).toBe(true);
     }
   );
 });

--- a/apps/service/__tests__/error-shape.controller.test.ts
+++ b/apps/service/__tests__/error-shape.controller.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it } from "vitest";
+
 import { app } from "../src/server";
 
 import * as guardMocks from "./helpers/guards";
@@ -24,7 +25,6 @@ describe("Error body shape", () => {
     expect(body.json).toMatchObject({
       defined: true,
       code: "BAD_REQUEST",
-      status: 400,
     });
   });
 });

--- a/apps/service/__tests__/feeds.controller.test.ts
+++ b/apps/service/__tests__/feeds.controller.test.ts
@@ -1,9 +1,10 @@
+import { safe } from "@orpc/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import * as dbMocks from "@chia/test/mocks/db-feeds";
 
 import * as guardMocks from "./helpers/guards";
-import { rpc } from "./helpers/rpc";
+import { client, errorCode } from "./helpers/rpc";
 
 const { mockSearchPublicFeedsService } = vi.hoisted(() => ({
   mockSearchPublicFeedsService: vi.fn(),
@@ -18,8 +19,6 @@ vi.mock("@chia/api/feeds/search", async (importOriginal) => {
   };
 });
 
-const search = (input: unknown) => rpc("feeds/search", input);
-
 describe("feeds.search", () => {
   beforeEach(() => {
     dbMocks.resetAllDbMocks();
@@ -29,44 +28,44 @@ describe("feeds.search", () => {
   });
 
   it("returns public search results", async () => {
-      mockSearchPublicFeedsService.mockResolvedValue([
-        {
-          feedId: 1,
-          type: "post",
-          slug: "test-feed",
-          locale: "zh-TW",
-          title: "Test feed",
-          description: "Description",
-          excerpt: "",
-        },
-      ]);
+    mockSearchPublicFeedsService.mockResolvedValue([
+      {
+        feedId: 1,
+        type: "post",
+        slug: "test-feed",
+        locale: "zh-TW",
+        title: "Test feed",
+        description: "Description",
+        excerpt: "",
+      },
+    ]);
 
-      const res = await search({ keyword: "test", locale: "zh-TW" });
-
-      expect(res.status).toBe(200);
-      await expect(res.json()).resolves.toEqual({
-        json: {
-          items: [
-            expect.objectContaining({
-              feedId: 1,
-              slug: "test-feed",
-            }),
-          ],
-        },
-      });
-      expect(mockSearchPublicFeedsService).toHaveBeenCalledWith(
-        expect.objectContaining({
-          keyword: "test",
-          locale: "zh-TW",
-          limit: 5,
-        })
-      );
+    const data = await client.feeds.search({
+      keyword: "test",
+      locale: "zh-TW",
     });
 
-    it("rejects a query shorter than two characters", async () => {
-      const res = await search({ keyword: "x", locale: "zh-TW" });
+    expect(data.items).toEqual([
+      expect.objectContaining({
+        feedId: 1,
+        slug: "test-feed",
+      }),
+    ]);
+    expect(mockSearchPublicFeedsService).toHaveBeenCalledWith(
+      expect.objectContaining({
+        keyword: "test",
+        locale: "zh-TW",
+        limit: 5,
+      })
+    );
+  });
 
-      expect(res.status).toBe(400);
-      expect(mockSearchPublicFeedsService).not.toHaveBeenCalled();
-    });
+  it("rejects a query shorter than two characters", async () => {
+    const { error } = await safe(
+      client.feeds.search({ keyword: "x", locale: "zh-TW" })
+    );
+
+    expect(errorCode(error)).toBe("BAD_REQUEST");
+    expect(mockSearchPublicFeedsService).not.toHaveBeenCalled();
+  });
 });

--- a/apps/service/__tests__/helpers/rpc.ts
+++ b/apps/service/__tests__/helpers/rpc.ts
@@ -1,8 +1,35 @@
+import { createORPCClient, ORPCError } from "@orpc/client";
+import { RPCLink } from "@orpc/client/fetch";
+import type { RouterContractClient } from "@orpc/contract";
+
+import type { routerContract } from "@chia/api/orpc/contracts";
+
 import { app } from "../../src/server";
 
-export const rpc = (path: string, input?: unknown) =>
-  app.request(`/api/v1/rpc/${path}`, {
+const RPC_PREFIX = "/api/v1/rpc";
+
+const link = new RPCLink({
+  url: RPC_PREFIX as `/${string}`,
+  fetch: async (url, init) => app.request(url, init),
+});
+
+export const client: RouterContractClient<typeof routerContract> =
+  createORPCClient(link);
+
+export const errorCode = (error: unknown): string | undefined =>
+  error instanceof ORPCError ? error.code : undefined;
+
+/** Path-only POST with the RPC envelope. Segments are encoded the same way as RPCLink. */
+export const rpc = (path: string, input?: unknown) => {
+  const encoded = path
+    .split("/")
+    .filter((segment) => segment.length > 0)
+    .map(encodeURIComponent)
+    .join("/");
+
+  return app.request(`${RPC_PREFIX}/${encoded}`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ json: input }),
   });
+};

--- a/apps/service/__tests__/rpc-status.controller.test.ts
+++ b/apps/service/__tests__/rpc-status.controller.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { CallerTier } from "@chia/service-kit/policies/caller.policy";
+import * as dbMocks from "@chia/test/mocks/db-feeds";
+
+import * as guardMocks from "./helpers/guards";
+import { rpc } from "./helpers/rpc";
+
+describe("RPCHandler errorStatusMap", () => {
+  beforeEach(() => {
+    guardMocks.resetAllGuardMocks();
+    dbMocks.resetAllDbMocks();
+  });
+
+  it("maps UNAUTHORIZED to 401", async () => {
+    guardMocks.setCallerTier(CallerTier.Anonymous);
+
+    const res = await rpc("feeds/delete", { feedId: 1 });
+
+    expect(res.status).toBe(401);
+  });
+
+  it("maps FORBIDDEN to 403", async () => {
+    guardMocks.setCallerTier(CallerTier.ApiKey);
+
+    const res = await rpc("feeds/delete", { feedId: 1 });
+
+    expect(res.status).toBe(403);
+  });
+
+  it("maps NOT_FOUND to 404", async () => {
+    guardMocks.setCallerTier(CallerTier.ApiKey);
+    dbMocks.upsertContent.mockResolvedValue(undefined);
+
+    const res = await rpc("feeds/content:upsert", {
+      feedTranslationId: 999,
+      content: "# hello",
+    });
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/apps/service/__tests__/toolings.controller.test.ts
+++ b/apps/service/__tests__/toolings.controller.test.ts
@@ -1,9 +1,8 @@
+import { safe } from "@orpc/client";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import * as guardMocks from "./helpers/guards";
-import { rpc } from "./helpers/rpc";
-
-const linkPreview = (input: unknown) => rpc("toolings/link-preview", input);
+import { client, errorCode } from "./helpers/rpc";
 
 describe("toolings.link-preview", () => {
   beforeEach(() => {
@@ -11,25 +10,35 @@ describe("toolings.link-preview", () => {
   });
 
   it("returns link preview data", async () => {
-    const res = await linkPreview({ href: "https://github.com" });
+    const { error, data } = await safe(
+      client.toolings["link-preview"]({ href: "https://github.com" })
+    );
 
-    expect([200, 500, 504]).toContain(res.status);
-    if (res.ok) {
-      const data = await res.json();
+    if (error) {
+      expect([
+        "BAD_REQUEST",
+        "INTERNAL_SERVER_ERROR",
+        "TIMEOUT",
+        "GATEWAY_TIMEOUT",
+        "MALFORMED_ORPC_RESPONSE",
+      ]).toContain(errorCode(error));
+    } else {
       expect(data).toBeDefined();
     }
   }, 30000);
 
   it("rejects an invalid URL", async () => {
-    const res = await linkPreview({ href: "not-a-valid-url" });
+    const { error } = await safe(
+      client.toolings["link-preview"]({ href: "not-a-valid-url" })
+    );
 
-    expect(res.status).toBe(400);
+    expect(errorCode(error)).toBe("BAD_REQUEST");
   }, 15000);
 
   it("rejects a missing href", async () => {
-    const res = await linkPreview({});
+    const { error } = await safe(client.toolings["link-preview"]({} as never));
 
-    expect(res.status).toBe(400);
+    expect(errorCode(error)).toBe("BAD_REQUEST");
   }, 15000);
 
   it("rejects malformed JSON", async () => {

--- a/apps/service/package.json
+++ b/apps/service/package.json
@@ -59,6 +59,8 @@
   "devDependencies": {
     "@chia/test": "workspace:*",
     "@chiastack/tsconfig": "catalog:chiastack",
+    "@orpc/client": "catalog:orpc",
+    "@orpc/contract": "catalog:orpc",
     "@types/lodash": "catalog:",
     "@types/node": "catalog:",
     "@types/react": "catalog:react-is",

--- a/apps/service/src/routes/rpc.route.ts
+++ b/apps/service/src/routes/rpc.route.ts
@@ -1,3 +1,4 @@
+import { COMMON_ERROR_STATUS_MAP } from "@orpc/server";
 import { RPCHandler } from "@orpc/server/fetch";
 import { Hono } from "hono";
 import { timeout } from "hono/timeout";
@@ -26,6 +27,8 @@ const isUntimedProcedure = (path: string): boolean =>
 
 /** Built once per process; holds no per-request state. */
 const handler = new RPCHandler(router, {
+  // QUOTA_EXCEEDED is the only AppError code outside oRPC's common codes.
+  errorStatusMap: { ...COMMON_ERROR_STATUS_MAP, QUOTA_EXCEEDED: 402 },
   interceptors: [
     (options) => withErrorReporting(options.context, () => options.next()),
   ],

--- a/apps/www/.next/dev/types/link.d.ts
+++ b/apps/www/.next/dev/types/link.d.ts
@@ -42,7 +42,7 @@ declare namespace __next_route_internal_types__ {
     | `/${SafeSlug<T>}/${SafeSlug<T>}/${SafeSlug<T>}/og` // ../../../src/app/[locale]/(blog)/[type]/[slug]/og/route.ts
     | `/${SafeSlug<T>}/about` // /[locale]/about
     | `/${SafeSlug<T>}/contact` // ../../../src/app/[locale]/contact/page.tsx
-    | `/${SafeSlug<T>}/email` // ../../../src/app/[locale]/email/page.ts
+    | `/${SafeSlug<T>}/email` // ../../../src/app/[locale]/@modal/(.)email/page.tsx
     | `/${SafeSlug<T>}/note/${SafeSlug<T>}` // /[locale]/note/[slug]
     | `/${SafeSlug<T>}/post/${SafeSlug<T>}` // /[locale]/post/[slug]
     | `/${SafeSlug<T>}/projects` // ../../../src/app/[locale]/projects/page.tsx

--- a/apps/www/__tests__/setup.ts
+++ b/apps/www/__tests__/setup.ts
@@ -29,7 +29,7 @@ vi.mock("next/navigation", () => navigation);
 vi.mock("next/navigation.js", () => navigation);
 
 vi.mock("next-intl", async (importOriginal) => {
-  const actual = await importOriginal();
+  const actual = await importOriginal<typeof import("next-intl")>();
   return {
     ...actual,
     useTranslations: () => (key: string) => key,

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -47,7 +47,7 @@
     "@next/third-parties": "catalog:next",
     "@orpc/client": "catalog:orpc",
     "@orpc/contract": "catalog:orpc",
-    "@orpc/server": "^1.15.0",
+    "@orpc/server": "catalog:orpc",
     "@orpc/tanstack-query": "catalog:orpc",
     "@sentry/nextjs": "^10.72.0",
     "@t3-oss/env-nextjs": "catalog:",

--- a/apps/www/src/components/commons/current-playing.tsx
+++ b/apps/www/src/components/commons/current-playing.tsx
@@ -11,7 +11,7 @@ import {
   useTransition,
 } from "react";
 
-import type { UseQueryResult, UseQueryOptions } from "@tanstack/react-query";
+import type { UseQueryResult } from "@tanstack/react-query";
 import { useQuery } from "@tanstack/react-query";
 
 import {
@@ -44,10 +44,9 @@ interface Props extends ExtendsProps {
   children?:
     | ReactNode
     | ((result: UseQueryResult<CurrentPlayingResponse, Error>) => ReactNode);
-  queryOptions?: Omit<
-    UseQueryOptions<CurrentPlayingResponse, Error>,
-    "queryKey" | "queryFn"
-  >;
+  queryOptions?: Parameters<
+    typeof orpc.spotify.playing.queryOptions<CurrentPlayingResponse>
+  >[0];
 }
 
 const ProgressContext = createContext<
@@ -367,12 +366,13 @@ export const CurrentPlaying = ({
   hoverCardContentClassName,
   experimental,
 }: Props) => {
-  const result = useQuery({
-    ...orpc.spotify.playing.queryOptions(),
-    refetchInterval: (ctx) => calculateRefetchInterval(ctx.state.data),
-    refetchOnWindowFocus: "always",
-    ...queryOptions,
-  });
+  const result = useQuery(
+    orpc.spotify.playing.queryOptions({
+      ...queryOptions,
+      refetchInterval: (ctx) => calculateRefetchInterval(ctx.state.data),
+      refetchOnWindowFocus: "always",
+    })
+  );
 
   if (children) {
     return <>{children instanceof Function ? children(result) : children}</>;

--- a/apps/www/src/components/commons/preview-link.tsx
+++ b/apps/www/src/components/commons/preview-link.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import type { ReactNode, ComponentPropsWithoutRef } from "react";
 import { useState } from "react";
 
-import type { UseQueryResult, UseQueryOptions } from "@tanstack/react-query";
+import type { UseQueryResult } from "@tanstack/react-query";
 import { useQuery } from "@tanstack/react-query";
 import * as z from "zod";
 
@@ -23,6 +23,8 @@ import type { RouterOutputs } from "@/libs/orpc/types";
 
 type LinkPreviewResponse = RouterOutputs["toolings"]["link-preview"];
 
+const linkPreview = orpc.toolings["link-preview"];
+
 const HOVER_CARD_STYLES = {
   base: "z-20 w-full max-w-80 border-[#FCA5A5]/50 shadow-[0px_0px_15px_4px_rgb(252_165_165_/_0.3)] transition-all dark:border-purple-400/50 dark:shadow-[0px_0px_15px_4px_RGB(192_132_252_/_0.3)]",
   error:
@@ -31,6 +33,10 @@ const HOVER_CARD_STYLES = {
 
 type InternalLinkProps = NextLinkProps &
   Omit<ComponentPropsWithoutRef<"a">, "href">;
+
+type LinkPreviewQueryOptions = Parameters<
+  typeof linkPreview.queryOptions<LinkPreviewResponse>
+>[0];
 
 export interface PreviewLinkProps extends Omit<
   InternalLinkProps,
@@ -43,10 +49,7 @@ export interface PreviewLinkProps extends Omit<
   previewContent?:
     | ReactNode
     | ((result: UseQueryResult<LinkPreviewResponse, Error>) => ReactNode);
-  queryOptions?: Omit<
-    UseQueryOptions<LinkPreviewResponse, Error>,
-    "queryKey" | "queryFn" | "enabled"
-  >;
+  queryOptions?: LinkPreviewQueryOptions;
   enabled?: boolean;
 }
 
@@ -141,20 +144,17 @@ const PreviewDetail = ({
 const useLinkPreview = (
   href: URL | string,
   isOpen: boolean,
-  queryOptions?: Omit<
-    UseQueryOptions<LinkPreviewResponse, Error>,
-    "queryKey" | "queryFn" | "enabled"
-  >,
+  queryOptions?: LinkPreviewQueryOptions,
   enabled?: boolean
 ) => {
-  return useQuery({
-    ...orpc.toolings["link-preview"].queryOptions({
+  return useQuery(
+    linkPreview.queryOptions({
+      ...queryOptions,
       input: { href: href.toString() },
-    }),
-    enabled: isOpen && isUrl(href) && enabled,
-    retry: 1,
-    ...queryOptions,
-  });
+      enabled: isOpen && isUrl(href) && enabled,
+      retry: 1,
+    })
+  );
 };
 
 const PreviewLink = ({

--- a/apps/www/src/libs/orpc/client.rsc.ts
+++ b/apps/www/src/libs/orpc/client.rsc.ts
@@ -1,7 +1,7 @@
 import "server-only";
 import { createORPCClient } from "@orpc/client";
 import { RPCLink } from "@orpc/client/fetch";
-import type { ContractRouterClient } from "@orpc/contract";
+import type { RouterContractClient } from "@orpc/contract";
 import { createTanstackQueryUtils } from "@orpc/tanstack-query";
 
 import type { routerContract } from "@chia/api/orpc/contracts";
@@ -11,11 +11,17 @@ import { Service } from "@chia/utils/schema";
 
 import { env } from "@/env";
 
-export const link = new RPCLink({
-  url: withServiceEndpoint("/rpc", Service.LegacyService, {
+const endpoint = new URL(
+  withServiceEndpoint("/rpc", Service.LegacyService, {
     isInternal: false,
     version: "LEGACY",
-  }),
+  })
+);
+
+export const link = new RPCLink({
+  origin: endpoint.origin,
+  /** SAFETY: `URL.pathname` always starts with `/`. */
+  url: endpoint.pathname as `/${string}`,
   headers: {
     /** Server-only: Cloudflare bypass plus `CH_API_KEY`. Browser `client.ts` must never get the key. */
     [X_CF_BYPASS_TOKEN]: env.CF_BYPASS_TOKEN ?? "",
@@ -23,7 +29,7 @@ export const link = new RPCLink({
   },
 });
 
-export const client: ContractRouterClient<typeof routerContract> =
+export const client: RouterContractClient<typeof routerContract> =
   createORPCClient(link);
 
 export const orpc = createTanstackQueryUtils(client);

--- a/apps/www/src/libs/orpc/client.ts
+++ b/apps/www/src/libs/orpc/client.ts
@@ -1,21 +1,27 @@
 import { createORPCClient } from "@orpc/client";
 import { RPCLink } from "@orpc/client/fetch";
-import type { ContractRouterClient } from "@orpc/contract";
+import type { RouterContractClient } from "@orpc/contract";
 import { createTanstackQueryUtils } from "@orpc/tanstack-query";
 
 import type { routerContract } from "@chia/api/orpc/contracts";
 import { withServiceEndpoint } from "@chia/utils/config";
 import { Service } from "@chia/utils/schema";
 
-/** Browser client: public procedures only. Never attach `CH_API_KEY`. */
-export const link = new RPCLink({
-  url: withServiceEndpoint("/rpc", Service.LegacyService, {
+const endpoint = new URL(
+  withServiceEndpoint("/rpc", Service.LegacyService, {
     isInternal: false,
     version: "LEGACY",
-  }),
+  })
+);
+
+/** Browser client: public procedures only. Never attach `CH_API_KEY`. */
+export const link = new RPCLink({
+  origin: endpoint.origin,
+  /** SAFETY: `URL.pathname` always starts with `/`. */
+  url: endpoint.pathname as `/${string}`,
 });
 
-export const client: ContractRouterClient<typeof routerContract> =
+export const client: RouterContractClient<typeof routerContract> =
   createORPCClient(link);
 
 export const orpc = createTanstackQueryUtils(client);

--- a/apps/www/src/libs/orpc/types.ts
+++ b/apps/www/src/libs/orpc/types.ts
@@ -1,10 +1,10 @@
 import type {
-  InferContractRouterOutputs,
-  InferContractRouterInputs,
+  InferRouterContractOutputs,
+  InferRouterContractInputs,
 } from "@orpc/contract";
 
 import type { routerContract } from "@chia/api/orpc/contracts";
 
-export type RouterOutputs = InferContractRouterOutputs<typeof routerContract>;
+export type RouterOutputs = InferRouterContractOutputs<typeof routerContract>;
 
-export type RouterInputs = InferContractRouterInputs<typeof routerContract>;
+export type RouterInputs = InferRouterContractInputs<typeof routerContract>;

--- a/packages/agent-elements/src/types.ts
+++ b/packages/agent-elements/src/types.ts
@@ -1,4 +1,4 @@
-import type { ContractRouterClient } from "@orpc/contract";
+import type { RouterContractClient } from "@orpc/contract";
 
 import type { AgentWireEvent } from "@chia/agent-runtime/wire/schema";
 import type { agentContracts, routerContract } from "@chia/api/orpc/contracts";
@@ -6,7 +6,7 @@ import type { agentContracts, routerContract } from "@chia/api/orpc/contracts";
 /**
  * The `agent` branch of the host's contract-typed oRPC client. This package never builds one.
  */
-export type AgentClient = ContractRouterClient<typeof routerContract>["agent"];
+export type AgentClient = RouterContractClient<typeof routerContract>["agent"];
 
 type SessionProcedures = AgentClient["sessions"];
 type CapabilityProcedures = AgentClient["capabilities"];

--- a/packages/agent-runtime/__tests__/runtime-compaction.test.ts
+++ b/packages/agent-runtime/__tests__/runtime-compaction.test.ts
@@ -1,6 +1,8 @@
 import { fauxAssistantMessage } from "@earendil-works/pi-ai/providers/faux";
 import { describe, expect, it } from "vitest";
 
+import type { AgentUsageReport } from "../src/types.ts";
+
 import {
   assistantUsageOf,
   build,

--- a/packages/agent-runtime/__tests__/runtime.test.ts
+++ b/packages/agent-runtime/__tests__/runtime.test.ts
@@ -1,3 +1,4 @@
+import type { Context } from "@earendil-works/pi-ai";
 import {
   fauxAssistantMessage,
   fauxToolCall,

--- a/packages/api/orpc/contracts/agent.contract.ts
+++ b/packages/api/orpc/contracts/agent.contract.ts
@@ -1,4 +1,4 @@
-import { eventIterator, oc } from "@orpc/contract";
+import { asyncIteratorObject, oc } from "@orpc/contract";
 import * as z from "zod";
 
 import { agentWireEventSchema } from "@chia/agent-runtime/wire/schema";
@@ -9,8 +9,8 @@ import { withMetaSchema } from "./shared";
 /** Kind-specific fields stay optional; the runtime selected by `agent.session.kind` owns their validation. */
 
 /**
- * Quota refusal is not an oRPC common code, so the status travels here. `resetAt` is when the
- * week turns over.
+ * Quota refusal is not an oRPC common code; the RPC handler's `errorStatusMap` owns its
+ * HTTP status. `resetAt` is when the week turns over.
  */
 export const agentQuotaExceededSchema = z.object({
   limitMicros: z.number(),
@@ -20,7 +20,7 @@ export const agentQuotaExceededSchema = z.object({
 });
 
 export const quotaExceededError = {
-  QUOTA_EXCEEDED: { status: 402, data: agentQuotaExceededSchema },
+  QUOTA_EXCEEDED: { data: agentQuotaExceededSchema },
 } as const;
 
 /** Refuses a new turn while the caller already has their cap of turns executing. */
@@ -296,7 +296,7 @@ export const chatAgentContract = oc
       ]),
     })
   )
-  .output(eventIterator(agentWireEventSchema));
+  .output(asyncIteratorObject(agentWireEventSchema));
 
 export const abortAgentContract = oc
   .errors({ UNAUTHORIZED: {}, FORBIDDEN: {}, NOT_FOUND: {} })

--- a/packages/api/orpc/guards/ai-key.guard.ts
+++ b/packages/api/orpc/guards/ai-key.guard.ts
@@ -29,7 +29,7 @@ export interface AiKeyGuardInput {
 /**
  * Resolves the caller's provider API key from cookies into `context.AI_AUTH_TOKEN`.
  * Whether a key is needed depends on the request's input, which a policy never sees, so
- * the procedure maps it in via `.use(guard, mapInput)`.
+ * the procedure maps it in via `.use(guard.adaptInput(mapInput))`.
  */
 export const aiKeyGuard = (defaults?: { provider?: AiProvider }) =>
   baseOS

--- a/packages/api/orpc/guards/auth.guard.ts
+++ b/packages/api/orpc/guards/auth.guard.ts
@@ -25,7 +25,7 @@ export interface SessionGuardInput {
  * A session is required either way; `rootOnly` only raises the bar.
  *
  * @example
- * .use(sessionGuard, (input) => ({ rootOnly: isOpenAIEmbeddingModel(input.model) }))
+ * .use(sessionGuard.adaptInput((input) => ({ rootOnly: isOpenAIEmbeddingModel(input.model) })))
  */
 export const sessionGuard = baseOS
   .errors({

--- a/packages/api/orpc/guards/captcha.guard.ts
+++ b/packages/api/orpc/guards/captcha.guard.ts
@@ -9,7 +9,7 @@ export interface CaptchaGuardInput {
 }
 
 /**
- * Verifies the captcha token mapped in via `.use(captchaGuard, (input) => ({ token: input.captchaToken }))`.
+ * Verifies the captcha token mapped in via `.use(captchaGuard.adaptInput((input) => ({ token: input.captchaToken })))`.
  * The verifier is injected because `@chia/service-kit` cannot depend on `@chia/api`.
  */
 export const captchaGuard = baseOS

--- a/packages/api/orpc/routes/email.route.ts
+++ b/packages/api/orpc/routes/email.route.ts
@@ -5,7 +5,7 @@ import { contractOS } from "../utils";
 
 export const sendContactEmailRoute = contractOS.email.send
   .use(rateLimitGuard({ prefix: "rate-limiter:email" }))
-  .use(captchaGuard, (input) => ({ token: input.captchaToken }))
+  .use(captchaGuard.adaptInput((input) => ({ token: input.captchaToken })))
   .handler(async (opts) => {
     await sendContactEmail({
       email: opts.input.email,

--- a/packages/api/orpc/routes/feeds.route.ts
+++ b/packages/api/orpc/routes/feeds.route.ts
@@ -135,7 +135,9 @@ export const searchFeedsAdvancedRoute = contractOS.feeds["search:advanced"]
    * Authenticated for every mode; root-only for modes that embed the query. Those spend
    * the server's embedding credentials; `bm25` does not.
    */
-  .use(sessionGuard, (input) => ({ rootOnly: input.model !== "bm25" }))
+  .use(
+    sessionGuard.adaptInput((input) => ({ rootOnly: input.model !== "bm25" }))
+  )
   .handler(async (opts) => {
     const { keyword, model, locale } = opts.input;
 

--- a/packages/api/orpc/services/agent.service.ts
+++ b/packages/api/orpc/services/agent.service.ts
@@ -114,8 +114,8 @@ export interface AgentKindService {
   ): Promise<AgentStreamCursor | null>;
 
   /**
-   * Returns an async generator so the oRPC handler can hand the iterator to `eventIterator`
-   * without buffering.
+   * Returns an async generator so the oRPC handler can hand the iterator to
+   * `asyncIteratorObject` without buffering.
    */
   stream(
     caller: AgentServiceCaller,

--- a/packages/service-kit/src/adapters/orpc.ts
+++ b/packages/service-kit/src/adapters/orpc.ts
@@ -5,10 +5,12 @@ import type { AppError } from "../errors";
 import { isAppError } from "../errors";
 import type { Policy } from "../policies/types";
 
-/** Renders an {@link AppError} as an `ORPCError`. Issues travel in `data.errors`. */
+/**
+ * Renders an {@link AppError} as an `ORPCError`. Issues travel in `data.errors`. The HTTP
+ * status comes from the handler's `errorStatusMap`, keyed by `code`.
+ */
 export const toORPCError = (error: AppError): ORPCError<string, unknown> =>
   new ORPCError(error.code, {
-    status: error.status,
     message: error.message,
     data:
       error.issues || error.data

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -316,17 +316,17 @@ catalogs:
       version: 16.3.3
   orpc:
     '@orpc/client':
-      specifier: 1.15.0
-      version: 1.15.0
+      specifier: 2.0.0-beta.32
+      version: 2.0.0-beta.32
     '@orpc/contract':
-      specifier: 1.15.0
-      version: 1.15.0
+      specifier: 2.0.0-beta.32
+      version: 2.0.0-beta.32
     '@orpc/server':
-      specifier: 1.15.0
-      version: 1.15.0
+      specifier: 2.0.0-beta.32
+      version: 2.0.0-beta.32
     '@orpc/tanstack-query':
-      specifier: 1.15.0
-      version: 1.15.0
+      specifier: 2.0.0-beta.32
+      version: 2.0.0-beta.32
   oxc:
     '@oxlint/plugins':
       specifier: 1.80.0
@@ -659,16 +659,16 @@ importers:
         version: 4.7.0(monaco-editor@0.56.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@orpc/client':
         specifier: catalog:orpc
-        version: 1.15.0(@opentelemetry/api@1.9.1)
+        version: 2.0.0-beta.32(@opentelemetry/api@1.9.1)
       '@orpc/contract':
         specifier: catalog:orpc
-        version: 1.15.0(@opentelemetry/api@1.9.1)
+        version: 2.0.0-beta.32(@opentelemetry/api@1.9.1)
       '@orpc/server':
         specifier: catalog:orpc
-        version: 1.15.0(@opentelemetry/api@1.9.1)(crossws@0.4.12(srvx@0.12.7))(ws@8.21.3)
+        version: 2.0.0-beta.32(@opentelemetry/api@1.9.1)(crossws@0.4.12(srvx@0.12.7))
       '@orpc/tanstack-query':
         specifier: catalog:orpc
-        version: 1.15.0(@opentelemetry/api@1.9.1)(@orpc/client@1.15.0(@opentelemetry/api@1.9.1))(@tanstack/query-core@5.102.8)
+        version: 2.0.0-beta.32(@opentelemetry/api@1.9.1)(@tanstack/query-core@5.102.8)(crossws@0.4.12(srvx@0.12.7))
       '@t3-oss/env-nextjs':
         specifier: 'catalog:'
         version: 0.13.11(typescript@7.0.2)(zod@4.5.4)
@@ -900,7 +900,7 @@ importers:
         version: 5.1.6(@opentelemetry/api@1.9.1)(keyv@5.6.0)
       '@orpc/server':
         specifier: catalog:orpc
-        version: 1.15.0(@opentelemetry/api@1.9.1)(crossws@0.4.12(srvx@0.11.22))(ws@8.21.3)
+        version: 2.0.0-beta.32(@opentelemetry/api@1.9.1)(crossws@0.4.12(srvx@0.11.22))
       '@t3-oss/env-core':
         specifier: 'catalog:'
         version: 0.13.11(typescript@7.0.2)(zod@4.5.4)
@@ -965,6 +965,12 @@ importers:
       '@chiastack/tsconfig':
         specifier: catalog:chiastack
         version: 2.1.2
+      '@orpc/client':
+        specifier: catalog:orpc
+        version: 2.0.0-beta.32(@opentelemetry/api@1.9.1)
+      '@orpc/contract':
+        specifier: catalog:orpc
+        version: 2.0.0-beta.32(@opentelemetry/api@1.9.1)
       '@types/lodash':
         specifier: 'catalog:'
         version: 4.17.25
@@ -1124,16 +1130,16 @@ importers:
         version: 16.3.3(next@16.3.3(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.4.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       '@orpc/client':
         specifier: catalog:orpc
-        version: 1.15.0(@opentelemetry/api@1.9.1)
+        version: 2.0.0-beta.32(@opentelemetry/api@1.9.1)
       '@orpc/contract':
         specifier: catalog:orpc
-        version: 1.15.0(@opentelemetry/api@1.9.1)
+        version: 2.0.0-beta.32(@opentelemetry/api@1.9.1)
       '@orpc/server':
-        specifier: ^1.15.0
-        version: 1.15.0(@opentelemetry/api@1.9.1)(crossws@0.4.12(srvx@0.12.7))(ws@8.21.3)
+        specifier: catalog:orpc
+        version: 2.0.0-beta.32(@opentelemetry/api@1.9.1)(crossws@0.4.12(srvx@0.12.7))
       '@orpc/tanstack-query':
         specifier: catalog:orpc
-        version: 1.15.0(@opentelemetry/api@1.9.1)(@orpc/client@1.15.0(@opentelemetry/api@1.9.1))(@tanstack/query-core@5.102.8)
+        version: 2.0.0-beta.32(@opentelemetry/api@1.9.1)(@tanstack/query-core@5.102.8)(crossws@0.4.12(srvx@0.12.7))
       '@sentry/nextjs':
         specifier: ^10.72.0
         version: 10.72.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(encoding@0.1.13)(next@16.3.3(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.4.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(supports-color@10.2.2)(webpack@5.110.1(@swc/core@1.16.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
@@ -1372,7 +1378,7 @@ importers:
         version: 3.2.4(@react-aria/i18n@3.13.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@react-aria/ssr@3.10.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@react-aria/utils@3.34.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@react-spectrum/provider@3.11.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/react-dom@19.2.5(@types/react@19.2.18))(@types/react@19.2.18)(react-aria-components@1.20.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-aria@3.51.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(tailwindcss@4.3.3)
       '@orpc/contract':
         specifier: catalog:orpc
-        version: 1.15.0(@opentelemetry/api@1.9.1)
+        version: 2.0.0-beta.32(@opentelemetry/api@1.9.1)
       '@shikijs/stream':
         specifier: catalog:ui
         version: 4.4.3(react@19.2.8)
@@ -1741,10 +1747,10 @@ importers:
         version: link:../workflow-control
       '@orpc/contract':
         specifier: catalog:orpc
-        version: 1.15.0(@opentelemetry/api@1.9.1)
+        version: 2.0.0-beta.32(@opentelemetry/api@1.9.1)
       '@orpc/server':
         specifier: catalog:orpc
-        version: 1.15.0(@opentelemetry/api@1.9.1)(crossws@0.4.12(srvx@0.12.7))(ws@8.21.3)
+        version: 2.0.0-beta.32(@opentelemetry/api@1.9.1)(crossws@0.4.12(srvx@0.12.7))
       '@t3-oss/env-core':
         specifier: 'catalog:'
         version: 0.13.11(typescript@7.0.2)(zod@4.5.4)
@@ -2101,7 +2107,7 @@ importers:
         version: 1.2.2(hono@4.13.5)
       '@orpc/server':
         specifier: catalog:orpc
-        version: 1.15.0(@opentelemetry/api@1.9.1)(crossws@0.4.12(srvx@0.12.7))(ws@8.21.3)
+        version: 2.0.0-beta.32(@opentelemetry/api@1.9.1)(crossws@0.4.12(srvx@0.12.7))
       hono:
         specifier: catalog:hono
         version: 4.13.5
@@ -3656,6 +3662,12 @@ packages:
   '@hexagon/base64@1.1.28':
     resolution: {integrity: sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw==}
 
+  '@hey-api/spec-types@0.0.0-next-20260408030107':
+    resolution: {integrity: sha512-P5DKr4dpZ7lmZpZt2bc2KWuzU9vl4GZcN7VrjchZF1WWKNGZFnwWhBxZo1t6P2muOCopIvqD2Fvp5os4QiitKA==}
+
+  '@hey-api/types@0.1.4':
+    resolution: {integrity: sha512-thWfawrDIP7wSI9ioT13I5soaaqB5vAPIiZmgD8PbeEVKNrkonc0N/Sjj97ezl7oQgusZmaNphGdMKipPO6IBg==}
+
   '@hono/react-renderer@1.0.1':
     resolution: {integrity: sha512-vjQ/70hVrbgsi2O44N7w5sO0v51lRcuXau/4caVzw0A1hje+U2zAnuhiBC3JhX56gGfhGT4kO5B0di4SROx0Lg==}
     engines: {node: '>=18'}
@@ -4690,61 +4702,51 @@ packages:
     resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
     engines: {node: '>=14'}
 
-  '@orpc/client@1.15.0':
-    resolution: {integrity: sha512-Qt0FdPSGySdQwy83iUWOq+Iqhw2gM9qHtyxfBbcw1mwOz1s4O2BwUFA3ymVTLIRRNYRgPrQLaBZhp8CacqeePg==}
+  '@orpc/client@2.0.0-beta.32':
+    resolution: {integrity: sha512-Uz+mO5+AHmxu95x9PKq3HLGlMDqZPZbi1AUPfiVtISz8vMwtSRrNk2OuOyTqzWBLIN1GNMHLY4Wy2IRf6aJmkA==}
 
-  '@orpc/contract@1.15.0':
-    resolution: {integrity: sha512-zo8+x+5iqnIMrFdcj+ibVgn6dJneWzLNcD3kZQxrJFGFNAFoxvZbwryR5wOdcHkaSCeS3N7Ib2NydU6pihSYmg==}
+  '@orpc/contract@2.0.0-beta.32':
+    resolution: {integrity: sha512-ltOySo2yHUCVoEDJW456JP14FQ17jzL4Xon0kZhDxPsnP17ibbXP6G7bSp72qi7ZTn9s41De89RVIWnSVUhgkQ==}
 
-  '@orpc/interop@1.15.0':
-    resolution: {integrity: sha512-Ah48o/rc00rN1yP5HcaoVsDCjdUhoh3JP1VibBbvwijhGvdOwRwiw5RWiGu442GSKcrPt9etAGhWXH88q8C3ww==}
+  '@orpc/json-schema@2.0.0-beta.32':
+    resolution: {integrity: sha512-LUS9AL8ZUrjkhuWc6IZCxRcts62HPZqOuuKwZDa3woJTDXujsfJkofBzQmQV/1eKv0RY7/Znditf5/DYuHNxLQ==}
 
-  '@orpc/server@1.15.0':
-    resolution: {integrity: sha512-l9FnL1MjQ8g77mB10/8D61okuKHLJBWhuwmd6OF65POHzBF177kMCcbHvRFEqUuxSbzP2eNiZGf3kXPMHmIKiQ==}
+  '@orpc/openapi@2.0.0-beta.32':
+    resolution: {integrity: sha512-rVKQ2ewPUQtUAE0HOTOj6EH4HEjoihb/qQeq1J7NnBpuF4CYNaDKabAS5LHP8NJuPv0Es0hpNyF6ZmPaSFqy8g==}
+    peerDependencies:
+      '@scalar/api-reference': '>=1.57.2'
+      '@types/swagger-ui': '>=5.32.0'
+      swagger-ui: '>=5.32.6'
+    peerDependenciesMeta:
+      '@scalar/api-reference':
+        optional: true
+      '@types/swagger-ui':
+        optional: true
+      swagger-ui:
+        optional: true
+
+  '@orpc/server@2.0.0-beta.32':
+    resolution: {integrity: sha512-CUgzQUigBQc1tj3/Kc9A7Lh96bebsSlPizaZrrXN3OYBuRowQiCym+5lauz3nDaLXAjTz98kHI9lujGoGaNJtQ==}
     peerDependencies:
       crossws: '>=0.3.4'
-      ws: '>=8.18.1'
+      fastify: '>=5.6.1'
     peerDependenciesMeta:
       crossws:
         optional: true
-      ws:
+      fastify:
         optional: true
 
-  '@orpc/shared@1.15.0':
-    resolution: {integrity: sha512-A3/JE7pQYSrrRm6/WYJxV3GBhpMdJRPM3h47slQtWBUZe9Sao5En5WBc4tISGQNP2emcez6qIvDziSgD2T+img==}
+  '@orpc/shared@2.0.0-beta.32':
+    resolution: {integrity: sha512-zxxkQAytfOfrT0yrOClngdsJzrbbbrTBgX8OCPYha5VPqYG8QUxMGMKT0DxS6yWhFEmlT7CdutYpqk/qvvn8hA==}
     peerDependencies:
       '@opentelemetry/api': '>=1.9.0'
     peerDependenciesMeta:
       '@opentelemetry/api':
         optional: true
 
-  '@orpc/standard-server-aws-lambda@1.15.0':
-    resolution: {integrity: sha512-laFW7C4t1gEV0NIt4EjCVCBU3kFPnj2FObJLQkTH+DkEOzxVy6zyJ1coIncDSeOPxzbf7rG8cs0B2vQQyuROag==}
-
-  '@orpc/standard-server-fastify@1.15.0':
-    resolution: {integrity: sha512-fcOl2004o3RnZxW7rhLuDCrCKSi/H2eWnyljeeoY+xykcygRf0ONCs2K2bSdxPm6cmvQGAXa9m8VBglG9oERVQ==}
+  '@orpc/tanstack-query@2.0.0-beta.32':
+    resolution: {integrity: sha512-gpt/uKeDbnRC1z6rh0Pb6JyM3J2Y4+Jq+Om3oa+OmvYBf56SiS7U+PEL7de7HVaoeKd+0AUkjhLSpamO0r7TxQ==}
     peerDependencies:
-      fastify: '>=5.6.1'
-    peerDependenciesMeta:
-      fastify:
-        optional: true
-
-  '@orpc/standard-server-fetch@1.15.0':
-    resolution: {integrity: sha512-XYVfgmIt71YrPJSI7RKRiNWjcyktPYHpevkjeohGNBP5aSMAUL95quZArAWr+XOPp4U56XRao54I6wFMZa4How==}
-
-  '@orpc/standard-server-node@1.15.0':
-    resolution: {integrity: sha512-3ye9SIIhYfJckQwyyGQQRHAEF5vW6QDbax7oi1mOQ9UBHaRDH5kcL28mT0JnETrUvgBoDRx+rfCsQaAOB4n3zw==}
-
-  '@orpc/standard-server-peer@1.15.0':
-    resolution: {integrity: sha512-fsTN+FrdPkseVx99yRenGJYSp0xOrEk9fODk8oh3zzricNYzlZ8GGgCYtDNgt9vFIR/J05dc+Nk76KhcPBQpLw==}
-
-  '@orpc/standard-server@1.15.0':
-    resolution: {integrity: sha512-bje/xn6thDqJY/JQ7xoOjmD1KWE4FsyZOPgnPxwqTZLx/r00stRhLuFvk1hDEGj9UlG7NLZEijDVx0wqvcyDzA==}
-
-  '@orpc/tanstack-query@1.15.0':
-    resolution: {integrity: sha512-Dp2JXqdmmRjBQu21Cq6oGBhxJF0Gel5ao5qMdOSYpVb5RjdqAEaXsDO9VMj1nEj6SseKGfm9pk10ZIskuI1jjg==}
-    peerDependencies:
-      '@orpc/client': 1.15.0
       '@tanstack/query-core': '>=5.80.2'
 
   '@oxc-project/types@0.147.0':
@@ -6482,6 +6484,32 @@ packages:
 
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
+
+  '@standardserver/aws-lambda@0.8.2':
+    resolution: {integrity: sha512-7ALbEEgCKdywwwc0uLr1/ZcsqZ/rzCebhV2zZdXVkutfJzxOwwpXFysvA/Jbhnhi3HPBgRxApHuWxx3j5wgRhw==}
+
+  '@standardserver/core@0.8.2':
+    resolution: {integrity: sha512-B5kGx4fm3PMaN0QNigeg5gul/bJM+fycuFK68SBwRMGKU55R4SGNv9ijtZbm/ZTbX1ZQ1r4xjOCheL6aO4HrHw==}
+
+  '@standardserver/fastify@0.8.2':
+    resolution: {integrity: sha512-jio9nXhdD0k4aC6k9/9n5BL2UvrhLINWmO8Na/ZuhtbDTRkfES4h+rKP2w5CFtbfFw//TcWZNC2m01GMOFRsGQ==}
+    peerDependencies:
+      fastify: '>=5.6.1'
+    peerDependenciesMeta:
+      fastify:
+        optional: true
+
+  '@standardserver/fetch@0.8.2':
+    resolution: {integrity: sha512-FQjsGQNRtnX1eXPFTOjTUp3k0Rwt0r51DIy/YgLTbMoTCBWNROU41HEiqBjOBusa2PKKEo/9oKiAtdySgL708w==}
+
+  '@standardserver/node@0.8.2':
+    resolution: {integrity: sha512-35lHa/Pdd+jOC7OhPHXKRp6199Iab0D+Am0BtqYfffByot1AYu0K5S8Ei5JvzoBKOgvLZ9BD73bkZxJugTShmg==}
+
+  '@standardserver/peer@0.8.2':
+    resolution: {integrity: sha512-kshztxLxMAkx5952oy1l8jKC2Q1QKjd4GBCCrHb/0B69hCy+x1/j5wcyzZphFc7kRCH8gxHAkC8k19ZZTnuIaA==}
+
+  '@standardserver/shared@0.8.2':
+    resolution: {integrity: sha512-6pe5pwnTwC6ALDxsRW4TJxuj8dS09sNj5dl1UkYf56kMSvTw7uRTS5c9iuFCy8e/M1aBP4uOntC8+OqAYMCa9g==}
 
   '@stitches/react@1.2.8':
     resolution: {integrity: sha512-9g9dWI4gsSVe8bNLlb+lMkBYsnIKCZTmvqvDG+Avnn69XfmHZKiaMrx7cgTaddq7aTPPmXiTsbFcUy0xgI4+wA==}
@@ -8705,6 +8733,10 @@ packages:
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
+
+  cookie@2.0.1:
+    resolution: {integrity: sha512-yuToqVvRrj6pfDXREyQAAv8SkAEk/8GS3jQRTiUMm66TVtBYmqQeoEjL2Lmq8Rpo6271vH76InTChTitEAm65w==}
+    engines: {node: '>=22'}
 
   copy-anything@4.1.0:
     resolution: {integrity: sha512-ufbM3smX/Jbnpk5wcQjzd1MgBpzmqfNETUAyZNrGwU9foRlyHoGzMMBBCRzEhQLBjZfFDE1W2ufPXX2vdWkV8Q==}
@@ -11974,9 +12006,6 @@ packages:
         optional: true
       zod:
         optional: true
-
-  openapi-types@12.1.3:
-    resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
 
   optics-ts@2.4.1:
     resolution: {integrity: sha512-HaYzMHvC80r7U/LqAd4hQyopDezC60PO2qF5GuIwALut2cl5rK1VWHsqTp0oqoJJWjiv6uXKqsO+Q2OO0C3MmQ==}
@@ -15443,6 +15472,12 @@ snapshots:
 
   '@hexagon/base64@1.1.28': {}
 
+  '@hey-api/spec-types@0.0.0-next-20260408030107':
+    dependencies:
+      '@hey-api/types': 0.1.4
+
+  '@hey-api/types@0.1.4': {}
+
   '@hono/react-renderer@1.0.1(hono@4.13.5)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       hono: 4.13.5
@@ -16326,125 +16361,108 @@ snapshots:
 
   '@opentelemetry/semantic-conventions@1.43.0': {}
 
-  '@orpc/client@1.15.0(@opentelemetry/api@1.9.1)':
+  '@orpc/client@2.0.0-beta.32(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@orpc/shared': 1.15.0(@opentelemetry/api@1.9.1)
-      '@orpc/standard-server': 1.15.0(@opentelemetry/api@1.9.1)
-      '@orpc/standard-server-fetch': 1.15.0(@opentelemetry/api@1.9.1)
-      '@orpc/standard-server-peer': 1.15.0(@opentelemetry/api@1.9.1)
+      '@orpc/shared': 2.0.0-beta.32(@opentelemetry/api@1.9.1)
+      '@standardserver/core': 0.8.2
+      '@standardserver/fetch': 0.8.2
+      '@standardserver/peer': 0.8.2
     transitivePeerDependencies:
       - '@opentelemetry/api'
 
-  '@orpc/contract@1.15.0(@opentelemetry/api@1.9.1)':
+  '@orpc/contract@2.0.0-beta.32(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@orpc/client': 1.15.0(@opentelemetry/api@1.9.1)
-      '@orpc/shared': 1.15.0(@opentelemetry/api@1.9.1)
+      '@orpc/client': 2.0.0-beta.32(@opentelemetry/api@1.9.1)
+      '@orpc/shared': 2.0.0-beta.32(@opentelemetry/api@1.9.1)
       '@standard-schema/spec': 1.1.0
-      openapi-types: 12.1.3
     transitivePeerDependencies:
       - '@opentelemetry/api'
 
-  '@orpc/interop@1.15.0': {}
-
-  '@orpc/server@1.15.0(@opentelemetry/api@1.9.1)(crossws@0.4.12(srvx@0.11.22))(ws@8.21.3)':
+  '@orpc/json-schema@2.0.0-beta.32(@opentelemetry/api@1.9.1)(crossws@0.4.12(srvx@0.12.7))':
     dependencies:
-      '@orpc/client': 1.15.0(@opentelemetry/api@1.9.1)
-      '@orpc/contract': 1.15.0(@opentelemetry/api@1.9.1)
-      '@orpc/interop': 1.15.0
-      '@orpc/shared': 1.15.0(@opentelemetry/api@1.9.1)
-      '@orpc/standard-server': 1.15.0(@opentelemetry/api@1.9.1)
-      '@orpc/standard-server-aws-lambda': 1.15.0(@opentelemetry/api@1.9.1)
-      '@orpc/standard-server-fastify': 1.15.0(@opentelemetry/api@1.9.1)
-      '@orpc/standard-server-fetch': 1.15.0(@opentelemetry/api@1.9.1)
-      '@orpc/standard-server-node': 1.15.0(@opentelemetry/api@1.9.1)
-      '@orpc/standard-server-peer': 1.15.0(@opentelemetry/api@1.9.1)
-      cookie: 1.1.1
+      '@orpc/client': 2.0.0-beta.32(@opentelemetry/api@1.9.1)
+      '@orpc/contract': 2.0.0-beta.32(@opentelemetry/api@1.9.1)
+      '@orpc/server': 2.0.0-beta.32(@opentelemetry/api@1.9.1)(crossws@0.4.12(srvx@0.12.7))
+      '@orpc/shared': 2.0.0-beta.32(@opentelemetry/api@1.9.1)
+      '@standard-schema/spec': 1.1.0
+      json-schema-typed: 8.0.2
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - crossws
+      - fastify
+
+  '@orpc/openapi@2.0.0-beta.32(@opentelemetry/api@1.9.1)(crossws@0.4.12(srvx@0.12.7))':
+    dependencies:
+      '@hey-api/spec-types': 0.0.0-next-20260408030107
+      '@orpc/client': 2.0.0-beta.32(@opentelemetry/api@1.9.1)
+      '@orpc/contract': 2.0.0-beta.32(@opentelemetry/api@1.9.1)
+      '@orpc/json-schema': 2.0.0-beta.32(@opentelemetry/api@1.9.1)(crossws@0.4.12(srvx@0.12.7))
+      '@orpc/server': 2.0.0-beta.32(@opentelemetry/api@1.9.1)(crossws@0.4.12(srvx@0.12.7))
+      '@orpc/shared': 2.0.0-beta.32(@opentelemetry/api@1.9.1)
+      '@standardserver/core': 0.8.2
+      '@standardserver/fetch': 0.8.2
+      rou3: 0.9.2
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - crossws
+      - fastify
+
+  '@orpc/server@2.0.0-beta.32(@opentelemetry/api@1.9.1)(crossws@0.4.12(srvx@0.11.22))':
+    dependencies:
+      '@orpc/client': 2.0.0-beta.32(@opentelemetry/api@1.9.1)
+      '@orpc/contract': 2.0.0-beta.32(@opentelemetry/api@1.9.1)
+      '@orpc/shared': 2.0.0-beta.32(@opentelemetry/api@1.9.1)
+      '@standardserver/aws-lambda': 0.8.2
+      '@standardserver/core': 0.8.2
+      '@standardserver/fastify': 0.8.2
+      '@standardserver/fetch': 0.8.2
+      '@standardserver/node': 0.8.2
+      '@standardserver/peer': 0.8.2
+      cookie: 2.0.1
     optionalDependencies:
       crossws: 0.4.12(srvx@0.11.22)
-      ws: 8.21.3
     transitivePeerDependencies:
       - '@opentelemetry/api'
-      - fastify
 
-  '@orpc/server@1.15.0(@opentelemetry/api@1.9.1)(crossws@0.4.12(srvx@0.12.7))(ws@8.21.3)':
+  '@orpc/server@2.0.0-beta.32(@opentelemetry/api@1.9.1)(crossws@0.4.12(srvx@0.12.7))':
     dependencies:
-      '@orpc/client': 1.15.0(@opentelemetry/api@1.9.1)
-      '@orpc/contract': 1.15.0(@opentelemetry/api@1.9.1)
-      '@orpc/interop': 1.15.0
-      '@orpc/shared': 1.15.0(@opentelemetry/api@1.9.1)
-      '@orpc/standard-server': 1.15.0(@opentelemetry/api@1.9.1)
-      '@orpc/standard-server-aws-lambda': 1.15.0(@opentelemetry/api@1.9.1)
-      '@orpc/standard-server-fastify': 1.15.0(@opentelemetry/api@1.9.1)
-      '@orpc/standard-server-fetch': 1.15.0(@opentelemetry/api@1.9.1)
-      '@orpc/standard-server-node': 1.15.0(@opentelemetry/api@1.9.1)
-      '@orpc/standard-server-peer': 1.15.0(@opentelemetry/api@1.9.1)
-      cookie: 1.1.1
+      '@orpc/client': 2.0.0-beta.32(@opentelemetry/api@1.9.1)
+      '@orpc/contract': 2.0.0-beta.32(@opentelemetry/api@1.9.1)
+      '@orpc/shared': 2.0.0-beta.32(@opentelemetry/api@1.9.1)
+      '@standardserver/aws-lambda': 0.8.2
+      '@standardserver/core': 0.8.2
+      '@standardserver/fastify': 0.8.2
+      '@standardserver/fetch': 0.8.2
+      '@standardserver/node': 0.8.2
+      '@standardserver/peer': 0.8.2
+      cookie: 2.0.1
     optionalDependencies:
       crossws: 0.4.12(srvx@0.12.7)
-      ws: 8.21.3
     transitivePeerDependencies:
       - '@opentelemetry/api'
-      - fastify
 
-  '@orpc/shared@1.15.0(@opentelemetry/api@1.9.1)':
+  '@orpc/shared@2.0.0-beta.32(@opentelemetry/api@1.9.1)':
     dependencies:
+      '@standardserver/shared': 0.8.2
       radash: 12.1.1
       type-fest: 5.8.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
 
-  '@orpc/standard-server-aws-lambda@1.15.0(@opentelemetry/api@1.9.1)':
+  '@orpc/tanstack-query@2.0.0-beta.32(@opentelemetry/api@1.9.1)(@tanstack/query-core@5.102.8)(crossws@0.4.12(srvx@0.12.7))':
     dependencies:
-      '@orpc/shared': 1.15.0(@opentelemetry/api@1.9.1)
-      '@orpc/standard-server': 1.15.0(@opentelemetry/api@1.9.1)
-      '@orpc/standard-server-fetch': 1.15.0(@opentelemetry/api@1.9.1)
-      '@orpc/standard-server-node': 1.15.0(@opentelemetry/api@1.9.1)
-    transitivePeerDependencies:
-      - '@opentelemetry/api'
-
-  '@orpc/standard-server-fastify@1.15.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@orpc/shared': 1.15.0(@opentelemetry/api@1.9.1)
-      '@orpc/standard-server': 1.15.0(@opentelemetry/api@1.9.1)
-      '@orpc/standard-server-node': 1.15.0(@opentelemetry/api@1.9.1)
-    transitivePeerDependencies:
-      - '@opentelemetry/api'
-
-  '@orpc/standard-server-fetch@1.15.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@orpc/shared': 1.15.0(@opentelemetry/api@1.9.1)
-      '@orpc/standard-server': 1.15.0(@opentelemetry/api@1.9.1)
-    transitivePeerDependencies:
-      - '@opentelemetry/api'
-
-  '@orpc/standard-server-node@1.15.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@orpc/shared': 1.15.0(@opentelemetry/api@1.9.1)
-      '@orpc/standard-server': 1.15.0(@opentelemetry/api@1.9.1)
-      '@orpc/standard-server-fetch': 1.15.0(@opentelemetry/api@1.9.1)
-    transitivePeerDependencies:
-      - '@opentelemetry/api'
-
-  '@orpc/standard-server-peer@1.15.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@orpc/shared': 1.15.0(@opentelemetry/api@1.9.1)
-      '@orpc/standard-server': 1.15.0(@opentelemetry/api@1.9.1)
-    transitivePeerDependencies:
-      - '@opentelemetry/api'
-
-  '@orpc/standard-server@1.15.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@orpc/shared': 1.15.0(@opentelemetry/api@1.9.1)
-    transitivePeerDependencies:
-      - '@opentelemetry/api'
-
-  '@orpc/tanstack-query@1.15.0(@opentelemetry/api@1.9.1)(@orpc/client@1.15.0(@opentelemetry/api@1.9.1))(@tanstack/query-core@5.102.8)':
-    dependencies:
-      '@orpc/client': 1.15.0(@opentelemetry/api@1.9.1)
-      '@orpc/shared': 1.15.0(@opentelemetry/api@1.9.1)
+      '@orpc/client': 2.0.0-beta.32(@opentelemetry/api@1.9.1)
+      '@orpc/contract': 2.0.0-beta.32(@opentelemetry/api@1.9.1)
+      '@orpc/openapi': 2.0.0-beta.32(@opentelemetry/api@1.9.1)(crossws@0.4.12(srvx@0.12.7))
+      '@orpc/shared': 2.0.0-beta.32(@opentelemetry/api@1.9.1)
       '@tanstack/query-core': 5.102.8
     transitivePeerDependencies:
       - '@opentelemetry/api'
+      - '@scalar/api-reference'
+      - '@types/swagger-ui'
+      - crossws
+      - fastify
+      - swagger-ui
 
   '@oxc-project/types@0.147.0': {}
 
@@ -18097,6 +18115,40 @@ snapshots:
   '@standard-schema/spec@1.1.0': {}
 
   '@standard-schema/utils@0.3.0': {}
+
+  '@standardserver/aws-lambda@0.8.2':
+    dependencies:
+      '@standardserver/core': 0.8.2
+      '@standardserver/fetch': 0.8.2
+      '@standardserver/node': 0.8.2
+      '@standardserver/shared': 0.8.2
+
+  '@standardserver/core@0.8.2':
+    dependencies:
+      '@standardserver/shared': 0.8.2
+
+  '@standardserver/fastify@0.8.2':
+    dependencies:
+      '@standardserver/core': 0.8.2
+      '@standardserver/node': 0.8.2
+
+  '@standardserver/fetch@0.8.2':
+    dependencies:
+      '@standardserver/core': 0.8.2
+      '@standardserver/shared': 0.8.2
+
+  '@standardserver/node@0.8.2':
+    dependencies:
+      '@standardserver/core': 0.8.2
+      '@standardserver/fetch': 0.8.2
+      '@standardserver/shared': 0.8.2
+
+  '@standardserver/peer@0.8.2':
+    dependencies:
+      '@standardserver/core': 0.8.2
+      '@standardserver/shared': 0.8.2
+
+  '@standardserver/shared@0.8.2': {}
 
   '@stitches/react@1.2.8(react@19.2.8)':
     dependencies:
@@ -20788,6 +20840,8 @@ snapshots:
   cookie@0.7.2: {}
 
   cookie@1.1.1: {}
+
+  cookie@2.0.1: {}
 
   copy-anything@4.1.0: {}
 
@@ -24848,8 +24902,6 @@ snapshots:
       undici: 7.29.0
       ws: 8.21.3
       zod: 4.5.4
-
-  openapi-types@12.1.3: {}
 
   optics-ts@2.4.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -104,10 +104,10 @@ catalogs:
     "@next/third-parties": 16.3.3
     next: 16.3.3
   orpc:
-    "@orpc/client": 1.15.0
-    "@orpc/contract": 1.15.0
-    "@orpc/server": 1.15.0
-    "@orpc/tanstack-query": 1.15.0
+    "@orpc/client": 2.0.0-beta.32
+    "@orpc/contract": 2.0.0-beta.32
+    "@orpc/server": 2.0.0-beta.32
+    "@orpc/tanstack-query": 2.0.0-beta.32
   oxc:
     "@oxlint/plugins": 1.80.0
     oxfmt: 0.65.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * API-key lists now refresh consistently after creating a key, including global and project-specific views.
  * Pruning RAG content now completes reliably from the maintenance controls.
  * Quota-exceeded responses now return the correct payment-required status.
  * Current playback and link-preview settings now consistently enforce required refresh and request behavior.

* **Refactor**
  * Improved RPC communication and error handling for more consistent responses across the dashboard, website, and service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->