### PR TITLE
feat: bump Pi to `0.85.1`

### DIFF
--- a/docs/agent-architecture.md
+++ b/docs/agent-architecture.md
@@ -2,7 +2,7 @@
 
 > Status: as-built
 >
-> Last updated: 2026-09-04
+> Last updated: 2026-09-06
 >
 > 中文版：[docs/agent-architecture.zh.md](./agent-architecture.zh.md)
 >
@@ -72,7 +72,7 @@ The public kind has only the shared content-read tools, no approval tier, web ac
 
 The transcript is a tree. `agent.session_entry.parentId` links a branch and `agent.session.leafEntryId` selects the active leaf. `seq` records persistence order across all branches and is safe because each session has one writer at a time.
 
-`PgSessionStorage` implements the runtime's `SessionTree`; tests use `InMemorySessionTree`. Pi session entries are stored as opaque JSON, and retired entry types are ignored rather than migrated. Kind-specific state uses extension tables instead of nullable columns on the shared session row.
+`PgSessionStorage` implements the runtime's `SessionTree`; tests use `InMemorySessionTree`. The runtime owns the entry types and the context projection; both mirror Pi's so a branch reads exactly as it would under Pi's harness. Session entries are stored as opaque JSON, and retired entry types are ignored rather than migrated. Kind-specific state uses extension tables instead of nullable columns on the shared session row.
 
 ```text
 agent.session            kind, settings and active leaf
@@ -368,7 +368,33 @@ Admin writes are validated against their code definition before persistence. API
 
 Do not add an engine adapter, capability plugin system or provider-neutral handle until a second execution engine creates a concrete requirement.
 
-## 12. Reference map
+## 12. Pi's durable harness
+
+Pi 0.85 ships a second execution path beside the `Agent` class: `createAgentHarness`, a durable operation runtime over its own storage contract. This runtime does not use it. The note below records why, and what an integration would look like, so the next Pi upgrade can re-evaluate instead of re-deriving.
+
+The harness is designed to be host-scheduled. Its lane API reduces to four durable primitives, and each maps onto a seam this runtime already has:
+
+| Harness primitive  | This runtime                                                          |
+| ------------------ | --------------------------------------------------------------------- |
+| `accept`           | `agent.run` creation and workflow start or hook resume under the lock |
+| `drive`            | `runAgentTurnStep`                                                    |
+| `requestAbort`     | The per-run abort-controller workflow                                 |
+| `inspectExecution` | Turn-marker reconciliation against the Workflow World                 |
+
+`drive` returns `settled`, `waiting: retry` with `notBefore`, or `waiting: deferred` with a poll interval, so provider retries and deferred responses become workflow sleeps rather than in-process waits.
+
+What an integration would change:
+
+- Every transition rewrites the complete operation state, so a turn step becomes resumable and `maxRetries = 0` can go.
+- Tool calls get intent, effect and settlement commits, `replay: "safe" | "never"` and invocation-scoped memos; assistant stream frames are persisted for partial recovery.
+- `message_end` carries the entry id, replacing the reserved-id handshake in `runPiTurn`; `LaneSnapshot` with `reduceLaneSnapshot` replaces the coarse and delta stream cursor for reconnect.
+- The approval handshake is unchanged: the `before_tool` hook blocks with `terminate` exactly as the tool gate does now.
+- A Postgres `Storage` and `SessionRepo` must be written; upstream ships only Memory, JSONL and SQLite. `@earendil-works/pi-agent-core/harness/session/testing` exports the conformance suites to validate one. Entries already match Pi's union; values, lists and the harness usage ledger are new tables.
+- Most of `packages/agent-runtime/src/pi/` is replaced by lane calls. `AgentWireEvent` stays the client boundary with a mapper over `HarnessEvent`.
+
+Do not start until all of these hold upstream: the storage format is declared stable with a migration mechanism (its spec marks format 4 as pre-stabilization, changeable in place), `Storage` interface changes appear in the changelog, and the open harness work packages (forks, `watchSession`, remote mutation transport) are closed. Then write the Postgres backend against the conformance suite first and swap `runAgentTurnStep` to `accept` plus `drive` second.
+
+## 13. Reference map
 
 | Concern                               | Location                                                                                              |
 | ------------------------------------- | ----------------------------------------------------------------------------------------------------- |

--- a/docs/agent-architecture.zh.md
+++ b/docs/agent-architecture.zh.md
@@ -2,7 +2,7 @@
 
 > 狀態：as-built
 >
-> 最後更新：2026-09-01
+> 最後更新：2026-09-06
 >
 > English: [docs/agent-architecture.md](./agent-architecture.md)
 >
@@ -72,7 +72,7 @@ Public kind 只有共用 content-read tools，沒有 approval tier、web、memor
 
 Transcript 是一棵樹。`agent.session_entry.parentId` 連接 branch，`agent.session.leafEntryId` 選擇 active leaf。`seq` 記錄所有 branch 的持久化順序；每個 session 同時只有一個 writer，因此此順序可靠。
 
-`PgSessionStorage` 實作 runtime 的 `SessionTree`，測試使用 `InMemorySessionTree`。Pi session entry 以 opaque JSON 保存；已淘汰的 entry type 直接忽略，不做資料 migration。Kind-specific state 使用 extension table，不在共用 session row 增加大量 nullable columns。
+`PgSessionStorage` 實作 runtime 的 `SessionTree`，測試使用 `InMemorySessionTree`。Entry type 與 context projection 由 runtime 自己持有，兩者都鏡射 Pi 的定義，因此 branch 讀起來與在 Pi harness 下完全一致。Session entry 以 opaque JSON 保存；已淘汰的 entry type 直接忽略，不做資料 migration。Kind-specific state 使用 extension table，不在共用 session row 增加大量 nullable columns。
 
 ```text
 agent.session            kind、settings、active leaf
