### PR TITLE
fix(dash): discard draft snapshots persisted under another schema version

### DIFF
--- a/apps/dash/__tests__/draft-snapshot.test.ts
+++ b/apps/dash/__tests__/draft-snapshot.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const STORAGE_KEY = "chia.dash.draft-snapshots";
+
+describe("draft snapshot store", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.resetModules();
+  });
+
+  it("discards snapshots written under another schema version", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        state: { entries: [{ draftId: 7, revision: 1, patch: { slug: "x" } }] },
+        version: 0,
+      })
+    );
+    const { readDraftSnapshot } =
+      await import("../src/components/feed/draft-snapshot");
+    expect(readDraftSnapshot(7)).toBeNull();
+  });
+
+  it("rehydrates snapshots of the current version", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        state: { entries: [{ draftId: 7, revision: 1, patch: { slug: "x" } }] },
+        version: 1,
+      })
+    );
+    const { readDraftSnapshot } =
+      await import("../src/components/feed/draft-snapshot");
+    expect(readDraftSnapshot(7)).toEqual({ revision: 1, patch: { slug: "x" } });
+  });
+});

--- a/apps/dash/src/components/feed/draft-snapshot.ts
+++ b/apps/dash/src/components/feed/draft-snapshot.ts
@@ -55,6 +55,8 @@ export const draftSnapshotStore = createStore<DraftSnapshotState>()(
       version: 1,
       storage: createJSONStorage(() => localStorage),
       partialize: (state) => ({ entries: state.entries }),
+      // Snapshots are short-lived; ones written under another schema are discarded, not converted.
+      migrate: () => ({ entries: [] }),
     }
   )
 );


### PR DESCRIPTION
## Summary

Follow-up to #3073. The snapshot store gained `version: 1` in the hook refactor but had no `migrate`, so zustand persist logged `State loaded from storage couldn't be migrated since no migrate function was provided` when a browser still held the earlier `version: 0` payload.

`migrate` now returns an empty entry list: snapshots are short-lived and ones written under another schema are discarded rather than converted.

## Test plan

- [x] New `draft-snapshot.test.ts`: a `version: 0` payload rehydrates to no entries; a `version: 1` payload rehydrates intact
- [x] `apps/dash` vitest 13 files / 45 tests, oxlint, tsc clean
- [ ] Manual: open a draft in a browser that showed the warning → no console error, editor works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