@@ -366,7 +366,33 @@ Admin write 在持久化前先依 code definition 驗證。API view 回傳 `defa
 
 在第二種 execution engine 形成具體需求前，不新增 engine adapter、capability plugin system 或 provider-neutral handle。
 
-## 12. 參考位置
+## 12. Pi 的 durable harness
+
+Pi 0.85 在 `Agent` class 之外另有一條執行路徑：`createAgentHarness`，一個建立在自有 storage contract 上的 durable operation runtime。本 runtime 沒有採用。這裡記下原因與整合的樣貌，讓下一次升 Pi 時能直接重新評估，不必重推一遍。
+
+Harness 本身就是為 host 排程設計的。Lane API 收斂成四個 durable primitive，每一個都對得上本 runtime 既有的 seam：
+
+| Harness primitive  | 本 runtime                                             |
+| ------------------ | ------------------------------------------------------ |
+| `accept`           | 在 lock 下建立 `agent.run` 並啟動 workflow 或喚醒 hook |
+| `drive`            | `runAgentTurnStep`                                     |
+| `requestAbort`     | 每個 run 的 abort-controller workflow                  |
+| `inspectExecution` | 對 Workflow World 做 turn-marker reconcile             |
+
+`drive` 回傳 `settled`、帶 `notBefore` 的 `waiting: retry`，或帶 poll 間隔的 `waiting: deferred`，因此 provider retry 與 deferred response 會變成 workflow sleep，而不是 process 內的等待。
+
+整合會改變的事：
+
+- 每次 transition 都重寫完整的 operation state，turn step 因此可以續跑，`maxRetries = 0` 可以拿掉。
+- Tool call 有 intent、effect、settlement 三段 commit，可宣告 `replay: "safe" | "never"` 與 invocation-scoped memo；assistant 串流 frame 會落地，供 partial 回復。
+- `message_end` 直接帶 entry id，取代 `runPiTurn` 裡預留 id 的對齊手法；`LaneSnapshot` 配合 `reduceLaneSnapshot` 取代 coarse 與 delta stream cursor 的 reconnect 機制。
+- Approval handshake 不變：`before_tool` hook 的 `block` 加 `terminate` 與現在的 tool gate 完全相同。
+- 必須自寫 Postgres 的 `Storage` 與 `SessionRepo`；上游只出貨 Memory、JSONL 與 SQLite。`@earendil-works/pi-agent-core/harness/session/testing` 匯出 conformance suite 可用來驗證。Entry 已與 Pi 的 union 一致；values、lists 與 harness 自己的 usage ledger 是新表。
+- `packages/agent-runtime/src/pi/` 大半被 lane 呼叫取代。`AgentWireEvent` 仍是 client 邊界，只是 mapper 改吃 `HarnessEvent`。
+
+以下條件在上游全部成立之前不要啟動：storage format 宣告穩定並具備 migration 機制（規格目前標記 format 4 為 pre-stabilization，可原地改形狀）、`Storage` 介面變更開始進 changelog、未完成的 harness work package（fork、`watchSession`、remote mutation transport）收尾。屆時先依 conformance suite 寫 Postgres backend，再把 `runAgentTurnStep` 換成 `accept` 加 `drive`。
+
+## 13. 參考位置
 
 | Concern                               | Location                                                                                              |
 | ------------------------------------- | ----------------------------------------------------------------------------------------------------- |

--- a/packages/agent-runtime/__tests__/events.test.ts
+++ b/packages/agent-runtime/__tests__/events.test.ts
@@ -191,6 +191,7 @@ describe("foldEvents", () => {
         timestamp: 1_767_225_601_000,
         fromId: "entry-1",
         summary: "A tangent about titles, abandoned.",
+        fromHook: false,
       },
     ];
 

--- a/packages/agent-runtime/__tests__/pg-storage.test.ts
+++ b/packages/agent-runtime/__tests__/pg-storage.test.ts
@@ -120,7 +120,7 @@ describe("PgSessionStorage", () => {
     await expect(storage().getLeafId()).resolves.toBe("entry-2");
   });
 
-  it("projects rows back into entries with their seq, a numeric timestamp and a tail on compactions", async () => {
+  it("projects rows back into entries with their seq, a numeric timestamp, and a tail and hook flag on compactions", async () => {
     getEntriesMock.mockResolvedValue(
       /* SAFETY: These rows implement the repository shape exercised by this case. */ [
         row(1, "entry-1", null, "compaction", {
@@ -141,6 +141,7 @@ describe("PgSessionStorage", () => {
       summary: "Summary",
       tokensBefore: 10,
       retainedTail: [],
+      fromHook: false,
     });
   });
 

--- a/packages/agent-runtime/__tests__/pi-maintenance.test.ts
+++ b/packages/agent-runtime/__tests__/pi-maintenance.test.ts
@@ -225,6 +225,7 @@ describe("navigatePiSession", () => {
       summary: "The first exchange, condensed.",
       tokensBefore: 10,
       retainedTail: [],
+      fromHook: false,
     });
     await session.appendEntry(user("u3", "c1", "Third question"));
     await session.appendEntry(assistant("a3", "u3", "Third answer"));
@@ -247,7 +248,7 @@ describe("navigatePiSession", () => {
     expect(leaf).toMatchObject({
       type: "branch_summary",
       parentId: null,
-      fromId: "root",
+      fromId: null,
     });
   });
 

--- a/packages/agent-runtime/__tests__/session-context.test.ts
+++ b/packages/agent-runtime/__tests__/session-context.test.ts
@@ -32,18 +32,19 @@ const user = (
 const assistant = (
   id: string,
   parentId: string | null,
-  text: string
+  text: string,
+  message = fauxAssistantMessage(text, { timestamp: 2 })
 ): SessionEntry => ({
   type: "message",
   id,
   parentId,
   seq: ++seq,
   timestamp: 2,
-  message: fauxAssistantMessage(text, { timestamp: 2 }),
+  message,
 });
 
 const serialize = (entries: readonly SessionEntry[]) =>
-  JSON.stringify(buildBranchContext(entries).messages);
+  JSON.stringify(buildBranchContext(entries));
 
 describe("buildBranchContext", () => {
   it("is deterministic for the same branch", () => {
@@ -55,11 +56,11 @@ describe("buildBranchContext", () => {
     const session = new InMemorySessionTree("s");
     await session.appendEntry(user("u1", null, "Hi"));
     await session.appendEntry(assistant("a1", "u1", "Hello"));
-    const before = buildBranchContext(await session.getBranch()).messages;
+    const before = buildBranchContext(await session.getBranch());
 
     await session.appendEntry(user("u2", "a1", "More"));
     await session.appendEntry(assistant("a2", "u2", "Sure"));
-    const after = buildBranchContext(await session.getBranch()).messages;
+    const after = buildBranchContext(await session.getBranch());
 
     expect(JSON.stringify(after.slice(0, before.length))).toBe(
       JSON.stringify(before)
@@ -87,13 +88,58 @@ describe("buildBranchContext", () => {
         timestamp: 4,
         name: "old",
       } as never,
-      assistant("a1", "s1", "Hello"),
+      /* SAFETY: A settings row Pi 0.85 no longer models; earlier releases wrote it. */ {
+        type: "active_tools_change",
+        id: "t1",
+        parentId: "s1",
+        seq: ++seq,
+        timestamp: 5,
+        activeToolNames: ["read_post"],
+      } as never,
+      assistant("a1", "t1", "Hello"),
     ];
 
-    expect(buildBranchContext(branch).messages.map((m) => m.role)).toEqual([
+    expect(buildBranchContext(branch).map((message) => message.role)).toEqual([
       "user",
       "assistant",
     ]);
+  });
+
+  it("drops replies the provider never completed, in the branch and in a retained tail", () => {
+    const aborted = fauxAssistantMessage("Half an ans", {
+      stopReason: "aborted",
+      timestamp: 3,
+    });
+    const failed = fauxAssistantMessage("", {
+      stopReason: "error",
+      errorMessage: "overloaded",
+      timestamp: 4,
+    });
+    const branch: SessionEntry[] = [
+      user("u1", null, "Hi"),
+      assistant("a1", "u1", "", aborted),
+      user("u2", "a1", "Again"),
+      assistant("a2", "u2", "", failed),
+      {
+        type: "compaction",
+        id: "c1",
+        parentId: "a2",
+        seq: ++seq,
+        timestamp: 5,
+        summary: "Condensed.",
+        tokensBefore: 1_000,
+        retainedTail: [aborted, fauxAssistantMessage("Done", { timestamp: 6 })],
+        fromHook: false,
+      },
+      user("u3", "c1", "More"),
+      assistant("a3", "u3", "", aborted),
+    ];
+
+    expect(
+      buildBranchContext(branch).map((message) =>
+        message.role === "assistant" ? message.stopReason : message.role
+      )
+    ).toEqual(["compactionSummary", "stop", "user"]);
   });
 
   it("projects a compaction as its summary plus the retained tail, dropping what came before", () => {
@@ -110,16 +156,17 @@ describe("buildBranchContext", () => {
         summary: "Everything so far.",
         tokensBefore: 90_000,
         retainedTail: [retained],
+        fromHook: false,
       },
       user("u2", "c1", "After"),
     ];
 
-    const messages = buildBranchContext(branch).messages;
+    const messages = buildBranchContext(branch);
 
     expect(JSON.stringify(messages)).toContain("Everything so far.");
     expect(JSON.stringify(messages)).not.toContain("Forgotten");
     // Pi projects the summary as its own message role ahead of the retained tail.
-    expect(messages.map((m) => m.role)).toEqual([
+    expect(messages.map((message) => message.role)).toEqual([
       "compactionSummary",
       "assistant",
       "user",

--- a/packages/agent-runtime/__tests__/session-tree.test.ts
+++ b/packages/agent-runtime/__tests__/session-tree.test.ts
@@ -26,6 +26,7 @@ const compaction = (id: string, parentId: string): SessionEntry => {
     summary: "Condensed.",
     tokensBefore: 50_000,
     retainedTail: [],
+    fromHook: false,
   };
 };
 

--- a/packages/agent-runtime/src/pi/compaction.ts
+++ b/packages/agent-runtime/src/pi/compaction.ts
@@ -1,8 +1,10 @@
 import {
+  BACKGROUND_CONTEXT,
   compact,
   DEFAULT_COMPACTION_SETTINGS,
   prepareCompaction,
   shouldCompact,
+  withAbortSignal,
 } from "@earendil-works/pi-agent-core";
 import type {
   CompactionPreparation,
@@ -97,8 +99,10 @@ const compactBranch = async (
     models,
     model,
     customInstructions,
-    signal,
-    thinkingLevel
+    thinkingLevel,
+    undefined,
+    undefined,
+    signal ? withAbortSignal(signal, BACKGROUND_CONTEXT) : BACKGROUND_CONTEXT
   );
   if (!compacted.ok) throw compacted.error;
   const result = compacted.value;
@@ -115,6 +119,7 @@ const compactBranch = async (
     retainedTail: result.retainedTail ?? [],
     details: result.details,
     usage: result.usage,
+    fromHook: false,
   };
   await session.appendEntry(entry);
   if (result.usage) {

--- a/packages/agent-runtime/src/pi/maintenance.ts
+++ b/packages/agent-runtime/src/pi/maintenance.ts
@@ -1,4 +1,8 @@
-import { generateBranchSummary } from "@earendil-works/pi-agent-core";
+import {
+  BACKGROUND_CONTEXT,
+  generateBranchSummary,
+  withAbortSignal,
+} from "@earendil-works/pi-agent-core";
 import type { Api, Model, Models } from "@earendil-works/pi-ai";
 
 import type {
@@ -74,11 +78,13 @@ export const navigatePiSession = async (
   if (options.summarize) {
     const entries = await entriesLeftBehind(session, oldLeafId, entryId);
     if (entries.length > 0) {
-      const generated = await generateBranchSummary(contextEntries(entries), {
-        models,
-        model,
-        signal: signal ?? new AbortController().signal,
-      });
+      const generated = await generateBranchSummary(
+        contextEntries(entries),
+        { models, model },
+        signal
+          ? withAbortSignal(signal, BACKGROUND_CONTEXT)
+          : BACKGROUND_CONTEXT
+      );
       if (!generated.ok) {
         if (generated.error.code === "aborted") return { cancelled: true };
         throw generated.error;
@@ -111,7 +117,8 @@ export const navigatePiSession = async (
       id: session.newEntryId(),
       parentId: newLeafId,
       timestamp: Date.now(),
-      fromId: newLeafId ?? "root",
+      fromId: newLeafId,
+      fromHook: false,
       ...summary,
     };
     await session.appendEntry(entry);

--- a/packages/agent-runtime/src/pi/turn.ts
+++ b/packages/agent-runtime/src/pi/turn.ts
@@ -273,7 +273,7 @@ export const runPiTurn = async <TContext extends object, TApproval>({
         model,
         thinkingLevel,
         tools: bindToolContext(activeTools, toolContext),
-        messages: buildBranchContext(branch).messages,
+        messages: buildBranchContext(branch),
       },
       // Bound to this turn's collection rather than a process-wide default: the collection
       // carries the operator's own credentials, and a default would let a BYOK turn fall back

--- a/packages/agent-runtime/src/session/context.ts
+++ b/packages/agent-runtime/src/session/context.ts
@@ -1,17 +1,63 @@
-import { buildSessionContext } from "@earendil-works/pi-agent-core";
-import type { SessionContext } from "@earendil-works/pi-agent-core";
+import {
+  createBranchSummaryMessage,
+  createCompactionSummaryMessage,
+} from "@earendil-works/pi-agent-core";
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
 
-import type { SessionEntry } from "./entries.ts";
+import type { ContextEntry, SessionEntry } from "./entries.ts";
 import { contextEntries } from "./entries.ts";
 
 /**
- * Projects a branch into what the model sees: compaction summaries with their retained tail,
- * branch summaries, and the messages after them, plus the settings the branch recorded.
+ * Projects a branch into what the model sees: the newest compaction as its summary and retained
+ * tail, branch summaries, and the messages after them.
  *
- * The projection is Pi's own so the transcript reads as it did under Pi's harness. It must stay
- * deterministic: a turn's provider request is the previous projection plus the entries it
- * appended, and any drift between the two breaks the provider's cached prefix.
+ * Mirrors Pi's own projection, which 0.85 keeps internal to its harness, so the transcript reads
+ * as it would under Pi. It must stay deterministic: a turn's provider request is the previous
+ * projection plus the entries it appended, and any drift between the two breaks the provider's
+ * cached prefix.
  */
 export const buildBranchContext = (
   entries: readonly SessionEntry[]
-): SessionContext => buildSessionContext(contextEntries(entries));
+): AgentMessage[] =>
+  fromNewestCompaction(contextEntries(entries)).flatMap(messagesOf);
+
+/** Everything before the newest compaction is what its summary replaces. */
+const fromNewestCompaction = (entries: ContextEntry[]): ContextEntry[] => {
+  const index = entries.findLastIndex((entry) => entry.type === "compaction");
+  return index === -1 ? entries : entries.slice(index);
+};
+
+/** A reply the provider never completed carries nothing the model should read back. */
+const isContextMessage = (message: AgentMessage): boolean =>
+  message.role !== "assistant" ||
+  (message.stopReason !== "error" &&
+    message.stopReason !== "aborted" &&
+    message.stopReason !== "deferred");
+
+const messagesOf = (entry: ContextEntry): AgentMessage[] => {
+  switch (entry.type) {
+    case "message":
+      return isContextMessage(entry.message) ? [entry.message] : [];
+    case "compaction":
+      return [
+        createCompactionSummaryMessage(
+          entry.summary,
+          entry.tokensBefore,
+          entry.timestamp
+        ),
+        ...entry.retainedTail.filter(isContextMessage),
+      ];
+    case "branch_summary":
+      return entry.summary
+        ? [
+            createBranchSummaryMessage(
+              entry.summary,
+              entry.fromId,
+              entry.timestamp
+            ),
+          ]
+        : [];
+    case "custom":
+      return [];
+  }
+};

--- a/packages/agent-runtime/src/session/entries.ts
+++ b/packages/agent-runtime/src/session/entries.ts
@@ -1,4 +1,4 @@
-import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import type { AgentMessage, JsonValue } from "@earendil-works/pi-agent-core";
 import type { Usage } from "@earendil-works/pi-ai";
 
 import type { AgentAttachment } from "../types.ts";
@@ -7,7 +7,7 @@ import type { AgentAttachment } from "../types.ts";
  * The persisted session tree, owned here rather than imported from Pi.
  *
  * Discriminants and payload fields match Pi's own entry union, so rows in `agent.session_entry`
- * read back unchanged and Pi's context projection accepts these entries structurally. `label`
+ * read back unchanged and Pi's compaction helpers accept these entries structurally. `label`
  * is the one entry Pi no longer models as a tree node; it stays one here because that is where
  * the rows already live and a navigation label is a tree event.
  */
@@ -42,38 +42,26 @@ export interface CompactionEntry extends SessionEntryBase {
   tokensBefore: number;
   /** Recent messages kept verbatim after the summary. Always an array once persisted. */
   retainedTail: AgentMessage[];
-  details?: unknown;
+  details?: JsonValue;
   usage?: Usage;
+  /** Whether a Pi hook wrote the entry. Always `false` here: the runtime writes every entry itself. */
+  fromHook: boolean;
 }
 
 export interface BranchSummaryEntry extends SessionEntryBase {
   type: "branch_summary";
-  fromId: string;
+  /** The leaf the session moved to when the branch was left; `null` at the root. */
+  fromId: string | null;
   summary: string;
-  details?: unknown;
+  details?: JsonValue;
   usage?: Usage;
-}
-
-export interface ModelChangeEntry extends SessionEntryBase {
-  type: "model_change";
-  provider: string;
-  modelId: string;
-}
-
-export interface ThinkingLevelEntry extends SessionEntryBase {
-  type: "thinking_level_change";
-  thinkingLevel: string;
-}
-
-export interface ActiveToolsEntry extends SessionEntryBase {
-  type: "active_tools_change";
-  activeToolNames: string[];
+  fromHook: boolean;
 }
 
 export interface CustomEntry extends SessionEntryBase {
   type: "custom";
   customType: string;
-  data?: unknown;
+  data?: JsonValue;
 }
 
 export interface LabelEntry extends SessionEntryBase {
@@ -87,9 +75,6 @@ export type ContextEntry =
   | MessageEntry
   | CompactionEntry
   | BranchSummaryEntry
-  | ModelChangeEntry
-  | ThinkingLevelEntry
-  | ActiveToolsEntry
   | CustomEntry;
 
 export type SessionEntry = ContextEntry | LabelEntry;
@@ -105,15 +90,13 @@ const CONTEXT_ENTRY_TYPES: ReadonlySet<string> = new Set<ContextEntry["type"]>([
   "message",
   "compaction",
   "branch_summary",
-  "model_change",
-  "thinking_level_change",
-  "active_tools_change",
   "custom",
 ]);
 
 /**
- * Labels annotate the tree, and rows of retired types (`session_info`, `leaf`) written by
- * earlier Pi releases are skipped rather than failing the whole session.
+ * Labels annotate the tree, and rows of retired types (`session_info`, `leaf`, `model_change`,
+ * `thinking_level_change`, `active_tools_change`) written by earlier Pi releases are skipped
+ * rather than failing the whole session.
  */
 export const isContextEntry = (entry: SessionEntry): entry is ContextEntry =>
   CONTEXT_ENTRY_TYPES.has(entry.type);

--- a/packages/agent-runtime/src/session/pg-storage.ts
+++ b/packages/agent-runtime/src/session/pg-storage.ts
@@ -121,8 +121,10 @@ export class PgSessionStorage implements SessionTree {
  * assigned after the spread so the projected shape never depends on column order.
  *
  * The payload is stored opaquely so an entry type this runtime has not modelled still
- * round-trips. A compaction persisted before `retainedTail` was mandatory reads back with an
- * empty tail, which is how the projection already treated it.
+ * round-trips. Fields that became mandatory after rows were written are defaulted here rather
+ * than migrated: a compaction without `retainedTail` reads back with an empty tail, which is how
+ * the projection already treated it, and a summary without `fromHook` was written by this
+ * runtime, never by a hook.
  */
 const toEntry = (row: EntryRow): SessionEntry => {
   const entry =
@@ -136,6 +138,9 @@ const toEntry = (row: EntryRow): SessionEntry => {
     } as SessionEntry;
   if (entry.type === "compaction" && !Array.isArray(entry.retainedTail)) {
     entry.retainedTail = [];
+  }
+  if (entry.type === "compaction" || entry.type === "branch_summary") {
+    entry.fromHook ??= false;
   }
   return entry;
 };

--- a/packages/agent-runtime/src/session/usage.ts
+++ b/packages/agent-runtime/src/session/usage.ts
@@ -21,7 +21,7 @@ export const estimateBranchContextTokens = (
   const lastCompactionIndex = entries.findLastIndex(
     (entry) => entry.type === "compaction"
   );
-  const messages = buildBranchContext(entries).messages;
+  const messages = buildBranchContext(entries);
 
   if (lastCompactionIndex === -1) {
     return estimateContextTokens(messages).tokens;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,11 +108,11 @@ settings:
 catalogs:
   agent:
     '@earendil-works/pi-agent-core':
-      specifier: 0.84.4
-      version: 0.84.4
+      specifier: 0.85.1
+      version: 0.85.1
     '@earendil-works/pi-ai':
-      specifier: 0.84.4
-      version: 0.84.4
+      specifier: 0.85.1
+      version: 0.85.1
     typebox:
       specifier: 1.3.23
       version: 1.3.23
@@ -1520,10 +1520,10 @@ importers:
         version: link:../utils
       '@earendil-works/pi-agent-core':
         specifier: catalog:agent
-        version: 0.84.4(supports-color@10.2.2)(ws@8.21.3)(zod@4.5.4)
+        version: 0.85.1(@modelcontextprotocol/sdk@1.30.0(supports-color@10.2.2)(zod@4.5.4))(supports-color@10.2.2)(ws@8.21.3)(zod@4.5.4)
       '@earendil-works/pi-ai':
         specifier: catalog:agent
-        version: 0.84.4(supports-color@10.2.2)(ws@8.21.3)(zod@4.5.4)
+        version: 0.85.1(@modelcontextprotocol/sdk@1.30.0(supports-color@10.2.2)(zod@4.5.4))(supports-color@10.2.2)(ws@8.21.3)(zod@4.5.4)
       es-toolkit:
         specifier: 'catalog:'
         version: 1.52.0
@@ -1712,7 +1712,7 @@ importers:
         version: link:../db
       '@earendil-works/pi-ai':
         specifier: catalog:agent
-        version: 0.84.4(supports-color@10.2.2)(ws@8.21.3)(zod@4.5.4)
+        version: 0.85.1(@modelcontextprotocol/sdk@1.30.0(supports-color@10.2.2)(zod@4.5.4))(supports-color@10.2.2)(ws@8.21.3)(zod@4.5.4)
       es-toolkit:
         specifier: 'catalog:'
         version: 1.52.0
@@ -1752,10 +1752,10 @@ importers:
         version: link:../utils
       '@earendil-works/pi-agent-core':
         specifier: catalog:agent
-        version: 0.84.4(supports-color@10.2.2)(ws@8.21.3)(zod@4.5.4)
+        version: 0.85.1(@modelcontextprotocol/sdk@1.30.0(supports-color@10.2.2)(zod@4.5.4))(supports-color@10.2.2)(ws@8.21.3)(zod@4.5.4)
       '@earendil-works/pi-ai':
         specifier: catalog:agent
-        version: 0.84.4(supports-color@10.2.2)(ws@8.21.3)(zod@4.5.4)
+        version: 0.85.1(@modelcontextprotocol/sdk@1.30.0(supports-color@10.2.2)(zod@4.5.4))(supports-color@10.2.2)(ws@8.21.3)(zod@4.5.4)
       es-toolkit:
         specifier: 'catalog:'
         version: 1.52.0
@@ -1801,10 +1801,10 @@ importers:
         version: link:../utils
       '@earendil-works/pi-agent-core':
         specifier: catalog:agent
-        version: 0.84.4(supports-color@10.2.2)(ws@8.21.3)(zod@4.5.4)
+        version: 0.85.1(@modelcontextprotocol/sdk@1.30.0(supports-color@10.2.2)(zod@4.5.4))(supports-color@10.2.2)(ws@8.21.3)(zod@4.5.4)
       '@earendil-works/pi-ai':
         specifier: catalog:agent
-        version: 0.84.4(supports-color@10.2.2)(ws@8.21.3)(zod@4.5.4)
+        version: 0.85.1(@modelcontextprotocol/sdk@1.30.0(supports-color@10.2.2)(zod@4.5.4))(supports-color@10.2.2)(ws@8.21.3)(zod@4.5.4)
       es-toolkit:
         specifier: 'catalog:'
         version: 1.52.0
@@ -2793,8 +2793,8 @@ packages:
       zod:
         optional: true
 
-  '@anthropic-ai/sdk@0.91.1':
-    resolution: {integrity: sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==}
+  '@anthropic-ai/sdk@0.123.0':
+    resolution: {integrity: sha512-Y9oX9mPNGZClHQOFqrWRk43Srcu/UHuPq3rfxxOq7JgW0gi+lJA2MAOK4Ul3k/+AUrwRWFJvd0tK3oC0Pw25dw==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -3169,17 +3169,21 @@ packages:
   '@drizzle-team/brocli@0.12.0':
     resolution: {integrity: sha512-mlUE+rZ8CatQekLhnaiN91Iemdd+e2gFKooGlnRB3oPTL3VghLfX24dx7HrzMNeC1JrIB/0kpsfyty3f5HNfxQ==}
 
-  '@earendil-works/pi-agent-core@0.84.4':
-    resolution: {integrity: sha512-HyUnjaOXj6oN/6SNcr8A1J/ElRQA50FtIE0XUTSKAQVqmdlb9qdojOyUQwF/jULE5+yOEtGuVgi/N1RnBiNG+g==}
+  '@earendil-works/chord@0.85.1':
+    resolution: {integrity: sha512-VDlkEC3dhCzQ5fcyH1OhG19dq+6jCn+rqc/iXFivwDYGR5anwo2RCiXij9PpHhqNR5GuhhE+Er69Zi1Sn4eY6w==}
     engines: {node: '>=22.19.0'}
 
-  '@earendil-works/pi-ai@0.84.4':
-    resolution: {integrity: sha512-AClAZxf5+c4RRu44NJPS6wyQy+Nmq+Mzyyrdvm4ZVMNuixelO02RZX4G4Aq1F145Yzp43wnM5S+hLlSI7ypfVw==}
+  '@earendil-works/pi-agent-core@0.85.1':
+    resolution: {integrity: sha512-hIXIP3eAWueAYiAl8aMvWCvvZ8Q5gT3Dip5bE5uJyIGh4+YlWRjtMLI4BaeoXoSs93zndjue61u1B/vhefLnuA==}
+    engines: {node: '>=22.19.0'}
+
+  '@earendil-works/pi-ai@0.85.1':
+    resolution: {integrity: sha512-+VgVIJDkDO2efYJKEEqvPTH4zmnIaXdAppGbO+vKFA9qy5PdhFiAenuFAkU+oiCSfOC4dMHDyrjdQeL4ZoC5CQ==}
     engines: {node: '>=22.19.0'}
     hasBin: true
 
-  '@earendil-works/pi-telemetry@0.84.4':
-    resolution: {integrity: sha512-8e2CuxM+ht+hedQXTZmi5JVl6/xDK9RpSDL2+MbITevKYQhMZ/z6lJOTFgox3HQyGxO8mOZEtYGVeQNaD4OzqA==}
+  '@earendil-works/pi-telemetry@0.85.1':
+    resolution: {integrity: sha512-Bg/YN6kA7Swja/NQxka8xFdecb4E/auIEGF2G5A25EaQXhRnPj300/7/KpgsDDMYUzHTDAv4RyUxaQPJKW81Rw==}
     engines: {node: '>=22.19.0'}
 
   '@egoist/tailwindcss-icons@1.9.2':
@@ -14441,9 +14445,10 @@ snapshots:
     optionalDependencies:
       zod: 4.5.4
 
-  '@anthropic-ai/sdk@0.91.1(zod@4.5.4)':
+  '@anthropic-ai/sdk@0.123.0(zod@4.5.4)':
     dependencies:
       json-schema-to-ts: 3.1.1
+      standardwebhooks: 1.1.1
     optionalDependencies:
       zod: 4.5.4
 
@@ -14494,7 +14499,7 @@ snapshots:
       '@aws-sdk/types': 3.974.5
       '@smithy/core': 3.33.3
       '@smithy/fetch-http-handler': 5.7.2
-      '@smithy/node-http-handler': 4.7.3
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.17.2
       tslib: 2.8.1
 
@@ -14955,10 +14960,15 @@ snapshots:
 
   '@drizzle-team/brocli@0.12.0': {}
 
-  '@earendil-works/pi-agent-core@0.84.4(supports-color@10.2.2)(ws@8.21.3)(zod@4.5.4)':
+  '@earendil-works/chord@0.85.1':
     dependencies:
-      '@earendil-works/pi-ai': 0.84.4(supports-color@10.2.2)(ws@8.21.3)(zod@4.5.4)
-      '@earendil-works/pi-telemetry': 0.84.4
+      esbuild: 0.28.1
+
+  '@earendil-works/pi-agent-core@0.85.1(@modelcontextprotocol/sdk@1.30.0(supports-color@10.2.2)(zod@4.5.4))(supports-color@10.2.2)(ws@8.21.3)(zod@4.5.4)':
+    dependencies:
+      '@earendil-works/chord': 0.85.1
+      '@earendil-works/pi-ai': 0.85.1(@modelcontextprotocol/sdk@1.30.0(supports-color@10.2.2)(zod@4.5.4))(supports-color@10.2.2)(ws@8.21.3)(zod@4.5.4)
+      '@earendil-works/pi-telemetry': 0.85.1
       diff: 8.0.4
       ignore: 7.0.5
       typebox: 1.3.7
@@ -14971,12 +14981,12 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-ai@0.84.4(supports-color@10.2.2)(ws@8.21.3)(zod@4.5.4)':
+  '@earendil-works/pi-ai@0.85.1(@modelcontextprotocol/sdk@1.30.0(supports-color@10.2.2)(zod@4.5.4))(supports-color@10.2.2)(ws@8.21.3)(zod@4.5.4)':
     dependencies:
-      '@anthropic-ai/sdk': 0.91.1(zod@4.5.4)
+      '@anthropic-ai/sdk': 0.123.0(zod@4.5.4)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0
-      '@earendil-works/pi-telemetry': 0.84.4
-      '@google/genai': 1.52.0(supports-color@10.2.2)
+      '@earendil-works/pi-telemetry': 0.85.1
+      '@google/genai': 1.52.0(@modelcontextprotocol/sdk@1.30.0(supports-color@10.2.2)(zod@4.5.4))(supports-color@10.2.2)
       '@smithy/node-http-handler': 4.7.3
       http-proxy-agent: 7.0.2(supports-color@10.2.2)
       https-proxy-agent: 7.0.6(supports-color@10.2.2)
@@ -14991,7 +15001,7 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-telemetry@0.84.4': {}
+  '@earendil-works/pi-telemetry@0.85.1': {}
 
   '@egoist/tailwindcss-icons@1.9.2(tailwindcss@4.3.3)':
     dependencies:
@@ -15388,12 +15398,14 @@ snapshots:
   '@gar/promisify@1.1.3':
     optional: true
 
-  '@google/genai@1.52.0(supports-color@10.2.2)':
+  '@google/genai@1.52.0(@modelcontextprotocol/sdk@1.30.0(supports-color@10.2.2)(zod@4.5.4))(supports-color@10.2.2)':
     dependencies:
       google-auth-library: 10.9.1(supports-color@10.2.2)
       p-retry: 4.6.2
       protobufjs: 7.6.6
       ws: 8.21.3
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.30.0(supports-color@10.2.2)(zod@4.5.4)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -15975,6 +15987,7 @@ snapshots:
       zod-to-json-schema: 3.25.2(zod@4.5.4)
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   '@modelcontextprotocol/sdk@1.30.0(supports-color@8.1.1)(zod@4.5.4)':
     dependencies:
@@ -21701,6 +21714,7 @@ snapshots:
       ip-address: 10.7.0
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   express-rate-limit@8.7.0(express@5.2.1(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -40,8 +40,8 @@ catalog:
 
 catalogs:
   agent:
-    "@earendil-works/pi-agent-core": 0.84.4
-    "@earendil-works/pi-ai": 0.84.4
+    "@earendil-works/pi-agent-core": 0.85.1
+    "@earendil-works/pi-ai": 0.85.1
     typebox: 1.3.23
   ai:
     "@ai-sdk/anthropic": 4.0.46
@@ -259,8 +259,8 @@ catalogs:
 linkWorkspacePackages: true
 
 minimumReleaseAgeExclude:
-  - '@earendil-works/pi-agent-core@0.84.3'
-  - '@earendil-works/pi-ai@0.84.3'
+  - '@earendil-works/pi-agent-core@0.85.1'
+  - '@earendil-works/pi-ai@0.85.1'
   - '@oxlint/binding-android-arm-eabi@1.79.0'
   - '@oxlint/binding-android-arm64@1.79.0'
   - '@oxlint/binding-darwin-arm64@1.79.0'
@@ -283,7 +283,8 @@ minimumReleaseAgeExclude:
   - '@oxlint/plugins@1.79.0'
   - oxlint@1.79.0
   - bun-types@1.4.0
-  - '@earendil-works/pi-telemetry@0.84.3'
+  - '@earendil-works/pi-telemetry@0.85.1'
+  - '@earendil-works/chord@0.85.1'
 
 strictPeerDependencies: false
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved session context reconstruction around compaction and branch summaries.
  - Excluded aborted, errored, deferred, and retired context entries from generated branch context.
  - Improved cancellation handling during compaction and session navigation.
  - Preserved compatibility when reading older stored sessions.

- **Documentation**
  - Added architecture guidance covering Pi’s durable harness, integration considerations, and adoption prerequisites.
  - Updated corresponding Chinese documentation and reference numbering.

- **Maintenance**
  - Clarified branch-summary ancestry handling and session entry metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->